### PR TITLE
Add Previews for Feature screens

### DIFF
--- a/core-model/src/main/java/com/google/samples/apps/nowinandroid/core/model/data/Author.kt
+++ b/core-model/src/main/java/com/google/samples/apps/nowinandroid/core/model/data/Author.kt
@@ -16,6 +16,8 @@
 
 package com.google.samples.apps.nowinandroid.core.model.data
 
+/* ktlint-disable max-line-length */
+
 /**
  * External data layer representation of an NiA Author
  */
@@ -26,4 +28,23 @@ data class Author(
     val twitter: String,
     val mediumPage: String,
     val bio: String,
+)
+
+val previewAuthors = listOf(
+    Author(
+        id = "22",
+        name = "Alex Vanyo",
+        mediumPage = "https://medium.com/@alexvanyo",
+        twitter = "https://twitter.com/alex_vanyo",
+        imageUrl = "https://pbs.twimg.com/profile_images/1431339735931305989/nOE2mmi2_400x400.jpg",
+        bio = "Alex joined Android DevRel in 2021, and has worked supporting form factors from small watches to large foldables and tablets. His special interests include insets, Compose, testing and state."
+    ),
+    Author(
+        id = "3",
+        name = "Simona Stojanovic",
+        mediumPage = "https://medium.com/@anomisSi",
+        twitter = "https://twitter.com/anomisSi",
+        imageUrl = "https://pbs.twimg.com/profile_images/1437506849016778756/pG0NZALw_400x400.jpg",
+        bio = "Android Developer Relations Engineer @Google, working on the Compose team and taking care of Layouts & Navigation."
+    )
 )

--- a/core-model/src/main/java/com/google/samples/apps/nowinandroid/core/model/data/NewsResource.kt
+++ b/core-model/src/main/java/com/google/samples/apps/nowinandroid/core/model/data/NewsResource.kt
@@ -16,7 +16,13 @@
 
 package com.google.samples.apps.nowinandroid.core.model.data
 
+import com.google.samples.apps.nowinandroid.core.model.data.NewsResourceType.Codelab
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+
+/* ktlint-disable max-line-length */
 
 /**
  * External data layer representation of a fully populated NiA news resource
@@ -32,4 +38,27 @@ data class NewsResource(
     val type: NewsResourceType,
     val authors: List<Author>,
     val topics: List<Topic>
+)
+
+val previewNewsResources = listOf(
+    NewsResource(
+        id = "1",
+        episodeId = "60",
+        title = "Android Basics with Compose",
+        content = "We released the first two units of Android Basics with Compose, our first free course that teaches Android Development with Jetpack Compose to anyone; you do not need any prior programming experience other than basic computer literacy to get started. You’ll learn the fundamentals of programming in Kotlin while building Android apps using Jetpack Compose, Android’s modern toolkit that simplifies and accelerates native UI development. These two units are just the beginning; more will be coming soon. Check out Android Basics with Compose to get started on your Android development journey",
+        url = "https://android-developers.googleblog.com/2022/05/new-android-basics-with-compose-course.html",
+        headerImageUrl = "https://developer.android.com/images/hero-assets/android-basics-compose.svg",
+        authors = listOf(previewAuthors[0]),
+        publishDate = LocalDateTime(
+            year = 2022,
+            monthNumber = 5,
+            dayOfMonth = 4,
+            hour = 23,
+            minute = 0,
+            second = 0,
+            nanosecond = 0
+        ).toInstant(TimeZone.UTC),
+        type = Codelab,
+        topics = listOf(previewTopics[1])
+    )
 )

--- a/core-model/src/main/java/com/google/samples/apps/nowinandroid/core/model/data/Topic.kt
+++ b/core-model/src/main/java/com/google/samples/apps/nowinandroid/core/model/data/Topic.kt
@@ -16,6 +16,8 @@
 
 package com.google.samples.apps.nowinandroid.core.model.data
 
+/* ktlint-disable max-line-length */
+
 /**
  * External data layer representation of a NiA Topic
  */
@@ -26,4 +28,31 @@ data class Topic(
     val longDescription: String,
     val url: String,
     val imageUrl: String,
+)
+
+val previewTopics = listOf(
+    Topic(
+        id = "2",
+        name = "Headlines",
+        shortDescription = "News we want everyone to see",
+        longDescription = "Stay up to date with the latest events and announcements from Android!",
+        imageUrl = "https://firebasestorage.googleapis.com/v0/b/now-in-android.appspot.com/o/img%2Fic_topic_Headlines.svg?alt=media&token=506faab0-617a-4668-9e63-4a2fb996603f",
+        url = ""
+    ),
+    Topic(
+        id = "3",
+        name = "UI",
+        shortDescription = "Material Design, Navigation, Text, Paging, Accessibility (a11y), Internationalization (i18n), Localization (l10n), Animations, Large Screens, Widgets",
+        longDescription = "Learn how to optimize your app's user interface - everything that users can see and interact with. Stay up to date on tocpis such as Material Design, Navigation, Text, Paging, Compose, Accessibility (a11y), Internationalization (i18n), Localization (l10n), Animations, Large Screens, Widgets, and many more!",
+        imageUrl = "https://firebasestorage.googleapis.com/v0/b/now-in-android.appspot.com/o/img%2Fic_topic_UI.svg?alt=media&token=0ee1842b-12e8-435f-87ba-a5bb02c47594",
+        url = ""
+    ),
+    Topic(
+        id = "4",
+        name = "Testing",
+        shortDescription = "CI, Espresso, TestLab, etc",
+        longDescription = "Testing is an integral part of the app development process. By running tests against your app consistently, you can verify your app's correctness, functional behavior, and usability before you release it publicly. Stay up to date on the latest tricks in CI, Espresso, and Firebase TestLab.",
+        imageUrl = "https://firebasestorage.googleapis.com/v0/b/now-in-android.appspot.com/o/img%2Fic_topic_Testing.svg?alt=media&token=a11533c4-7cc8-4b11-91a3-806158ebf428",
+        url = ""
+    ),
 )

--- a/feature-author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorScreen.kt
+++ b/feature-author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorScreen.kt
@@ -34,11 +34,9 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -46,7 +44,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -232,7 +229,6 @@ private fun AuthorToolbar(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
 @Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
 @Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
@@ -241,23 +237,16 @@ private fun AuthorToolbar(
 fun AuthorScreenPopulated() {
     NiaTheme {
         NiaBackground {
-            Scaffold(
-                containerColor = Color.Transparent,
-                contentColor = MaterialTheme.colorScheme.onBackground,
-            ) { padding ->
-                AuthorScreen(
-                    authorState = AuthorUiState.Success(FollowableAuthor(previewAuthors[0], false)),
-                    newsState = NewsUiState.Success(previewNewsResources),
-                    onBackClick = {},
-                    onFollowClick = {},
-                    modifier = Modifier.padding(padding)
-                )
-            }
+            AuthorScreen(
+                authorState = AuthorUiState.Success(FollowableAuthor(previewAuthors[0], false)),
+                newsState = NewsUiState.Success(previewNewsResources),
+                onBackClick = {},
+                onFollowClick = {}
+            )
         }
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
 @Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
 @Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
@@ -266,18 +255,12 @@ fun AuthorScreenPopulated() {
 fun AuthorScreenLoading() {
     NiaTheme {
         NiaBackground {
-            Scaffold(
-                containerColor = Color.Transparent,
-                contentColor = MaterialTheme.colorScheme.onBackground,
-            ) { padding ->
-                AuthorScreen(
-                    authorState = AuthorUiState.Loading,
-                    newsState = NewsUiState.Loading,
-                    onBackClick = {},
-                    onFollowClick = {},
-                    modifier = Modifier.padding(padding)
-                )
-            }
+            AuthorScreen(
+                authorState = AuthorUiState.Loading,
+                newsState = NewsUiState.Loading,
+                onBackClick = {},
+                onFollowClick = {}
+            )
         }
     }
 }

--- a/feature-author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorScreen.kt
+++ b/feature-author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorScreen.kt
@@ -17,7 +17,6 @@
 package com.google.samples.apps.nowinandroid.feature.author
 
 import androidx.annotation.VisibleForTesting
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -35,9 +34,11 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -45,6 +46,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -53,11 +55,13 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.google.samples.apps.nowinandroid.core.model.data.Author
 import com.google.samples.apps.nowinandroid.core.model.data.FollowableAuthor
+import com.google.samples.apps.nowinandroid.core.model.data.previewAuthors
+import com.google.samples.apps.nowinandroid.core.model.data.previewNewsResources
 import com.google.samples.apps.nowinandroid.core.ui.LoadingWheel
+import com.google.samples.apps.nowinandroid.core.ui.component.NiaBackground
 import com.google.samples.apps.nowinandroid.core.ui.component.NiaFilterChip
 import com.google.samples.apps.nowinandroid.core.ui.newsResourceCardItems
-import com.google.samples.apps.nowinandroid.feature.author.AuthorUiState.Loading
-import com.google.samples.apps.nowinandroid.feature.author.R.string
+import com.google.samples.apps.nowinandroid.core.ui.theme.NiaTheme
 
 @Composable
 fun AuthorRoute(
@@ -76,7 +80,6 @@ fun AuthorRoute(
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @VisibleForTesting
 @Composable
 internal fun AuthorScreen(
@@ -100,11 +103,11 @@ internal fun AuthorScreen(
             )
         }
         when (authorState) {
-            Loading -> {
+            AuthorUiState.Loading -> {
                 item {
                     LoadingWheel(
                         modifier = modifier,
-                        contentDesc = stringResource(id = string.author_loading),
+                        contentDesc = stringResource(id = R.string.author_loading),
                     )
                 }
             }
@@ -221,30 +224,60 @@ private fun AuthorToolbar(
             onCheckedChange = onFollowClick,
         ) {
             if (selected) {
-                Text(stringResource(id = string.author_following))
+                Text(stringResource(id = R.string.author_following))
             } else {
-                Text(stringResource(id = string.author_not_following))
+                Text(stringResource(id = R.string.author_not_following))
             }
         }
     }
 }
 
-@Preview
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
+@Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
+@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
+@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
 @Composable
-private fun AuthorBodyPreview() {
-    MaterialTheme {
-        LazyColumn {
-            authorBody(
-                author = Author(
-                    id = "0",
-                    name = "Android Dev",
-                    bio = "Works on Compose",
-                    twitter = "dev",
-                    mediumPage = "",
-                    imageUrl = "",
-                ),
-                news = NewsUiState.Success(emptyList())
-            )
+fun AuthorScreenPopulated() {
+    NiaTheme {
+        NiaBackground {
+            Scaffold(
+                containerColor = Color.Transparent,
+                contentColor = MaterialTheme.colorScheme.onBackground,
+            ) { padding ->
+                AuthorScreen(
+                    authorState = AuthorUiState.Success(FollowableAuthor(previewAuthors[0], false)),
+                    newsState = NewsUiState.Success(previewNewsResources),
+                    onBackClick = {},
+                    onFollowClick = {},
+                    modifier = Modifier.padding(padding)
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
+@Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
+@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
+@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
+@Composable
+fun AuthorScreenLoading() {
+    NiaTheme {
+        NiaBackground {
+            Scaffold(
+                containerColor = Color.Transparent,
+                contentColor = MaterialTheme.colorScheme.onBackground,
+            ) { padding ->
+                AuthorScreen(
+                    authorState = AuthorUiState.Loading,
+                    newsState = NewsUiState.Loading,
+                    onBackClick = {},
+                    onFollowClick = {},
+                    modifier = Modifier.padding(padding)
+                )
+            }
         }
     }
 }

--- a/feature-foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature-foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -79,13 +79,12 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
-import com.google.samples.apps.nowinandroid.core.model.data.Author
 import com.google.samples.apps.nowinandroid.core.model.data.FollowableAuthor
 import com.google.samples.apps.nowinandroid.core.model.data.FollowableTopic
-import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
-import com.google.samples.apps.nowinandroid.core.model.data.NewsResourceType.Video
 import com.google.samples.apps.nowinandroid.core.model.data.SaveableNewsResource
-import com.google.samples.apps.nowinandroid.core.model.data.Topic
+import com.google.samples.apps.nowinandroid.core.model.data.previewAuthors
+import com.google.samples.apps.nowinandroid.core.model.data.previewNewsResources
+import com.google.samples.apps.nowinandroid.core.model.data.previewTopics
 import com.google.samples.apps.nowinandroid.core.ui.LoadingWheel
 import com.google.samples.apps.nowinandroid.core.ui.NewsResourceCardExpanded
 import com.google.samples.apps.nowinandroid.core.ui.component.NiaFilledButton
@@ -96,7 +95,6 @@ import com.google.samples.apps.nowinandroid.core.ui.icon.NiaIcons
 import com.google.samples.apps.nowinandroid.core.ui.theme.NiaTheme
 import com.google.samples.apps.nowinandroid.core.ui.theme.NiaTypography
 import kotlin.math.floor
-import kotlinx.datetime.Instant
 
 @Composable
 fun ForYouRoute(
@@ -482,9 +480,65 @@ private fun LazyListScope.Feed(
 }
 
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
-@Preview(device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
-@Preview(device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
-@Preview(device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
+@Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
+@Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
+@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
+@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
+@Composable
+fun ForYouScreenPopulatedFeed() {
+    BoxWithConstraints {
+        NiaTheme {
+            ForYouScreen(
+                windowSizeClass = WindowSizeClass.calculateFromSize(DpSize(maxWidth, maxHeight)),
+                interestsSelectionState = ForYouInterestsSelectionUiState.NoInterestsSelection,
+                feedState = ForYouFeedUiState.Success(
+                    feed = previewNewsResources.map {
+                        SaveableNewsResource(it, false)
+                    }
+                ),
+                onTopicCheckedChanged = { _, _ -> },
+                onAuthorCheckedChanged = { _, _ -> },
+                saveFollowedTopics = {},
+                onNewsResourcesCheckedChanged = { _, _ -> }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+@Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
+@Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
+@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
+@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
+@Composable
+fun ForYouScreenTopicSelection() {
+    BoxWithConstraints {
+        NiaTheme {
+            ForYouScreen(
+                windowSizeClass = WindowSizeClass.calculateFromSize(DpSize(maxWidth, maxHeight)),
+                interestsSelectionState = ForYouInterestsSelectionUiState.WithInterestsSelection(
+                    topics = previewTopics.map { FollowableTopic(it, false) },
+                    authors = previewAuthors.map { FollowableAuthor(it, false) }
+                ),
+                feedState = ForYouFeedUiState.Success(
+                    feed = previewNewsResources.map {
+                        SaveableNewsResource(it, false)
+                    }
+                ),
+                onAuthorCheckedChanged = { _, _ -> },
+                onTopicCheckedChanged = { _, _ -> },
+                saveFollowedTopics = {},
+                onNewsResourcesCheckedChanged = { _, _ -> }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+@Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
+@Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
+@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
+@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
 @Composable
 fun ForYouScreenLoading() {
     BoxWithConstraints {
@@ -501,201 +555,3 @@ fun ForYouScreenLoading() {
         }
     }
 }
-
-@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
-@Preview(device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
-@Preview(device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
-@Preview(device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
-@Composable
-fun ForYouScreenTopicSelection() {
-    BoxWithConstraints {
-        NiaTheme {
-            ForYouScreen(
-                windowSizeClass = WindowSizeClass.calculateFromSize(DpSize(maxWidth, maxHeight)),
-                interestsSelectionState = ForYouInterestsSelectionUiState.WithInterestsSelection(
-                    topics = listOf(
-                        FollowableTopic(
-                            topic = Topic(
-                                id = "0",
-                                name = "Headlines",
-                                shortDescription = "",
-                                longDescription = "",
-                                url = "",
-                                imageUrl = ""
-                            ),
-                            isFollowed = false
-                        ),
-                        FollowableTopic(
-                            topic = Topic(
-                                id = "1",
-                                name = "UI",
-                                shortDescription = "",
-                                longDescription = "",
-                                url = "",
-                                imageUrl = ""
-                            ),
-                            isFollowed = false
-                        ),
-                        FollowableTopic(
-                            topic = Topic(
-                                id = "2",
-                                name = "Publishing and Distribution",
-                                shortDescription = "",
-                                longDescription = "",
-                                url = "",
-                                imageUrl = ""
-                            ),
-                            isFollowed = false
-                        ),
-                    ),
-                    authors = listOf(
-                        FollowableAuthor(
-                            author = Author(
-                                id = "0",
-                                name = "Android Dev",
-                                imageUrl = "",
-                                twitter = "",
-                                mediumPage = "",
-                                bio = "",
-                            ),
-                            isFollowed = false
-                        ),
-                        FollowableAuthor(
-                            author = Author(
-                                id = "1",
-                                name = "Android Dev 2",
-                                imageUrl = "",
-                                twitter = "",
-                                mediumPage = "",
-                                bio = "",
-                            ),
-                            isFollowed = false
-                        ),
-                        FollowableAuthor(
-                            author = Author(
-                                id = "2",
-                                name = "Android Dev 3",
-                                imageUrl = "",
-                                twitter = "",
-                                mediumPage = "",
-                                bio = "",
-                            ),
-                            isFollowed = false
-                        )
-                    )
-                ),
-                feedState = ForYouFeedUiState.Success(
-                    feed = saveableNewsResource,
-                ),
-                onAuthorCheckedChanged = { _, _ -> },
-                onTopicCheckedChanged = { _, _ -> },
-                saveFollowedTopics = {},
-                onNewsResourcesCheckedChanged = { _, _ -> }
-            )
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
-@Preview(device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
-@Preview(device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
-@Preview(device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
-@Composable
-fun PopulatedFeed() {
-    BoxWithConstraints {
-        NiaTheme {
-            ForYouScreen(
-                windowSizeClass = WindowSizeClass.calculateFromSize(DpSize(maxWidth, maxHeight)),
-                interestsSelectionState = ForYouInterestsSelectionUiState.NoInterestsSelection,
-                feedState = ForYouFeedUiState.Success(
-                    feed = saveableNewsResource
-                ),
-                onTopicCheckedChanged = { _, _ -> },
-                onAuthorCheckedChanged = { _, _ -> },
-                saveFollowedTopics = {},
-                onNewsResourcesCheckedChanged = { _, _ -> }
-            )
-        }
-    }
-}
-
-private val saveableNewsResource = listOf(
-    SaveableNewsResource(
-        newsResource = NewsResource(
-            id = "1",
-            episodeId = "52",
-            title = "Thanks for helping us reach 1M YouTube Subscribers",
-            content = "Thank you everyone for following the Now in Android series " +
-                "and everything the Android Developers YouTube channel has to offer. " +
-                "During the Android Developer Summit, our YouTube channel reached 1 " +
-                "million subscribers! Here’s a small video to thank you all.",
-            url = "https://youtu.be/-fJ6poHQrjM",
-            headerImageUrl = "https://i.ytimg.com/vi/-fJ6poHQrjM/maxresdefault.jpg",
-            publishDate = Instant.parse("2021-11-09T00:00:00.000Z"),
-            type = Video,
-            topics = listOf(
-                Topic(
-                    id = "0",
-                    name = "Headlines",
-                    shortDescription = "",
-                    longDescription = "",
-                    url = "",
-                    imageUrl = ""
-                )
-            ),
-            authors = emptyList()
-        ),
-        isSaved = false
-    ),
-    SaveableNewsResource(
-        newsResource = NewsResource(
-            id = "2",
-            episodeId = "52",
-            title = "Transformations and customisations in the Paging Library",
-            content = "A demonstration of different operations that can be performed " +
-                "with Paging. Transformations like inserting separators, when to " +
-                "create a new pager, and customisation options for consuming " +
-                "PagingData.",
-            url = "https://youtu.be/ZARz0pjm5YM",
-            headerImageUrl = "https://i.ytimg.com/vi/ZARz0pjm5YM/maxresdefault.jpg",
-            publishDate = Instant.parse("2021-11-01T00:00:00.000Z"),
-            type = Video,
-            topics = listOf(
-                Topic(
-                    id = "1",
-                    name = "UI",
-                    shortDescription = "",
-                    longDescription = "",
-                    url = "",
-                    imageUrl = ""
-                ),
-            ),
-            authors = emptyList()
-        ),
-        isSaved = false
-    ),
-    SaveableNewsResource(
-        newsResource = NewsResource(
-            id = "3",
-            episodeId = "52",
-            title = "Community tip on Paging",
-            content = "Tips for using the Paging library from the developer community",
-            url = "https://youtu.be/r5JgIyS3t3s",
-            headerImageUrl = "https://i.ytimg.com/vi/r5JgIyS3t3s/maxresdefault.jpg",
-            publishDate = Instant.parse("2021-11-08T00:00:00.000Z"),
-            type = Video,
-            topics = listOf(
-                Topic(
-                    id = "1",
-                    name = "UI",
-                    shortDescription = "",
-                    longDescription = "",
-                    url = "",
-                    imageUrl = ""
-                ),
-            ),
-            authors = emptyList()
-        ),
-        isSaved = false
-    ),
-)

--- a/feature-interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsScreen.kt
+++ b/feature-interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsScreen.kt
@@ -27,19 +27,30 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.google.samples.apps.nowinandroid.core.model.data.FollowableAuthor
+import com.google.samples.apps.nowinandroid.core.model.data.FollowableTopic
+import com.google.samples.apps.nowinandroid.core.model.data.previewAuthors
+import com.google.samples.apps.nowinandroid.core.model.data.previewTopics
 import com.google.samples.apps.nowinandroid.core.ui.LoadingWheel
+import com.google.samples.apps.nowinandroid.core.ui.component.NiaBackground
 import com.google.samples.apps.nowinandroid.core.ui.component.NiaTab
 import com.google.samples.apps.nowinandroid.core.ui.component.NiaTabRow
 import com.google.samples.apps.nowinandroid.core.ui.component.NiaTopAppBar
+import com.google.samples.apps.nowinandroid.core.ui.theme.NiaTheme
 
 @Composable
 fun InterestsRoute(
@@ -163,4 +174,100 @@ private fun InterestsContent(
 @Composable
 private fun InterestsEmptyScreen() {
     Text(text = stringResource(id = R.string.interests_empty_header))
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
+@Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
+@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
+@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
+@Composable
+fun InterestsScreenPopulated() {
+    NiaTheme {
+        NiaBackground {
+            Scaffold(
+                containerColor = Color.Transparent,
+                contentColor = MaterialTheme.colorScheme.onBackground,
+            ) { padding ->
+                InterestsScreen(
+                    uiState = InterestsUiState.Interests(
+                        authors = previewAuthors.map { FollowableAuthor(it, false) },
+                        topics = previewTopics.map { FollowableTopic(it, false) }
+                    ),
+                    tabState = InterestsTabState(
+                        titles = listOf(R.string.interests_topics, R.string.interests_people),
+                        currentIndex = 0
+                    ),
+                    followAuthor = { _, _ -> },
+                    followTopic = { _, _ -> },
+                    navigateToAuthor = {},
+                    navigateToTopic = {},
+                    switchTab = {},
+                    modifier = Modifier.padding(padding)
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
+@Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
+@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
+@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
+@Composable
+fun InterestsScreenLoading() {
+    NiaTheme {
+        NiaBackground {
+            Scaffold(
+                containerColor = Color.Transparent,
+                contentColor = MaterialTheme.colorScheme.onBackground,
+            ) { padding ->
+                InterestsScreen(
+                    uiState = InterestsUiState.Loading,
+                    tabState = InterestsTabState(
+                        titles = listOf(R.string.interests_topics, R.string.interests_people),
+                        currentIndex = 0
+                    ),
+                    followAuthor = { _, _ -> },
+                    followTopic = { _, _ -> },
+                    navigateToAuthor = {},
+                    navigateToTopic = {},
+                    switchTab = {},
+                    modifier = Modifier.padding(padding)
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
+@Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
+@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
+@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
+@Composable
+fun InterestsScreenEmpty() {
+    NiaTheme {
+        NiaBackground {
+            Scaffold(
+                containerColor = Color.Transparent,
+                contentColor = MaterialTheme.colorScheme.onBackground,
+            ) { padding ->
+                InterestsScreen(
+                    uiState = InterestsUiState.Empty,
+                    tabState = InterestsTabState(
+                        titles = listOf(R.string.interests_topics, R.string.interests_people),
+                        currentIndex = 0
+                    ),
+                    followAuthor = { _, _ -> },
+                    followTopic = { _, _ -> },
+                    navigateToAuthor = {},
+                    navigateToTopic = {},
+                    switchTab = {},
+                    modifier = Modifier.padding(padding)
+                )
+            }
+        }
+    }
 }

--- a/feature-interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsScreen.kt
+++ b/feature-interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsScreen.kt
@@ -27,16 +27,12 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -176,7 +172,6 @@ private fun InterestsEmptyScreen() {
     Text(text = stringResource(id = R.string.interests_empty_header))
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
 @Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
 @Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
@@ -185,32 +180,25 @@ private fun InterestsEmptyScreen() {
 fun InterestsScreenPopulated() {
     NiaTheme {
         NiaBackground {
-            Scaffold(
-                containerColor = Color.Transparent,
-                contentColor = MaterialTheme.colorScheme.onBackground,
-            ) { padding ->
-                InterestsScreen(
-                    uiState = InterestsUiState.Interests(
-                        authors = previewAuthors.map { FollowableAuthor(it, false) },
-                        topics = previewTopics.map { FollowableTopic(it, false) }
-                    ),
-                    tabState = InterestsTabState(
-                        titles = listOf(R.string.interests_topics, R.string.interests_people),
-                        currentIndex = 0
-                    ),
-                    followAuthor = { _, _ -> },
-                    followTopic = { _, _ -> },
-                    navigateToAuthor = {},
-                    navigateToTopic = {},
-                    switchTab = {},
-                    modifier = Modifier.padding(padding)
-                )
-            }
+            InterestsScreen(
+                uiState = InterestsUiState.Interests(
+                    authors = previewAuthors.map { FollowableAuthor(it, false) },
+                    topics = previewTopics.map { FollowableTopic(it, false) }
+                ),
+                tabState = InterestsTabState(
+                    titles = listOf(R.string.interests_topics, R.string.interests_people),
+                    currentIndex = 0
+                ),
+                followAuthor = { _, _ -> },
+                followTopic = { _, _ -> },
+                navigateToAuthor = {},
+                navigateToTopic = {},
+                switchTab = {}
+            )
         }
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
 @Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
 @Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
@@ -219,29 +207,22 @@ fun InterestsScreenPopulated() {
 fun InterestsScreenLoading() {
     NiaTheme {
         NiaBackground {
-            Scaffold(
-                containerColor = Color.Transparent,
-                contentColor = MaterialTheme.colorScheme.onBackground,
-            ) { padding ->
-                InterestsScreen(
-                    uiState = InterestsUiState.Loading,
-                    tabState = InterestsTabState(
-                        titles = listOf(R.string.interests_topics, R.string.interests_people),
-                        currentIndex = 0
-                    ),
-                    followAuthor = { _, _ -> },
-                    followTopic = { _, _ -> },
-                    navigateToAuthor = {},
-                    navigateToTopic = {},
-                    switchTab = {},
-                    modifier = Modifier.padding(padding)
-                )
-            }
+            InterestsScreen(
+                uiState = InterestsUiState.Loading,
+                tabState = InterestsTabState(
+                    titles = listOf(R.string.interests_topics, R.string.interests_people),
+                    currentIndex = 0
+                ),
+                followAuthor = { _, _ -> },
+                followTopic = { _, _ -> },
+                navigateToAuthor = {},
+                navigateToTopic = {},
+                switchTab = {},
+            )
         }
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
 @Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
 @Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
@@ -250,24 +231,18 @@ fun InterestsScreenLoading() {
 fun InterestsScreenEmpty() {
     NiaTheme {
         NiaBackground {
-            Scaffold(
-                containerColor = Color.Transparent,
-                contentColor = MaterialTheme.colorScheme.onBackground,
-            ) { padding ->
-                InterestsScreen(
-                    uiState = InterestsUiState.Empty,
-                    tabState = InterestsTabState(
-                        titles = listOf(R.string.interests_topics, R.string.interests_people),
-                        currentIndex = 0
-                    ),
-                    followAuthor = { _, _ -> },
-                    followTopic = { _, _ -> },
-                    navigateToAuthor = {},
-                    navigateToTopic = {},
-                    switchTab = {},
-                    modifier = Modifier.padding(padding)
-                )
-            }
+            InterestsScreen(
+                uiState = InterestsUiState.Empty,
+                tabState = InterestsTabState(
+                    titles = listOf(R.string.interests_topics, R.string.interests_people),
+                    currentIndex = 0
+                ),
+                followAuthor = { _, _ -> },
+                followTopic = { _, _ -> },
+                navigateToAuthor = {},
+                navigateToTopic = {},
+                switchTab = {}
+            )
         }
     }
 }

--- a/feature-topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
+++ b/feature-topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
@@ -34,24 +34,31 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.google.samples.apps.nowinandroid.core.model.data.FollowableTopic
+import com.google.samples.apps.nowinandroid.core.model.data.previewNewsResources
+import com.google.samples.apps.nowinandroid.core.model.data.previewTopics
 import com.google.samples.apps.nowinandroid.core.ui.LoadingWheel
+import com.google.samples.apps.nowinandroid.core.ui.component.NiaBackground
 import com.google.samples.apps.nowinandroid.core.ui.component.NiaFilterChip
 import com.google.samples.apps.nowinandroid.core.ui.newsResourceCardItems
+import com.google.samples.apps.nowinandroid.core.ui.theme.NiaTheme
 import com.google.samples.apps.nowinandroid.feature.topic.R.string
 import com.google.samples.apps.nowinandroid.feature.topic.TopicUiState.Loading
 
@@ -188,19 +195,6 @@ private fun LazyListScope.TopicCards(news: NewsUiState) {
     }
 }
 
-@Preview
-@Composable
-private fun TopicBodyPreview() {
-    MaterialTheme {
-        LazyColumn {
-            TopicBody(
-                "Jetpack Compose", "Lorem ipsum maximum",
-                NewsUiState.Success(emptyList()), ""
-            )
-        }
-    }
-}
-
 @Composable
 private fun TopicToolbar(
     uiState: FollowableTopic,
@@ -231,6 +225,56 @@ private fun TopicToolbar(
                 Text("FOLLOWING")
             } else {
                 Text("NOT FOLLOWING")
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
+@Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
+@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
+@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
+@Composable
+fun TopicScreenPopulated() {
+    NiaTheme {
+        NiaBackground {
+            Scaffold(
+                containerColor = Color.Transparent,
+                contentColor = MaterialTheme.colorScheme.onBackground,
+            ) { padding ->
+                TopicScreen(
+                    topicState = TopicUiState.Success(FollowableTopic(previewTopics[0], false)),
+                    newsState = NewsUiState.Success(previewNewsResources),
+                    onBackClick = {},
+                    onFollowClick = {},
+                    modifier = Modifier.padding(padding)
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
+@Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
+@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
+@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
+@Composable
+fun TopicScreenLoading() {
+    NiaTheme {
+        NiaBackground {
+            Scaffold(
+                containerColor = Color.Transparent,
+                contentColor = MaterialTheme.colorScheme.onBackground,
+            ) { padding ->
+                TopicScreen(
+                    topicState = TopicUiState.Loading,
+                    newsState = NewsUiState.Loading,
+                    onBackClick = {},
+                    onFollowClick = {},
+                    modifier = Modifier.padding(padding)
+                )
             }
         }
     }

--- a/feature-topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
+++ b/feature-topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
@@ -34,18 +34,15 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -230,7 +227,6 @@ private fun TopicToolbar(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
 @Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
 @Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
@@ -239,23 +235,16 @@ private fun TopicToolbar(
 fun TopicScreenPopulated() {
     NiaTheme {
         NiaBackground {
-            Scaffold(
-                containerColor = Color.Transparent,
-                contentColor = MaterialTheme.colorScheme.onBackground,
-            ) { padding ->
-                TopicScreen(
-                    topicState = TopicUiState.Success(FollowableTopic(previewTopics[0], false)),
-                    newsState = NewsUiState.Success(previewNewsResources),
-                    onBackClick = {},
-                    onFollowClick = {},
-                    modifier = Modifier.padding(padding)
-                )
-            }
+            TopicScreen(
+                topicState = TopicUiState.Success(FollowableTopic(previewTopics[0], false)),
+                newsState = NewsUiState.Success(previewNewsResources),
+                onBackClick = {},
+                onFollowClick = {}
+            )
         }
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
 @Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
 @Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
@@ -264,18 +253,12 @@ fun TopicScreenPopulated() {
 fun TopicScreenLoading() {
     NiaTheme {
         NiaBackground {
-            Scaffold(
-                containerColor = Color.Transparent,
-                contentColor = MaterialTheme.colorScheme.onBackground,
-            ) { padding ->
-                TopicScreen(
-                    topicState = TopicUiState.Loading,
-                    newsState = NewsUiState.Loading,
-                    onBackClick = {},
-                    onFollowClick = {},
-                    modifier = Modifier.padding(padding)
-                )
-            }
+            TopicScreen(
+                topicState = TopicUiState.Loading,
+                newsState = NewsUiState.Loading,
+                onBackClick = {},
+                onFollowClick = {}
+            )
         }
     }
 }


### PR DESCRIPTION
Adding Previews for the different UI states:
- Loading
- Onboarding
- Content
- Empty

Added fake data to the various model classes. Not sure about adding this in production code, but couldn't think of a better approach, and will be removed in release build anyway.