### PR TITLE
Introduce Gradle Managed Devices + Automated Test Device

### DIFF
--- a/.github/workflows/AndroidCIWithGmd.yml
+++ b/.github/workflows/AndroidCIWithGmd.yml
@@ -1,0 +1,25 @@
+name: Android CI with GMD
+
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+
+  android-ci:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+    - uses: actions/checkout@v2
+
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v2
+
+    - name: Run instrumented tests with GMD
+      run: ./gradlew pixel4Api30DemoDebugAndroidTest  -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect"
+


### PR DESCRIPTION
- Update the AGP to 7.3.0-beta05 because it's needed for GMD
- Introduce GMD + ATD for a single module at first (core-database)

By running "./gradlew pixel4Api30DebugAndroidTest", the instrumented
tests of core-database are executed using the device configurations
specified in the build script.