### PR TITLE
Update Android Gradle Plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 accompanist = "0.24.8-beta"
 androidDesugarJdkLibs = "1.1.5"
-androidGradlePlugin = "7.1.2"
+androidGradlePlugin = "7.2.1"
 androidxActivity = "1.4.0"
 androidxAppCompat = "1.3.0"
 androidxCompose = "1.2.0-beta01"


### PR DESCRIPTION
Android Studio Chipmunk supports AGP 7.2, and our [gradle-wrapper.properties](https://github.com/android/nowinandroid/blob/main/gradle/wrapper/gradle-wrapper.properties) specifies gradle 7.4, which isn't compatible with the current AGP 7.1.2 

This helps resolve part of the problem described in https://github.com/android/nowinandroid/issues/22 