### PR TITLE
Fix themed app icon launcher roundIcon

### DIFF
--- a/app-nia-catalog/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app-nia-catalog/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -17,4 +17,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/drawable-v24/ic_launcher_background.xml
+++ b/app/src/main/res/drawable-v24/ic_launcher_background.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2022 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <path
+      android:pathData="M0,0h108v108h-108z"
+      android:fillColor="#FFFFFF"/>
+</vector>

--- a/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2022 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <path
+      android:pathData="M108,0L108,108L0,108L0,0L108,0ZM68.25,64.93L64.32,71.73C61.31,70.36 57.94,69.59 54.33,69.59C50.73,69.59 47.35,70.36 44.34,71.73L40.41,64.93C40.19,64.54 39.69,64.41 39.31,64.63C38.92,64.85 38.79,65.35 39.01,65.73L42.89,72.44C36.22,76.07 31.67,82.81 31,90.77L77.67,90.77C77,82.8 72.44,76.06 65.77,72.44L69.66,65.73C69.88,65.35 69.74,64.85 69.36,64.63C68.97,64.41 68.48,64.54 68.25,64.93ZM62.39,46.2L60.69,46.2C59.98,46.2 59.4,46.74 59.34,47.43L59.33,47.56L59.33,51.64L58.15,51.64C57.72,51.64 57.36,51.96 57.31,52.38L57.3,52.48L57.3,53.5C57.3,53.93 57.62,54.29 58.04,54.34L58.15,54.35L61.54,54.35L61.65,54.34C62.03,54.3 62.34,53.99 62.38,53.61L62.39,53.5L62.39,46.2ZM47.42,46.2L45.72,46.2L45.72,53.5C45.72,53.93 46.04,54.29 46.46,54.34L46.57,54.35L49.97,54.35C50.43,54.35 50.81,53.97 50.81,53.5L50.81,52.48C50.81,52.02 50.43,51.64 49.97,51.64L48.78,51.64L48.78,47.56C48.78,46.81 48.17,46.2 47.42,46.2ZM45.72,43.15L44.19,43.15C43.35,43.15 42.67,43.83 42.67,44.68C42.67,45.52 43.35,46.2 44.19,46.2L45.72,46.2L45.72,43.15ZM63.92,43.15L62.39,43.15L62.39,46.2L63.92,46.2C64.76,46.2 65.44,45.52 65.44,44.68C65.44,43.83 64.76,43.15 63.92,43.15ZM49.97,35L46.57,35C46.1,35 45.72,35.38 45.72,35.85L45.72,43.15L47.42,43.15C48.17,43.15 48.78,42.54 48.78,41.79L48.78,37.72L49.97,37.72C50.43,37.72 50.81,37.34 50.81,36.87L50.81,35.85C50.81,35.38 50.43,35 49.97,35ZM61.54,35L58.15,35C57.72,35 57.36,35.32 57.31,35.74L57.3,35.85L57.3,36.87C57.3,37.3 57.62,37.66 58.04,37.71L58.15,37.72L59.33,37.72L59.33,41.79C59.33,42.5 59.87,43.08 60.56,43.14L60.69,43.15L62.39,43.15L62.39,35.85C62.39,35.38 62.01,35 61.54,35Z"
+      android:fillColor="#000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="M65.08,84.13C64.01,84.13 63.13,83.26 63.13,82.18C63.13,81.11 64,80.24 65.08,80.24C66.15,80.24 67.02,81.11 67.02,82.18C67.02,83.26 66.15,84.13 65.08,84.13Z"
+      android:fillColor="#000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="M43.6,84.13C42.53,84.13 41.65,83.26 41.65,82.18C41.65,81.11 42.52,80.24 43.6,80.24C44.66,80.24 45.54,81.11 45.54,82.18C45.54,83.26 44.67,84.13 43.6,84.13Z"
+      android:fillColor="#000000"
+      android:fillType="nonZero"/>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -17,4 +17,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
Add `monochrome` attribute to `ic_launcher_round.xml` in :app and :app-nia-catalog

| **Before** | **After** |
|--|--|
| <img src="https://user-images.githubusercontent.com/26246782/168880454-eccc5931-1ca2-4f3f-8c5a-2eb2bb645368.png" /> | <img src="https://user-images.githubusercontent.com/26246782/168880720-363854b8-b2c9-48f4-8e13-84643d43cd2f.png" /> |