### PR TITLE
Remove weight on NiaButtonContent that was causing narrow buttons when using Row with horizontalScroll

### DIFF
--- a/core-designsystem/src/main/java/com/google/samples/apps/nowinandroid/core/designsystem/component/Button.kt
+++ b/core-designsystem/src/main/java/com/google/samples/apps/nowinandroid/core/designsystem/component/Button.kt
@@ -324,7 +324,6 @@ private fun RowScope.NiaButtonContent(
     }
     Box(
         Modifier
-            .weight(1f, fill = false)
             .padding(
                 start = if (leadingIcon != null) {
                     NiaButtonDefaults.ButtonContentSpacing


### PR DESCRIPTION
Fix for issue described here: https://github.com/android/nowinandroid/pull/151#discussion_r917180383