### PR TITLE
Add a gradle.properties file to the build-logic build

### DIFF
--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -1,0 +1,4 @@
+# Gradle properties are not passed to included builds https://github.com/gradle/gradle/issues/2534
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configureondemand=true


### PR DESCRIPTION
This PR closes adds a `gradle.properties` to the `build-logic` build because the global properties aren't passed down to composite builds. Gradle issue [here](https://github.com/gradle/gradle/issues/2534)

I've set the following flags to true, but feel free to modify these properties further according to the project requirements down the line.

```
org.gradle.parallel=true
org.gradle.caching=true
org.gradle.configureondemand=true

```
This closes https://github.com/android/nowinandroid/issues/167