### PR TITLE
Update ci-gradle.properties to fix daemon disappearing issues on CI

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -16,7 +16,6 @@
 
 org.gradle.daemon=false
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx5120m
 org.gradle.workers.max=2
 
 kotlin.incremental=false


### PR DESCRIPTION
We currently have GitHub Actions CI setup to copy `ci-gradle.properties` to `~/.gradle/gradle.properties` on CI, to specify CI specific Gradle properties. Importantly, these properties take precedence over the project `gradle.properties` (as verified by `./gradlew properties`). This means that the `org.gradle.jvmargs` that we were specifying in `ci-gradle.properties` were overwriting the default project ones specified here:

https://github.com/android/nowinandroid/blob/e53bb89671937e7fb3e1cc89092092968d9861f9/gradle.properties#L12-L13

This means that we were again running into https://github.com/gradle/gradle/issues/19750 on CI only, likely the cause for the "daemon disappeared" issues from some PRs.

As a fix, I've removed the `org.gradle.jvmargs` from the `ci-gradle.properties`, to avoid overwriting and instead just use the project default ones which are already working around that issue.

We may want to take another look at what other properties we are specifying in `ci-gradle.properties`, and if we really want them. For example, `org.gradle.parallel=true` is already specified in the default project `gradle.properties`, so specifying it in `ci-gradle.properties` is technically redundant.