### PR TITLE
Fix : class name Typo

### DIFF
--- a/docs/ModularizationLearningJourney.md
+++ b/docs/ModularizationLearningJourney.md
@@ -183,7 +183,7 @@ Using the above modularization strategy, the Now in Android app has the followin
    </td>
    <td>Making network requests and handling responses from a remote data source.
    </td>
-   <td><code>RetrofitNiANetworkApi</code>
+   <td><code>RetrofitNiaNetworkApi</code>
    </td>
   </tr>
   <tr>
@@ -209,7 +209,7 @@ Using the above modularization strategy, the Now in Android app has the followin
    </td>
    <td>Local database storage using Room.
    </td>
-   <td><code>NiADatabase</code><br>
+   <td><code>NiaDatabase</code><br>
    <code>DatabaseMigrations</code><br>
    <code>Dao</code> classes
    </td>


### PR DESCRIPTION
[docs/ModularizationLearningJourney.md](https://github.com/android/nowinandroid/compare/main...wswon:nowinandroid:fix-typo?expand=1#diff-20fea451f034320617feaf7fba5cb8bcc4e152f97c1fdb4366ceb890883763ef) 
While reading the document, I found a typo in the class name.