### PR TITLE
Linkify baseline profile file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Find out more about the [UI architecture here](docs/ArchitectureLearningJourney.
 
 # Baseline profiles
 
-The baseline profile for this app is located at `app/src/main/baseline-prof.txt`.
+The baseline profile for this app is located at [`app/src/main/baseline-prof.txt`](app/src/main/baseline-prof.txt).
 It contains rules that enable AOT compilation of the critical user path taken during app launch.
 For more information on baseline profiles, read [this document](https://developer.android.com/studio/profile/baselineprofiles).
 
@@ -121,7 +121,7 @@ For more information on baseline profiles, read [this document](https://develope
 
 To generate the baseline profile, select the `benchmark` build variant and run the
 `BaselineProfileGenerator` benchmark test on an AOSP Android Emulator.
-Then copy the resulting baseline profile from the emulator to `app/src/main/baseline-prof.txt`.
+Then copy the resulting baseline profile from the emulator to [`app/src/main/baseline-prof.txt`](app/src/main/baseline-prof.txt).
 
 # License
 


### PR DESCRIPTION
 `app/src/main/baseline-prof.txt` vs [`app/src/main/baseline-prof.txt`](app/src/main/baseline-prof.txt)