### PR TITLE
Fix distorted buttons in nia-catalog

### DIFF
--- a/app-nia-catalog/build.gradle.kts
+++ b/app-nia-catalog/build.gradle.kts
@@ -35,4 +35,5 @@ dependencies {
     implementation(project(":core-ui"))
 
     implementation(libs.androidx.activity.compose)
+    implementation(libs.accompanist.flowlayout)
 }

--- a/app-nia-catalog/src/main/java/com/google/samples/apps/niacatalog/ui/Catalog.kt
+++ b/app-nia-catalog/src/main/java/com/google/samples/apps/niacatalog/ui/Catalog.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import com.google.accompanist.flowlayout.FlowRow
 import com.google.samples.apps.nowinandroid.core.ui.component.NiaDropdownMenuButton
 import com.google.samples.apps.nowinandroid.core.ui.component.NiaFilledButton
 import com.google.samples.apps.nowinandroid.core.ui.component.NiaFilterChip
@@ -76,7 +77,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Buttons", Modifier.padding(top = 16.dp)) }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp)  {
                         NiaFilledButton(onClick = {}) {
                             Text(text = "Enabled")
                         }
@@ -90,7 +91,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Disabled buttons", Modifier.padding(top = 16.dp)) }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp)  {
                         NiaFilledButton(
                             onClick = {},
                             enabled = false
@@ -113,7 +114,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Buttons with leading icons", Modifier.padding(top = 16.dp)) }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp)  {
                         NiaFilledButton(
                             onClick = {},
                             text = { Text(text = "Enabled") },
@@ -139,7 +140,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Disabled buttons with leading icons", Modifier.padding(top = 16.dp)) }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp)  {
                         NiaFilledButton(
                             onClick = {},
                             enabled = false,
@@ -168,7 +169,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Buttons with trailing icons", Modifier.padding(top = 16.dp)) }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         NiaFilledButton(
                             onClick = {},
                             text = { Text(text = "Enabled") },
@@ -194,7 +195,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Disabled buttons with trailing icons", Modifier.padding(top = 16.dp)) }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp)  {
                         NiaFilledButton(
                             onClick = {},
                             enabled = false,
@@ -223,7 +224,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Small buttons", Modifier.padding(top = 16.dp)) }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp)  {
                         NiaFilledButton(
                             onClick = {},
                             small = true
@@ -246,7 +247,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Disabled small buttons", Modifier.padding(top = 16.dp)) }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp)  {
                         NiaFilledButton(
                             onClick = {},
                             enabled = false,
@@ -272,7 +273,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Small buttons with leading icons", Modifier.padding(top = 16.dp)) }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         NiaFilledButton(
                             onClick = {},
                             small = true,
@@ -306,7 +307,7 @@ fun NiaCatalog() {
                     )
                 }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp)  {
                         NiaFilledButton(
                             onClick = {},
                             enabled = false,
@@ -338,7 +339,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Small buttons with trailing icons", Modifier.padding(top = 16.dp)) }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp)  {
                         NiaFilledButton(
                             onClick = {},
                             small = true,
@@ -372,7 +373,7 @@ fun NiaCatalog() {
                     )
                 }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp)  {
                         NiaFilledButton(
                             onClick = {},
                             enabled = false,
@@ -413,7 +414,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Chips", Modifier.padding(top = 16.dp)) }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp)  {
                         var firstChecked by remember { mutableStateOf(false) }
                         NiaFilterChip(
                             checked = firstChecked,
@@ -437,7 +438,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Toggle buttons", Modifier.padding(top = 16.dp)) }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp)  {
                         var firstChecked by remember { mutableStateOf(false) }
                         NiaToggleButton(
                             checked = firstChecked,
@@ -498,7 +499,7 @@ fun NiaCatalog() {
                 }
                 item { Text("View toggle", Modifier.padding(top = 16.dp)) }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp)  {
                         var firstExpanded by remember { mutableStateOf(false) }
                         NiaViewToggleButton(
                             expanded = firstExpanded,
@@ -517,7 +518,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Tags", Modifier.padding(top = 16.dp)) }
                 item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    FlowRow(mainAxisSpacing = 16.dp)  {
                         var firstFollowed by remember { mutableStateOf(false) }
                         NiaTopicTag(
                             followed = firstFollowed,

--- a/app-nia-catalog/src/main/java/com/google/samples/apps/niacatalog/ui/Catalog.kt
+++ b/app-nia-catalog/src/main/java/com/google/samples/apps/niacatalog/ui/Catalog.kt
@@ -17,7 +17,6 @@
 package com.google.samples.apps.niacatalog.ui
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.add
 import androidx.compose.foundation.layout.asPaddingValues
@@ -77,7 +76,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Buttons", Modifier.padding(top = 16.dp)) }
                 item {
-                    FlowRow(mainAxisSpacing = 16.dp)  {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         NiaFilledButton(onClick = {}) {
                             Text(text = "Enabled")
                         }
@@ -91,7 +90,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Disabled buttons", Modifier.padding(top = 16.dp)) }
                 item {
-                    FlowRow(mainAxisSpacing = 16.dp)  {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         NiaFilledButton(
                             onClick = {},
                             enabled = false
@@ -114,7 +113,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Buttons with leading icons", Modifier.padding(top = 16.dp)) }
                 item {
-                    FlowRow(mainAxisSpacing = 16.dp)  {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         NiaFilledButton(
                             onClick = {},
                             text = { Text(text = "Enabled") },
@@ -140,7 +139,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Disabled buttons with leading icons", Modifier.padding(top = 16.dp)) }
                 item {
-                    FlowRow(mainAxisSpacing = 16.dp)  {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         NiaFilledButton(
                             onClick = {},
                             enabled = false,
@@ -195,7 +194,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Disabled buttons with trailing icons", Modifier.padding(top = 16.dp)) }
                 item {
-                    FlowRow(mainAxisSpacing = 16.dp)  {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         NiaFilledButton(
                             onClick = {},
                             enabled = false,
@@ -224,7 +223,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Small buttons", Modifier.padding(top = 16.dp)) }
                 item {
-                    FlowRow(mainAxisSpacing = 16.dp)  {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         NiaFilledButton(
                             onClick = {},
                             small = true
@@ -247,7 +246,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Disabled small buttons", Modifier.padding(top = 16.dp)) }
                 item {
-                    FlowRow(mainAxisSpacing = 16.dp)  {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         NiaFilledButton(
                             onClick = {},
                             enabled = false,
@@ -307,7 +306,7 @@ fun NiaCatalog() {
                     )
                 }
                 item {
-                    FlowRow(mainAxisSpacing = 16.dp)  {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         NiaFilledButton(
                             onClick = {},
                             enabled = false,
@@ -339,7 +338,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Small buttons with trailing icons", Modifier.padding(top = 16.dp)) }
                 item {
-                    FlowRow(mainAxisSpacing = 16.dp)  {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         NiaFilledButton(
                             onClick = {},
                             small = true,
@@ -373,7 +372,7 @@ fun NiaCatalog() {
                     )
                 }
                 item {
-                    FlowRow(mainAxisSpacing = 16.dp)  {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         NiaFilledButton(
                             onClick = {},
                             enabled = false,
@@ -414,7 +413,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Chips", Modifier.padding(top = 16.dp)) }
                 item {
-                    FlowRow(mainAxisSpacing = 16.dp)  {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         var firstChecked by remember { mutableStateOf(false) }
                         NiaFilterChip(
                             checked = firstChecked,
@@ -438,7 +437,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Toggle buttons", Modifier.padding(top = 16.dp)) }
                 item {
-                    FlowRow(mainAxisSpacing = 16.dp)  {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         var firstChecked by remember { mutableStateOf(false) }
                         NiaToggleButton(
                             checked = firstChecked,
@@ -499,7 +498,7 @@ fun NiaCatalog() {
                 }
                 item { Text("View toggle", Modifier.padding(top = 16.dp)) }
                 item {
-                    FlowRow(mainAxisSpacing = 16.dp)  {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         var firstExpanded by remember { mutableStateOf(false) }
                         NiaViewToggleButton(
                             expanded = firstExpanded,
@@ -518,7 +517,7 @@ fun NiaCatalog() {
                 }
                 item { Text("Tags", Modifier.padding(top = 16.dp)) }
                 item {
-                    FlowRow(mainAxisSpacing = 16.dp)  {
+                    FlowRow(mainAxisSpacing = 16.dp) {
                         var firstFollowed by remember { mutableStateOf(false) }
                         NiaTopicTag(
                             followed = firstFollowed,


### PR DESCRIPTION
Fix #28 by replacing all `Row` by `FlowRow` so that the new element is displayed on a new line when there is no more space

![Screenshot_20220513_174115](https://user-images.githubusercontent.com/55670723/168319295-654f49ee-af78-4630-9d18-78cd7b977f25.png)

