### PR TITLE
Use `ExistingWorkPolicy.KEEP`.

### DIFF
--- a/sync/src/main/java/com/google/samples/apps/nowinandroid/sync/initializers/SyncInitializer.kt
+++ b/sync/src/main/java/com/google/samples/apps/nowinandroid/sync/initializers/SyncInitializer.kt
@@ -46,7 +46,7 @@ class SyncInitializer : Initializer<Sync> {
             // Run sync on app startup and ensure only one sync worker runs at any time
             enqueueUniqueWork(
                 SyncWorkName,
-                ExistingWorkPolicy.REPLACE,
+                ExistingWorkPolicy.KEEP,
                 SyncWorker.startUpSyncWork()
             )
         }


### PR DESCRIPTION
* You almost never want replace, given `REPLACE` enqueues a
new instance of the WorkRequest again.