### PR TITLE
Remove workaround for hilt crash with androidx startup

### DIFF
--- a/app/src/main/java/com/google/samples/apps/nowinandroid/NiaApp.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/NiaApp.kt
@@ -20,7 +20,6 @@ import android.app.Application
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import coil.decode.SvgDecoder
-import com.google.samples.apps.nowinandroid.sync.initializers.Sync
 import dagger.hilt.android.HiltAndroidApp
 
 /**
@@ -28,12 +27,6 @@ import dagger.hilt.android.HiltAndroidApp
  */
 @HiltAndroidApp
 class NiaApp : Application(), ImageLoaderFactory {
-    override fun onCreate() {
-        super.onCreate()
-        // Initialize Sync; the system responsible for keeping data in the app up to date.
-        Sync.initialize(context = this)
-    }
-
     /**
      * Since we're displaying SVGs in the app, Coil needs an ImageLoader which supports this
      * format. During Coil's initialization it will call `applicationContext.newImageLoader()` to

--- a/sync/src/main/AndroidManifest.xml
+++ b/sync/src/main/AndroidManifest.xml
@@ -24,11 +24,9 @@
             android:authorities="${applicationId}.androidx-startup"
             android:exported="false"
             tools:node="merge">
-            <!--  TODO: b/2173216 Disable auto sync startup till it works well with instrumented tests   -->
             <meta-data
                 android:name="com.google.samples.apps.nowinandroid.sync.initializers.SyncInitializer"
-                android:value="androidx.startup"
-                tools:node="remove" />
+                android:value="androidx.startup" />
         </provider>
 
     </application>

--- a/sync/src/main/java/com/google/samples/apps/nowinandroid/sync/initializers/SyncInitializer.kt
+++ b/sync/src/main/java/com/google/samples/apps/nowinandroid/sync/initializers/SyncInitializer.kt
@@ -17,22 +17,13 @@
 package com.google.samples.apps.nowinandroid.sync.initializers
 
 import android.content.Context
-import androidx.startup.AppInitializer
 import androidx.startup.Initializer
 import androidx.work.ExistingWorkPolicy
 import androidx.work.WorkManager
 import androidx.work.WorkManagerInitializer
 import com.google.samples.apps.nowinandroid.sync.workers.SyncWorker
 
-object Sync {
-    // This method is a workaround to manually initialize the sync process instead of relying on
-    // automatic initialization with Androidx Startup. It is called from the app module's
-    // Application.onCreate() and should be only done once.
-    fun initialize(context: Context) {
-        AppInitializer.getInstance(context)
-            .initializeComponent(SyncInitializer::class.java)
-    }
-}
+object Sync
 
 // This name should not be changed otherwise the app may have concurrent sync requests running
 private const val SyncWorkName = "SyncWorkName"


### PR DESCRIPTION
This issue was fixed in hilt here: https://github.com/google/dagger/issues/3356

We've already updated to the requisite version.