### PR TITLE
Reuse the same RoundedCornerShape for NewsResourceCardExpanded and NewsResourceHeaderImage

### DIFF
--- a/core-ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
+++ b/core-ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
@@ -141,7 +141,6 @@ fun NewsResourceHeaderImage(
         },
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(topEnd = 16.dp, topStart = 16.dp))
             .height(180.dp),
         contentScale = ContentScale.Crop,
         model = headerImageUrl,

--- a/core-ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
+++ b/core-ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
@@ -141,7 +141,7 @@ fun NewsResourceHeaderImage(
         },
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(topEnd = 24.dp, topStart = 24.dp))
+            .clip(RoundedCornerShape(topEnd = 16.dp, topStart = 16.dp))
             .height(180.dp),
         contentScale = ContentScale.Crop,
         model = headerImageUrl,


### PR DESCRIPTION
Fixes #15

| Before | After | Diff |
|---|---|---|
| ![Screenshot_20220512_232930](https://user-images.githubusercontent.com/1921278/168171262-9757f124-4012-4a2a-b1e3-87b571814f43.png) | ![Screenshot_20220512_232950](https://user-images.githubusercontent.com/1921278/168171267-a5ab6ef2-2c6d-43b7-b246-73414ebf2ae0.png) | ![20220512-233019-diff](https://user-images.githubusercontent.com/1921278/168171317-4f03b465-155e-48bd-bd31-95a2fd1b60a9.png) |