### PR TITLE
Rename UI State sealed interface class with UiState postfix

### DIFF
--- a/feature-foryou/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreenTest.kt
+++ b/feature-foryou/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreenTest.kt
@@ -92,7 +92,8 @@ class ForYouScreenTest {
                     windowSizeClass = WindowSizeClass.calculateFromSize(
                         DpSize(maxWidth, maxHeight)
                     ),
-                    interestsSelectionState = ForYouInterestsSelectionUiState.WithInterestsSelection(
+                    interestsSelectionState =
+                    ForYouInterestsSelectionUiState.WithInterestsSelection(
                         topics = listOf(
                             FollowableTopic(
                                 topic = Topic(
@@ -200,7 +201,8 @@ class ForYouScreenTest {
                     windowSizeClass = WindowSizeClass.calculateFromSize(
                         DpSize(maxWidth, maxHeight)
                     ),
-                    interestsSelectionState = ForYouInterestsSelectionUiState.WithInterestsSelection(
+                    interestsSelectionState =
+                    ForYouInterestsSelectionUiState.WithInterestsSelection(
                         topics = listOf(
                             FollowableTopic(
                                 topic = Topic(
@@ -314,7 +316,8 @@ class ForYouScreenTest {
                     windowSizeClass = WindowSizeClass.calculateFromSize(
                         DpSize(maxWidth, maxHeight)
                     ),
-                    interestsSelectionState = ForYouInterestsSelectionUiState.WithInterestsSelection(
+                    interestsSelectionState =
+                    ForYouInterestsSelectionUiState.WithInterestsSelection(
                         topics = listOf(
                             FollowableTopic(
                                 topic = Topic(
@@ -670,7 +673,10 @@ class ForYouScreenTest {
             )
 
         val firstFeedItem = composeTestRule
-            .onNodeWithText("Thanks for helping us reach 1M YouTube Subscribers", substring = true)
+            .onNodeWithText(
+                "Thanks for helping us reach 1M YouTube Subscribers",
+                substring = true
+            )
             .assertHasClickAction()
             .fetchSemanticsNode()
 

--- a/feature-foryou/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreenTest.kt
+++ b/feature-foryou/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreenTest.kt
@@ -67,8 +67,8 @@ class ForYouScreenTest {
                     windowSizeClass = WindowSizeClass.calculateFromSize(
                         DpSize(maxWidth, maxHeight)
                     ),
-                    interestsSelectionState = ForYouInterestsSelectionState.Loading,
-                    feedState = ForYouFeedState.Loading,
+                    interestsSelectionState = ForYouInterestsSelectionUiState.Loading,
+                    feedState = ForYouFeedUiState.Loading,
                     onAuthorCheckedChanged = { _, _ -> },
                     onTopicCheckedChanged = { _, _ -> },
                     saveFollowedTopics = {},
@@ -92,7 +92,7 @@ class ForYouScreenTest {
                     windowSizeClass = WindowSizeClass.calculateFromSize(
                         DpSize(maxWidth, maxHeight)
                     ),
-                    interestsSelectionState = ForYouInterestsSelectionState.WithInterestsSelection(
+                    interestsSelectionState = ForYouInterestsSelectionUiState.WithInterestsSelection(
                         topics = listOf(
                             FollowableTopic(
                                 topic = Topic(
@@ -153,7 +153,7 @@ class ForYouScreenTest {
                             ),
                         )
                     ),
-                    feedState = ForYouFeedState.Success(
+                    feedState = ForYouFeedUiState.Success(
                         feed = emptyList()
                     ),
                     onAuthorCheckedChanged = { _, _ -> },
@@ -200,7 +200,7 @@ class ForYouScreenTest {
                     windowSizeClass = WindowSizeClass.calculateFromSize(
                         DpSize(maxWidth, maxHeight)
                     ),
-                    interestsSelectionState = ForYouInterestsSelectionState.WithInterestsSelection(
+                    interestsSelectionState = ForYouInterestsSelectionUiState.WithInterestsSelection(
                         topics = listOf(
                             FollowableTopic(
                                 topic = Topic(
@@ -261,7 +261,7 @@ class ForYouScreenTest {
                             ),
                         ),
                     ),
-                    feedState = ForYouFeedState.Success(
+                    feedState = ForYouFeedUiState.Success(
                         feed = emptyList()
                     ),
                     onAuthorCheckedChanged = { _, _ -> },
@@ -314,7 +314,7 @@ class ForYouScreenTest {
                     windowSizeClass = WindowSizeClass.calculateFromSize(
                         DpSize(maxWidth, maxHeight)
                     ),
-                    interestsSelectionState = ForYouInterestsSelectionState.WithInterestsSelection(
+                    interestsSelectionState = ForYouInterestsSelectionUiState.WithInterestsSelection(
                         topics = listOf(
                             FollowableTopic(
                                 topic = Topic(
@@ -375,7 +375,7 @@ class ForYouScreenTest {
                             ),
                         ),
                     ),
-                    feedState = ForYouFeedState.Success(
+                    feedState = ForYouFeedUiState.Success(
                         feed = emptyList()
                     ),
                     onAuthorCheckedChanged = { _, _ -> },
@@ -428,7 +428,7 @@ class ForYouScreenTest {
                     windowSizeClass = WindowSizeClass.calculateFromSize(
                         DpSize(maxWidth, maxHeight)
                     ),
-                    interestsSelectionState = ForYouInterestsSelectionState.WithInterestsSelection(
+                    interestsSelectionState = ForYouInterestsSelectionUiState.WithInterestsSelection(
                         topics = listOf(
                             FollowableTopic(
                                 topic = Topic(
@@ -489,7 +489,7 @@ class ForYouScreenTest {
                             ),
                         ),
                     ),
-                    feedState = ForYouFeedState.Loading,
+                    feedState = ForYouFeedUiState.Loading,
                     onAuthorCheckedChanged = { _, _ -> },
                     onTopicCheckedChanged = { _, _ -> },
                     saveFollowedTopics = {},
@@ -523,8 +523,8 @@ class ForYouScreenTest {
                     windowSizeClass = WindowSizeClass.calculateFromSize(
                         DpSize(maxWidth, maxHeight)
                     ),
-                    interestsSelectionState = ForYouInterestsSelectionState.NoInterestsSelection,
-                    feedState = ForYouFeedState.Loading,
+                    interestsSelectionState = ForYouInterestsSelectionUiState.NoInterestsSelection,
+                    feedState = ForYouFeedUiState.Loading,
                     onAuthorCheckedChanged = { _, _ -> },
                     onTopicCheckedChanged = { _, _ -> },
                     saveFollowedTopics = {},
@@ -643,8 +643,8 @@ class ForYouScreenTest {
 
                 ForYouScreen(
                     windowSizeClass = windowSizeClass,
-                    interestsSelectionState = ForYouInterestsSelectionState.NoInterestsSelection,
-                    feedState = ForYouFeedState.Success(
+                    interestsSelectionState = ForYouInterestsSelectionUiState.NoInterestsSelection,
+                    feedState = ForYouFeedUiState.Success(
                         feed = saveableNewsResources
                     ),
                     onAuthorCheckedChanged = { _, _ -> },

--- a/feature-foryou/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreenTest.kt
+++ b/feature-foryou/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreenTest.kt
@@ -428,7 +428,8 @@ class ForYouScreenTest {
                     windowSizeClass = WindowSizeClass.calculateFromSize(
                         DpSize(maxWidth, maxHeight)
                     ),
-                    interestsSelectionState = ForYouInterestsSelectionUiState.WithInterestsSelection(
+                    interestsSelectionState =
+                    ForYouInterestsSelectionUiState.WithInterestsSelection(
                         topics = listOf(
                             FollowableTopic(
                                 topic = Topic(

--- a/feature-foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouFeedUiState.kt
+++ b/feature-foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouFeedUiState.kt
@@ -21,11 +21,11 @@ import com.google.samples.apps.nowinandroid.core.model.data.SaveableNewsResource
 /**
  * A sealed hierarchy describing the state of the feed on the for you screen.
  */
-sealed interface ForYouFeedState {
+sealed interface ForYouFeedUiState {
     /**
      * The feed is still loading.
      */
-    object Loading : ForYouFeedState
+    object Loading : ForYouFeedUiState
 
     /**
      * The feed is loaded with the given list of news resources.
@@ -35,5 +35,5 @@ sealed interface ForYouFeedState {
          * The list of news resources contained in this [PopulatedFeed].
          */
         val feed: List<SaveableNewsResource>
-    ) : ForYouFeedState
+    ) : ForYouFeedUiState
 }

--- a/feature-foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouInterestsSelectionUiState.kt
+++ b/feature-foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouInterestsSelectionUiState.kt
@@ -22,16 +22,16 @@ import com.google.samples.apps.nowinandroid.core.model.data.FollowableTopic
 /**
  * A sealed hierarchy describing the interests selection state for the for you screen.
  */
-sealed interface ForYouInterestsSelectionState {
+sealed interface ForYouInterestsSelectionUiState {
     /**
      * The interests selection state is loading.
      */
-    object Loading : ForYouInterestsSelectionState
+    object Loading : ForYouInterestsSelectionUiState
 
     /**
      * There is no interests selection state.
      */
-    object NoInterestsSelection : ForYouInterestsSelectionState
+    object NoInterestsSelection : ForYouInterestsSelectionUiState
 
     /**
      * There is a interests selection state, with the given lists of topics and authors.
@@ -39,7 +39,7 @@ sealed interface ForYouInterestsSelectionState {
     data class WithInterestsSelection(
         val topics: List<FollowableTopic>,
         val authors: List<FollowableAuthor>
-    ) : ForYouInterestsSelectionState {
+    ) : ForYouInterestsSelectionUiState {
         /**
          * True if the current in-progress selection can be saved.
          */

--- a/feature-foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature-foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -123,8 +123,8 @@ fun ForYouRoute(
 @Composable
 fun ForYouScreen(
     windowSizeClass: WindowSizeClass,
-    interestsSelectionState: ForYouInterestsSelectionState,
-    feedState: ForYouFeedState,
+    interestsSelectionState: ForYouInterestsSelectionUiState,
+    feedState: ForYouFeedUiState,
     onTopicCheckedChanged: (String, Boolean) -> Unit,
     onAuthorCheckedChanged: (String, Boolean) -> Unit,
     saveFollowedTopics: () -> Unit,
@@ -183,7 +183,7 @@ fun ForYouScreen(
                         // Avoid showing a second loading wheel if we already are for the interests
                         // selection
                         showLoadingUIIfLoading =
-                        interestsSelectionState !is ForYouInterestsSelectionState.Loading,
+                        interestsSelectionState !is ForYouInterestsSelectionUiState.Loading,
                         numberOfColumns = numberOfColumns,
                         onNewsResourcesCheckedChanged = onNewsResourcesCheckedChanged
                     )
@@ -212,14 +212,14 @@ fun ForYouScreen(
  * states.
  */
 private fun LazyListScope.InterestsSelection(
-    interestsSelectionState: ForYouInterestsSelectionState,
+    interestsSelectionState: ForYouInterestsSelectionUiState,
     showLoadingUIIfLoading: Boolean,
     onAuthorCheckedChanged: (String, Boolean) -> Unit,
     onTopicCheckedChanged: (String, Boolean) -> Unit,
     saveFollowedTopics: () -> Unit
 ) {
     when (interestsSelectionState) {
-        ForYouInterestsSelectionState.Loading -> {
+        ForYouInterestsSelectionUiState.Loading -> {
             if (showLoadingUIIfLoading) {
                 item {
                     LoadingWheel(
@@ -231,8 +231,8 @@ private fun LazyListScope.InterestsSelection(
                 }
             }
         }
-        ForYouInterestsSelectionState.NoInterestsSelection -> Unit
-        is ForYouInterestsSelectionState.WithInterestsSelection -> {
+        ForYouInterestsSelectionUiState.NoInterestsSelection -> Unit
+        is ForYouInterestsSelectionUiState.WithInterestsSelection -> {
             item {
                 Text(
                     text = stringResource(R.string.onboarding_guidance_title),
@@ -298,7 +298,7 @@ private fun LazyListScope.InterestsSelection(
 
 @Composable
 private fun TopicSelection(
-    interestsSelectionState: ForYouInterestsSelectionState.WithInterestsSelection,
+    interestsSelectionState: ForYouInterestsSelectionUiState.WithInterestsSelection,
     onTopicCheckedChanged: (String, Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -412,13 +412,13 @@ fun TopicIcon(
  * states.
  */
 private fun LazyListScope.Feed(
-    feedState: ForYouFeedState,
+    feedState: ForYouFeedUiState,
     showLoadingUIIfLoading: Boolean,
     @IntRange(from = 1) numberOfColumns: Int,
     onNewsResourcesCheckedChanged: (String, Boolean) -> Unit
 ) {
     when (feedState) {
-        ForYouFeedState.Loading -> {
+        ForYouFeedUiState.Loading -> {
             if (showLoadingUIIfLoading) {
                 item {
                     LoadingWheel(
@@ -430,7 +430,7 @@ private fun LazyListScope.Feed(
                 }
             }
         }
-        is ForYouFeedState.Success -> {
+        is ForYouFeedUiState.Success -> {
             items(
                 feedState.feed.chunked(numberOfColumns)
             ) { saveableNewsResources ->
@@ -496,8 +496,8 @@ fun ForYouScreenLoading() {
         NiaTheme {
             ForYouScreen(
                 windowSizeClass = WindowSizeClass.calculateFromSize(DpSize(maxWidth, maxHeight)),
-                interestsSelectionState = ForYouInterestsSelectionState.Loading,
-                feedState = ForYouFeedState.Loading,
+                interestsSelectionState = ForYouInterestsSelectionUiState.Loading,
+                feedState = ForYouFeedUiState.Loading,
                 onTopicCheckedChanged = { _, _ -> },
                 onAuthorCheckedChanged = { _, _ -> },
                 saveFollowedTopics = {},
@@ -517,7 +517,7 @@ fun ForYouScreenTopicSelection() {
         NiaTheme {
             ForYouScreen(
                 windowSizeClass = WindowSizeClass.calculateFromSize(DpSize(maxWidth, maxHeight)),
-                interestsSelectionState = ForYouInterestsSelectionState.WithInterestsSelection(
+                interestsSelectionState = ForYouInterestsSelectionUiState.WithInterestsSelection(
                     topics = listOf(
                         FollowableTopic(
                             topic = Topic(
@@ -589,7 +589,7 @@ fun ForYouScreenTopicSelection() {
                         )
                     )
                 ),
-                feedState = ForYouFeedState.Success(
+                feedState = ForYouFeedUiState.Success(
                     feed = saveableNewsResource,
                 ),
                 onAuthorCheckedChanged = { _, _ -> },
@@ -611,8 +611,8 @@ fun PopulatedFeed() {
         NiaTheme {
             ForYouScreen(
                 windowSizeClass = WindowSizeClass.calculateFromSize(DpSize(maxWidth, maxHeight)),
-                interestsSelectionState = ForYouInterestsSelectionState.NoInterestsSelection,
-                feedState = ForYouFeedState.Success(
+                interestsSelectionState = ForYouInterestsSelectionUiState.NoInterestsSelection,
+                feedState = ForYouFeedUiState.Success(
                     feed = saveableNewsResource
                 ),
                 onTopicCheckedChanged = { _, _ -> },

--- a/feature-foryou/src/test/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouViewModelTest.kt
+++ b/feature-foryou/src/test/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouViewModelTest.kt
@@ -58,12 +58,12 @@ class ForYouViewModelTest {
     }
 
     /**
-     * A pairing of [ForYouInterestsSelectionState] and [ForYouFeedState] for ease of testing
+     * A pairing of [ForYouInterestsSelectionUiState] and [ForYouFeedUiState] for ease of testing
      * state updates as a single flow.
      */
     private data class ForYouUiState(
-        val interestsSelectionState: ForYouInterestsSelectionState,
-        val feedState: ForYouFeedState,
+        val interestsSelectionState: ForYouInterestsSelectionUiState,
+        val feedState: ForYouFeedUiState,
     )
 
     private val ForYouViewModel.uiState
@@ -79,8 +79,8 @@ class ForYouViewModelTest {
         viewModel.uiState.test {
             assertEquals(
                 ForYouUiState(
-                    ForYouInterestsSelectionState.Loading,
-                    ForYouFeedState.Loading
+                    ForYouInterestsSelectionUiState.Loading,
+                    ForYouFeedUiState.Loading
                 ),
                 awaitItem()
             )
@@ -93,8 +93,8 @@ class ForYouViewModelTest {
         viewModel.uiState.test {
             assertEquals(
                 ForYouUiState(
-                    ForYouInterestsSelectionState.Loading,
-                    ForYouFeedState.Loading
+                    ForYouInterestsSelectionUiState.Loading,
+                    ForYouFeedUiState.Loading
                 ),
                 awaitItem()
             )
@@ -109,8 +109,8 @@ class ForYouViewModelTest {
         viewModel.uiState.test {
             assertEquals(
                 ForYouUiState(
-                    ForYouInterestsSelectionState.Loading,
-                    ForYouFeedState.Loading
+                    ForYouInterestsSelectionUiState.Loading,
+                    ForYouFeedUiState.Loading
                 ),
                 awaitItem()
             )
@@ -125,8 +125,8 @@ class ForYouViewModelTest {
         viewModel.uiState.test {
             assertEquals(
                 ForYouUiState(
-                    ForYouInterestsSelectionState.Loading,
-                    ForYouFeedState.Loading
+                    ForYouInterestsSelectionUiState.Loading,
+                    ForYouFeedUiState.Loading
                 ),
                 awaitItem()
             )
@@ -141,8 +141,8 @@ class ForYouViewModelTest {
         viewModel.uiState.test {
             assertEquals(
                 ForYouUiState(
-                    ForYouInterestsSelectionState.Loading,
-                    ForYouFeedState.Loading
+                    ForYouInterestsSelectionUiState.Loading,
+                    ForYouFeedUiState.Loading
                 ),
                 awaitItem()
             )
@@ -166,7 +166,7 @@ class ForYouViewModelTest {
             assertEquals(
                 ForYouUiState(
                     interestsSelectionState =
-                    ForYouInterestsSelectionState.WithInterestsSelection(
+                    ForYouInterestsSelectionUiState.WithInterestsSelection(
                         topics = listOf(
                             FollowableTopic(
                                 topic = Topic(
@@ -238,7 +238,7 @@ class ForYouViewModelTest {
                             )
                         ),
                     ),
-                    feedState = ForYouFeedState.Success(
+                    feedState = ForYouFeedUiState.Success(
                         feed = emptyList()
                     )
                 ),
@@ -263,7 +263,7 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.WithInterestsSelection(
+                        ForYouInterestsSelectionUiState.WithInterestsSelection(
                             topics = listOf(
                                 FollowableTopic(
                                     topic = Topic(
@@ -335,7 +335,7 @@ class ForYouViewModelTest {
                                 )
                             ),
                         ),
-                        feedState = ForYouFeedState.Success(
+                        feedState = ForYouFeedUiState.Success(
                             feed = emptyList()
                         )
                     ),
@@ -359,8 +359,8 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.NoInterestsSelection,
-                        feedState = ForYouFeedState.Loading
+                        ForYouInterestsSelectionUiState.NoInterestsSelection,
+                        feedState = ForYouFeedUiState.Loading
                     ),
                     awaitItem()
                 )
@@ -370,8 +370,8 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.NoInterestsSelection,
-                        feedState = ForYouFeedState.Success(
+                        ForYouInterestsSelectionUiState.NoInterestsSelection,
+                        feedState = ForYouFeedUiState.Success(
                             feed = sampleNewsResources.map {
                                 SaveableNewsResource(
                                     newsResource = it,
@@ -400,8 +400,8 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.NoInterestsSelection,
-                        feedState = ForYouFeedState.Loading
+                        ForYouInterestsSelectionUiState.NoInterestsSelection,
+                        feedState = ForYouFeedUiState.Loading
                     ),
                     awaitItem()
                 )
@@ -411,8 +411,8 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.NoInterestsSelection,
-                        feedState = ForYouFeedState.Success(
+                        ForYouInterestsSelectionUiState.NoInterestsSelection,
+                        feedState = ForYouFeedUiState.Success(
                             feed = sampleNewsResources.map {
                                 SaveableNewsResource(
                                     newsResource = it,
@@ -445,7 +445,7 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.WithInterestsSelection(
+                        ForYouInterestsSelectionUiState.WithInterestsSelection(
                             topics = listOf(
                                 FollowableTopic(
                                     topic = Topic(
@@ -517,7 +517,7 @@ class ForYouViewModelTest {
                                 )
                             ),
                         ),
-                        feedState = ForYouFeedState.Success(
+                        feedState = ForYouFeedUiState.Success(
                             feed = emptyList(),
                         )
                     ),
@@ -526,7 +526,7 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.WithInterestsSelection(
+                        ForYouInterestsSelectionUiState.WithInterestsSelection(
                             topics = listOf(
                                 FollowableTopic(
                                     topic = Topic(
@@ -598,14 +598,14 @@ class ForYouViewModelTest {
                                 )
                             ),
                         ),
-                        feedState = ForYouFeedState.Loading
+                        feedState = ForYouFeedUiState.Loading
                     ),
                     awaitItem()
                 )
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.WithInterestsSelection(
+                        ForYouInterestsSelectionUiState.WithInterestsSelection(
                             topics = listOf(
                                 FollowableTopic(
                                     topic = Topic(
@@ -677,7 +677,7 @@ class ForYouViewModelTest {
                                 )
                             ),
                         ),
-                        feedState = ForYouFeedState.Success(
+                        feedState = ForYouFeedUiState.Success(
                             feed = listOf(
                                 SaveableNewsResource(
                                     newsResource = sampleNewsResources[1],
@@ -714,7 +714,7 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.WithInterestsSelection(
+                        ForYouInterestsSelectionUiState.WithInterestsSelection(
                             topics = listOf(
                                 FollowableTopic(
                                     topic = Topic(
@@ -786,7 +786,7 @@ class ForYouViewModelTest {
                                 )
                             ),
                         ),
-                        feedState = ForYouFeedState.Success(
+                        feedState = ForYouFeedUiState.Success(
                             feed = emptyList(),
                         )
                     ),
@@ -795,7 +795,7 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.WithInterestsSelection(
+                        ForYouInterestsSelectionUiState.WithInterestsSelection(
                             topics = listOf(
                                 FollowableTopic(
                                     topic = Topic(
@@ -867,14 +867,14 @@ class ForYouViewModelTest {
                                 )
                             ),
                         ),
-                        feedState = ForYouFeedState.Loading
+                        feedState = ForYouFeedUiState.Loading
                     ),
                     awaitItem()
                 )
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.WithInterestsSelection(
+                        ForYouInterestsSelectionUiState.WithInterestsSelection(
                             topics = listOf(
                                 FollowableTopic(
                                     topic = Topic(
@@ -946,7 +946,7 @@ class ForYouViewModelTest {
                                 )
                             ),
                         ),
-                        feedState = ForYouFeedState.Success(
+                        feedState = ForYouFeedUiState.Success(
                             feed = listOf(
                                 SaveableNewsResource(
                                     newsResource = sampleNewsResources[1],
@@ -981,7 +981,7 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.WithInterestsSelection(
+                        ForYouInterestsSelectionUiState.WithInterestsSelection(
                             topics = listOf(
                                 FollowableTopic(
                                     topic = Topic(
@@ -1053,7 +1053,7 @@ class ForYouViewModelTest {
                                 )
                             ),
                         ),
-                        feedState = ForYouFeedState.Success(
+                        feedState = ForYouFeedUiState.Success(
                             feed = emptyList()
                         )
                     ),
@@ -1079,7 +1079,7 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.WithInterestsSelection(
+                        ForYouInterestsSelectionUiState.WithInterestsSelection(
                             topics = listOf(
                                 FollowableTopic(
                                     topic = Topic(
@@ -1151,7 +1151,7 @@ class ForYouViewModelTest {
                                 )
                             ),
                         ),
-                        feedState = ForYouFeedState.Success(
+                        feedState = ForYouFeedUiState.Success(
                             feed = emptyList()
                         )
                     ),
@@ -1181,8 +1181,8 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.NoInterestsSelection,
-                        feedState = ForYouFeedState.Success(
+                        ForYouInterestsSelectionUiState.NoInterestsSelection,
+                        feedState = ForYouFeedUiState.Success(
                             feed = listOf(
                                 SaveableNewsResource(
                                     newsResource = sampleNewsResources[1],
@@ -1223,8 +1223,8 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.NoInterestsSelection,
-                        feedState = ForYouFeedState.Success(
+                        ForYouInterestsSelectionUiState.NoInterestsSelection,
+                        feedState = ForYouFeedUiState.Success(
                             feed = listOf(
                                 SaveableNewsResource(
                                     newsResource = sampleNewsResources[0],
@@ -1262,8 +1262,8 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.NoInterestsSelection,
-                        feedState = ForYouFeedState.Success(
+                        ForYouInterestsSelectionUiState.NoInterestsSelection,
+                        feedState = ForYouFeedUiState.Success(
                             feed = listOf(
                                 SaveableNewsResource(
                                     newsResource = sampleNewsResources[1],
@@ -1305,7 +1305,7 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.WithInterestsSelection(
+                        ForYouInterestsSelectionUiState.WithInterestsSelection(
                             topics = listOf(
                                 FollowableTopic(
                                     topic = Topic(
@@ -1377,7 +1377,7 @@ class ForYouViewModelTest {
                                 )
                             )
                         ),
-                        feedState = ForYouFeedState.Success(
+                        feedState = ForYouFeedUiState.Success(
                             feed = emptyList()
                         )
                     ),
@@ -1409,7 +1409,7 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.WithInterestsSelection(
+                        ForYouInterestsSelectionUiState.WithInterestsSelection(
                             topics = listOf(
                                 FollowableTopic(
                                     topic = Topic(
@@ -1481,7 +1481,7 @@ class ForYouViewModelTest {
                                 )
                             )
                         ),
-                        feedState = ForYouFeedState.Success(
+                        feedState = ForYouFeedUiState.Success(
                             feed = emptyList()
                         )
                     ),
@@ -1506,8 +1506,8 @@ class ForYouViewModelTest {
                 assertEquals(
                     ForYouUiState(
                         interestsSelectionState =
-                        ForYouInterestsSelectionState.NoInterestsSelection,
-                        feedState = ForYouFeedState.Success(
+                        ForYouInterestsSelectionUiState.NoInterestsSelection,
+                        feedState = ForYouFeedUiState.Success(
                             feed = listOf(
                                 SaveableNewsResource(
                                     newsResource = sampleNewsResources[1],


### PR DESCRIPTION
Rename the following two files:

1. ForYouInterestsSelectionState -> ForYouInterestsSelectionUiState ;
2. ForYouFeedState -> ForYouFeedUiState ;

Based on the following:
1.  The [naming convention](https://developer.android.com/jetpack/guide/ui-layer#naming-conventions) in official documents is to add the suffix UiState.
2.  [AuthorUiState](https://github.com/android/nowinandroid/blob/ef42543b32b58038fbe5cdcee17af8fe69756ad7/feature-topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt#L105)、[NewsUiState](https://github.com/android/nowinandroid/blob/ef42543b32b58038fbe5cdcee17af8fe69756ad7/feature-topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt#L111)、[AuthorScreenUiState](https://github.com/android/nowinandroid/blob/ef42543b32b58038fbe5cdcee17af8fe69756ad7/feature-topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt#L117) and so on adopt the naming convention of UiState suffix.



