### PR TITLE
Add timber for debugging

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -127,6 +127,9 @@ dependencies {
     kapt(libs.hilt.compiler)
     kaptAndroidTest(libs.hilt.compiler)
 
+    //Timber
+    implementation("com.jakewharton.timber:timber:5.0.1")
+
     // androidx.test is forcing JUnit, 4.12. This forces it to use 4.13
     configurations.configureEach {
         resolutionStrategy {

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/NiaApplication.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/NiaApplication.kt
@@ -22,6 +22,7 @@ import coil.ImageLoaderFactory
 import coil.decode.SvgDecoder
 import com.google.samples.apps.nowinandroid.sync.initializers.Sync
 import dagger.hilt.android.HiltAndroidApp
+import timber.log.Timber
 
 /**
  * [Application] class for NiA
@@ -32,6 +33,9 @@ class NiaApplication : Application(), ImageLoaderFactory {
         super.onCreate()
         // Initialize Sync; the system responsible for keeping data in the app up to date.
         Sync.initialize(context = this)
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
     }
 
     /**

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/di/JankStatsModule.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/di/JankStatsModule.kt
@@ -17,7 +17,6 @@
 package com.google.samples.apps.nowinandroid.di
 
 import android.app.Activity
-import android.util.Log
 import android.view.Window
 import androidx.metrics.performance.JankStats
 import dagger.Module
@@ -27,6 +26,7 @@ import dagger.hilt.android.components.ActivityComponent
 import java.util.concurrent.Executor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asExecutor
+import timber.log.Timber
 
 @Module
 @InstallIn(ActivityComponent::class)
@@ -37,7 +37,7 @@ object JankStatsModule {
             // Make sure to only log janky frames.
             if (frameData.isJank) {
                 // We're currently logging this but would better report it to a backend.
-                Log.v("NiA Jank", frameData.toString())
+                Timber.v(frameData.toString())
             }
         }
     }


### PR DESCRIPTION
I am new to Android and still learning. I went through the complete app and the code looks very interesting. Thanks to the Google team for building such an amazing and helpful app.

I thought of adding Timber for debugging as it really eases the process of logging by avoiding necessarily adding TAG. Not sure if it is a part of AndroidX library. 
I remember learning to to use Timber instead of Logs from my classes at Udacity (where most of educators were from Google) so I think it might be a good add to the project. Thanks!