### PR TITLE
[Experimenting] Update GitHub action to fix API 23 build sometimes failing

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -101,7 +101,6 @@ jobs:
           disable-animations: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           sdcard-path-or-size: 100M
-          disable-animations: true
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run instrumentation tests

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -82,14 +82,14 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         
-      - name: AVD cache
-        uses: actions/cache@v3
+      # Retrieve the cached emulator snapshot.
+      - uses: actions/cache@v3
         id: avd-cache
         with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+            path: |
+                ~/.android/avd/*
+                ~/.android/adb*
+            key: ${{ runner.os }}-avd-${{ env.CACHE_VERSION }}-${{ steps.avd-info.outputs.arch }}-${{ steps.avd-info.outputs.target }}-${{ matrix.api-level }}
       
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
@@ -99,8 +99,8 @@ jobs:
           arch: ${{ matrix.arch }}
           force-avd-creation: false
           disable-animations: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          sdcard-path-or-size: 100M
+          ram-size: 4096M
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot-save
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run instrumentation tests
@@ -109,9 +109,9 @@ jobs:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
           disable-animations: true
-          disk-size: 1500M
-          heap-size: 512M
           force-avd-creation: false
+          ram-size: 4096M
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot-save
           script: ./gradlew connectedProdDebugAndroidTest -x :benchmark:connectedProdBenchmarkAndroidTest --stacktrace
 
       - name: Upload test reports

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -85,6 +85,7 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
+          first-boot-delay: 1000
           disable-animations: true
           disk-size: 1500M
           heap-size: 512M

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     timeout-minutes: 60
 
     steps:
@@ -85,7 +85,6 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
-          first-boot-delay: 1000
           disable-animations: true
           disk-size: 1500M
           heap-size: 512M

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:
@@ -59,11 +59,13 @@ jobs:
 
   androidTest:
     needs: build
-    runs-on: macOS-latest # enables hardware acceleration in the virtual machine
+    runs-on: macos-latest # enables hardware acceleration in the virtual machine
     timeout-minutes: 45
     strategy:
       matrix:
         api-level: [23, 26, 30]
+        arch: [x86_64]
+        first-boot-delay: [1000]
 
     steps:
       - name: Checkout

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -97,7 +97,6 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
 

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -81,6 +81,25 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+        
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+      
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
 
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -65,7 +65,7 @@ jobs:
       matrix:
         api-level: [23, 26, 30]
         arch: [x86_64]
-        first-boot-delay: [1000]
+        first-boot-delay: [600]
 
     steps:
       - name: Checkout
@@ -96,8 +96,12 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          arch: ${{ matrix.arch }}
           force-avd-creation: false
           disable-animations: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          sdcard-path-or-size: 100M
+          disable-animations: true
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run instrumentation tests
@@ -108,6 +112,7 @@ jobs:
           disable-animations: true
           disk-size: 1500M
           heap-size: 512M
+          force-avd-creation: false
           script: ./gradlew connectedProdDebugAndroidTest -x :benchmark:connectedProdBenchmarkAndroidTest --stacktrace
 
       - name: Upload test reports


### PR DESCRIPTION
Attempt to fix a common build fail on emulators running API 23

```
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':feature-topic:connectedProdDebugAndroidTest'.
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.lambda$executeIfValid$1(ExecuteActionsTaskExecuter.java:147)
	at org.gradle.internal.Try$Failure.ifSuccessfulOrElse(Try.java:282)
```