### PR TITLE
fix: gradle build failed - 'VERSION_CATALOGS' feature

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+enableFeaturePreview("VERSION_CATALOGS")
 
 dependencyResolutionManagement {
     repositories {


### PR DESCRIPTION
to fix gradle build failed - "Using dependency catalogs requires the activation of the matching feature preview." when first running `app` module