### PR TITLE
remove explicit cancel calls in tests

### DIFF
--- a/feature-author/src/test/java/com/google/samples/apps/nowinandroid/feature/author/AuthorViewModelTest.kt
+++ b/feature-author/src/test/java/com/google/samples/apps/nowinandroid/feature/author/AuthorViewModelTest.kt
@@ -75,8 +75,6 @@ class AuthorViewModelTest {
 
             successAuthorUiState.followableAuthor.author
             assertEquals(authorFromRepository, successAuthorUiState.followableAuthor.author)
-
-            cancel()
         }
     }
 
@@ -84,7 +82,6 @@ class AuthorViewModelTest {
     fun uiStateNews_whenInitialized_thenShowLoading() = runTest {
         viewModel.uiState.test {
             assertEquals(NewsUiState.Loading, awaitItem().newsState)
-            cancel()
         }
     }
 
@@ -92,7 +89,6 @@ class AuthorViewModelTest {
     fun uiStateAuthor_whenInitialized_thenShowLoading() = runTest {
         viewModel.uiState.test {
             assertEquals(AuthorUiState.Loading, awaitItem().authorState)
-            cancel()
         }
     }
 
@@ -101,7 +97,6 @@ class AuthorViewModelTest {
         viewModel.uiState.test {
             authorsRepository.setFollowedAuthorIds(setOf(testInputAuthors[1].author.id))
             assertEquals(AuthorUiState.Loading, awaitItem().authorState)
-            cancel()
         }
     }
 
@@ -115,7 +110,6 @@ class AuthorViewModelTest {
                 val item = awaitItem()
                 assertTrue(item.authorState is AuthorUiState.Success)
                 assertTrue(item.newsState is NewsUiState.Loading)
-                cancel()
             }
         }
 
@@ -130,7 +124,6 @@ class AuthorViewModelTest {
                 val item = awaitItem()
                 assertTrue(item.authorState is AuthorUiState.Success)
                 assertTrue(item.newsState is NewsUiState.Success)
-                cancel()
             }
         }
 
@@ -149,7 +142,6 @@ class AuthorViewModelTest {
                     AuthorUiState.Success(followableAuthor = testOutputAuthors[0]),
                     awaitItem().authorState
                 )
-                cancel()
             }
     }
 }

--- a/feature-foryou/src/test/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouViewModelTest.kt
+++ b/feature-foryou/src/test/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouViewModelTest.kt
@@ -84,7 +84,6 @@ class ForYouViewModelTest {
                 ),
                 awaitItem()
             )
-            cancel()
         }
     }
 
@@ -99,8 +98,6 @@ class ForYouViewModelTest {
                 awaitItem()
             )
             topicsRepository.sendTopics(sampleTopics)
-
-            cancel()
         }
     }
 
@@ -115,8 +112,6 @@ class ForYouViewModelTest {
                 awaitItem()
             )
             authorsRepository.sendAuthors(sampleAuthors)
-
-            cancel()
         }
     }
 
@@ -131,8 +126,6 @@ class ForYouViewModelTest {
                 awaitItem()
             )
             topicsRepository.setFollowedTopicIds(emptySet())
-
-            cancel()
         }
     }
 
@@ -147,8 +140,6 @@ class ForYouViewModelTest {
                 awaitItem()
             )
             authorsRepository.setFollowedAuthorIds(emptySet())
-
-            cancel()
         }
     }
 
@@ -244,8 +235,6 @@ class ForYouViewModelTest {
                 ),
                 expectMostRecentItem()
             )
-
-            cancel()
         }
     }
 
@@ -341,7 +330,6 @@ class ForYouViewModelTest {
                     ),
                     expectMostRecentItem()
                 )
-                cancel()
             }
     }
 
@@ -382,7 +370,6 @@ class ForYouViewModelTest {
                     ),
                     awaitItem()
                 )
-                cancel()
             }
     }
 
@@ -423,7 +410,6 @@ class ForYouViewModelTest {
                     ),
                     awaitItem()
                 )
-                cancel()
             }
     }
 
@@ -692,7 +678,6 @@ class ForYouViewModelTest {
                     ),
                     awaitItem()
                 )
-                cancel()
             }
     }
 
@@ -961,7 +946,6 @@ class ForYouViewModelTest {
                     ),
                     awaitItem()
                 )
-                cancel()
             }
     }
 
@@ -1059,7 +1043,6 @@ class ForYouViewModelTest {
                     ),
                     expectMostRecentItem()
                 )
-                cancel()
             }
     }
 
@@ -1157,7 +1140,6 @@ class ForYouViewModelTest {
                     ),
                     expectMostRecentItem()
                 )
-                cancel()
             }
     }
 
@@ -1199,7 +1181,6 @@ class ForYouViewModelTest {
                 )
                 assertEquals(setOf("1"), topicsRepository.getCurrentFollowedTopics())
                 assertEquals(emptySet<Int>(), authorsRepository.getCurrentFollowedAuthors())
-                cancel()
             }
     }
 
@@ -1237,7 +1218,6 @@ class ForYouViewModelTest {
                 )
                 assertEquals(emptySet<Int>(), topicsRepository.getCurrentFollowedTopics())
                 assertEquals(setOf("0"), authorsRepository.getCurrentFollowedAuthors())
-                cancel()
             }
     }
 
@@ -1280,7 +1260,6 @@ class ForYouViewModelTest {
                 )
                 assertEquals(setOf("1"), topicsRepository.getCurrentFollowedTopics())
                 assertEquals(setOf("1"), authorsRepository.getCurrentFollowedAuthors())
-                cancel()
             }
     }
 
@@ -1384,7 +1363,6 @@ class ForYouViewModelTest {
 
                     expectMostRecentItem()
                 )
-                cancel()
             }
     }
 
@@ -1487,7 +1465,6 @@ class ForYouViewModelTest {
                     ),
                     expectMostRecentItem()
                 )
-                cancel()
             }
     }
 
@@ -1522,7 +1499,6 @@ class ForYouViewModelTest {
                     ),
                     expectMostRecentItem()
                 )
-                cancel()
             }
     }
 }

--- a/feature-interests/src/test/java/com/google/samples/apps/nowinandroid/interests/InterestsViewModelTest.kt
+++ b/feature-interests/src/test/java/com/google/samples/apps/nowinandroid/interests/InterestsViewModelTest.kt
@@ -50,7 +50,6 @@ class InterestsViewModelTest {
     fun uiState_whenInitialized_thenShowLoading() = runTest {
         viewModel.uiState.test {
             assertEquals(InterestsUiState.Loading, awaitItem())
-            cancel()
         }
     }
 
@@ -60,7 +59,6 @@ class InterestsViewModelTest {
             assertEquals(InterestsUiState.Loading, awaitItem())
             authorsRepository.setFollowedAuthorIds(setOf("1"))
             topicsRepository.setFollowedTopicIds(emptySet())
-            cancel()
         }
     }
 
@@ -70,7 +68,6 @@ class InterestsViewModelTest {
             assertEquals(InterestsUiState.Loading, awaitItem())
             authorsRepository.setFollowedAuthorIds(emptySet())
             topicsRepository.setFollowedTopicIds(setOf("1"))
-            cancel()
         }
     }
 
@@ -100,7 +97,6 @@ class InterestsViewModelTest {
                     InterestsUiState.Interests(topics = testOutputTopics, authors = emptyList()),
                     awaitItem()
                 )
-                cancel()
             }
     }
 
@@ -124,7 +120,6 @@ class InterestsViewModelTest {
                     InterestsUiState.Interests(topics = emptyList(), authors = testOutputAuthors),
                     awaitItem()
                 )
-                cancel()
             }
     }
 
@@ -156,7 +151,6 @@ class InterestsViewModelTest {
                     InterestsUiState.Interests(topics = testInputTopics, authors = emptyList()),
                     awaitItem()
                 )
-                cancel()
             }
     }
 
@@ -182,7 +176,6 @@ class InterestsViewModelTest {
                     InterestsUiState.Interests(topics = emptyList(), authors = testInputAuthors),
                     awaitItem()
                 )
-                cancel()
             }
     }
 }

--- a/feature-topic/src/test/java/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModelTest.kt
+++ b/feature-topic/src/test/java/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModelTest.kt
@@ -69,7 +69,6 @@ class TopicViewModelTest {
             ).first()
 
             assertEquals(topicFromRepository, successTopicState.followableTopic.topic)
-            cancel()
         }
     }
 
@@ -77,7 +76,6 @@ class TopicViewModelTest {
     fun uiStateNews_whenInitialized_thenShowLoading() = runTest {
         viewModel.uiState.test {
             assertEquals(NewsUiState.Loading, awaitItem().newsState)
-            cancel()
         }
     }
 
@@ -85,7 +83,6 @@ class TopicViewModelTest {
     fun uiStateTopic_whenInitialized_thenShowLoading() = runTest {
         viewModel.uiState.test {
             assertEquals(TopicUiState.Loading, awaitItem().topicState)
-            cancel()
         }
     }
 
@@ -94,7 +91,6 @@ class TopicViewModelTest {
         viewModel.uiState.test {
             topicsRepository.setFollowedTopicIds(setOf(testInputTopics[1].topic.id))
             assertEquals(TopicUiState.Loading, awaitItem().topicState)
-            cancel()
         }
     }
 
@@ -108,7 +104,6 @@ class TopicViewModelTest {
                 val item = awaitItem()
                 assertTrue(item.topicState is TopicUiState.Success)
                 assertTrue(item.newsState is NewsUiState.Loading)
-                cancel()
             }
         }
 
@@ -123,7 +118,6 @@ class TopicViewModelTest {
                 val item = awaitItem()
                 assertTrue(item.topicState is TopicUiState.Success)
                 assertTrue(item.newsState is NewsUiState.Success)
-                cancel()
             }
         }
 
@@ -142,7 +136,6 @@ class TopicViewModelTest {
                     TopicUiState.Success(followableTopic = testOutputTopics[0]),
                     awaitItem().topicState
                 )
-                cancel()
             }
     }
 }


### PR DESCRIPTION
fixes #122
Simplify tests with turbine by removing explicit cancel calls 