### PR TITLE
Remove redundant configuration in AndroidLibraryComposeConventionPlugin

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
@@ -23,7 +23,6 @@ import org.gradle.kotlin.dsl.getByType
 class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            pluginManager.apply("com.android.library")
             val extension = extensions.getByType<LibraryExtension>()
             configureAndroidCompose(extension)
         }


### PR DESCRIPTION
Related to https://github.com/android/nowinandroid/issues/234