### PR TITLE
Icons alignment to use NiaIcons

### DIFF
--- a/core/designsystem/src/main/java/com/google/samples/apps/nowinandroid/core/designsystem/component/TopAppBar.kt
+++ b/core/designsystem/src/main/java/com/google/samples/apps/nowinandroid/core/designsystem/component/TopAppBar.kt
@@ -17,9 +17,6 @@
 package com.google.samples.apps.nowinandroid.core.designsystem.component
 
 import androidx.annotation.StringRes
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -33,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.google.samples.apps.nowinandroid.core.designsystem.icon.NiaIcons
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -107,9 +105,9 @@ fun NiaTopAppBar(
 fun NiaTopAppBarPreview() {
     NiaTopAppBar(
         titleRes = android.R.string.untitled,
-        navigationIcon = Icons.Default.Search,
+        navigationIcon = NiaIcons.Search,
         navigationIconContentDescription = "Navigation icon",
-        actionIcon = Icons.Default.MoreVert,
+        actionIcon = NiaIcons.MoreVert,
         actionIconContentDescription = "Action icon"
     )
 }

--- a/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorScreen.kt
+++ b/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorScreen.kt
@@ -32,8 +32,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons.Filled
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -53,6 +51,7 @@ import coil.compose.AsyncImage
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaBackground
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaFilterChip
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaLoadingWheel
+import com.google.samples.apps.nowinandroid.core.designsystem.icon.NiaIcons
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import com.google.samples.apps.nowinandroid.core.domain.model.FollowableAuthor
 import com.google.samples.apps.nowinandroid.core.domain.model.SaveableNewsResource
@@ -213,7 +212,7 @@ private fun AuthorToolbar(
     ) {
         IconButton(onClick = { onBackClick() }) {
             Icon(
-                imageVector = Filled.ArrowBack,
+                imageVector = NiaIcons.ArrowBack,
                 contentDescription = stringResource(
                     id = com.google.samples.apps.nowinandroid.core.ui.R.string.back
                 )

--- a/feature/topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
@@ -31,8 +31,6 @@ import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.icons.Icons.Filled
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -51,6 +49,7 @@ import coil.compose.AsyncImage
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaBackground
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaFilterChip
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaLoadingWheel
+import com.google.samples.apps.nowinandroid.core.designsystem.icon.NiaIcons
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import com.google.samples.apps.nowinandroid.core.domain.model.FollowableTopic
 import com.google.samples.apps.nowinandroid.core.domain.model.SaveableNewsResource
@@ -109,6 +108,7 @@ internal fun TopicScreen(
                     contentDesc = stringResource(id = string.topic_loading),
                 )
             }
+
             TopicUiState.Error -> TODO()
             is TopicUiState.Success -> {
                 item {
@@ -186,9 +186,11 @@ private fun LazyListScope.TopicCards(
                 itemModifier = Modifier.padding(24.dp)
             )
         }
+
         is NewsUiState.Loading -> item {
             NiaLoadingWheel(contentDesc = "Loading news") // TODO
         }
+
         else -> item {
             Text("Error") // TODO
         }
@@ -224,7 +226,7 @@ private fun TopicToolbar(
     ) {
         IconButton(onClick = { onBackClick() }) {
             Icon(
-                imageVector = Filled.ArrowBack,
+                imageVector = NiaIcons.ArrowBack,
                 contentDescription = stringResource(
                     id = com.google.samples.apps.nowinandroid.core.ui.R.string.back
                 )


### PR DESCRIPTION
**Changes**
1. Changed icons used to use Nia Design System defined icons.
2. Replaced `ArrowBack` from `Rounded` to `Filled` variant as `Rounded` was not used, but `Filled` was.