### PR TITLE
Fix dark mode system icon colors

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -16,7 +16,7 @@
 -->
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="NightAdjusted.Theme" parent="android:Theme.Material.NoActionBar">
+    <style name="NightAdjusted.Theme.Nia" parent="android:Theme.Material.NoActionBar">
         <item name="android:windowLightStatusBar" tools:targetApi="23">false</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="27">false</item>
     </style>


### PR DESCRIPTION
Fixes #232 

The `values-night` `NightAdjusted.Theme` didn't match the intended `NightAdjusted.Theme.Nia` that was defined in `values`, meaning that it wasn't actually overriding the theme in dark mode, as intended. This resulted in the icons in the system bar being the wrong color in dark mode.