### PR TITLE
use serializedName to serialize NewsResourceType

### DIFF
--- a/core-network/src/main/java/com/google/samples/apps/nowinandroid/core/network/model/util/NewsResourceTypeSerializer.kt
+++ b/core-network/src/main/java/com/google/samples/apps/nowinandroid/core/network/model/util/NewsResourceTypeSerializer.kt
@@ -35,5 +35,5 @@ object NewsResourceTypeSerializer : KSerializer<NewsResourceType> {
     )
 
     override fun serialize(encoder: Encoder, value: NewsResourceType) =
-        encoder.encodeString(value.name)
+        encoder.encodeString(value.serializedName)
 }

--- a/core-network/src/test/java/com/google/samples/apps/nowinandroid/core/network/model/util/NewsResourceTypeSerializerTest.kt
+++ b/core-network/src/test/java/com/google/samples/apps/nowinandroid/core/network/model/util/NewsResourceTypeSerializerTest.kt
@@ -94,4 +94,13 @@ class NewsResourceTypeSerializerTest {
             Json.decodeFromString(NewsResourceTypeSerializer, """"umm"""")
         )
     }
+
+    @Test
+    fun test_serialize_and_deserialize() {
+        val json = Json.encodeToString(NewsResourceTypeSerializer, NewsResourceType.Video)
+        assertEquals(
+            NewsResourceType.Video,
+            Json.decodeFromString(NewsResourceTypeSerializer, json)
+        )
+    }
 }


### PR DESCRIPTION
NewsResourceTypeSerializer uses serializedName to deserialize, so it should also use serializedName to serialize.