### PR TITLE
changed newUiState to newsUiState in AuthorViewModel.kt to avoid conf…

### DIFF
--- a/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorScreen.kt
+++ b/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorScreen.kt
@@ -69,7 +69,7 @@ fun AuthorRoute(
     viewModel: AuthorViewModel = hiltViewModel(),
 ) {
     val authorUiState: AuthorUiState by viewModel.authorUiState.collectAsStateWithLifecycle()
-    val newsUiState: NewsUiState by viewModel.newUiState.collectAsStateWithLifecycle()
+    val newsUiState: NewsUiState by viewModel.newsUiState.collectAsStateWithLifecycle()
 
     AuthorScreen(
         authorUiState = authorUiState,

--- a/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorViewModel.kt
+++ b/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorViewModel.kt
@@ -62,7 +62,7 @@ class AuthorViewModel @Inject constructor(
             initialValue = AuthorUiState.Loading
         )
 
-    val newUiState: StateFlow<NewsUiState> = newsUiStateStream(
+    val newsUiState: StateFlow<NewsUiState> = newsUiStateStream(
         authorId = authorId,
         userDataRepository = userDataRepository,
         newsRepository = newsRepository

--- a/feature/author/src/test/java/com/google/samples/apps/nowinandroid/feature/author/AuthorViewModelTest.kt
+++ b/feature/author/src/test/java/com/google/samples/apps/nowinandroid/feature/author/AuthorViewModelTest.kt
@@ -91,7 +91,7 @@ class AuthorViewModelTest {
 
     @Test
     fun uiStateNews_whenInitialized_thenShowLoading() = runTest {
-        assertEquals(NewsUiState.Loading, viewModel.newUiState.value)
+        assertEquals(NewsUiState.Loading, viewModel.newsUiState.value)
     }
 
     @Test
@@ -115,7 +115,7 @@ class AuthorViewModelTest {
             val collectJob = launch(UnconfinedTestDispatcher()) {
                 combine(
                     viewModel.authorUiState,
-                    viewModel.newUiState,
+                    viewModel.newsUiState,
                     ::Pair
                 ).collect()
             }
@@ -123,7 +123,7 @@ class AuthorViewModelTest {
             authorsRepository.sendAuthors(testInputAuthors.map { it.author })
             userDataRepository.setFollowedAuthorIds(setOf(testInputAuthors[1].author.id))
             val authorState = viewModel.authorUiState.value
-            val newsUiState = viewModel.newUiState.value
+            val newsUiState = viewModel.newsUiState.value
 
             assertTrue(authorState is AuthorUiState.Success)
             assertTrue(newsUiState is NewsUiState.Loading)
@@ -137,7 +137,7 @@ class AuthorViewModelTest {
             val collectJob = launch(UnconfinedTestDispatcher()) {
                 combine(
                     viewModel.authorUiState,
-                    viewModel.newUiState,
+                    viewModel.newsUiState,
                     ::Pair
                 ).collect()
             }
@@ -146,7 +146,7 @@ class AuthorViewModelTest {
             userDataRepository.setFollowedAuthorIds(setOf(testInputAuthors[1].author.id))
             newsRepository.sendNewsResources(sampleNewsResources)
             val authorState = viewModel.authorUiState.value
-            val newsUiState = viewModel.newUiState.value
+            val newsUiState = viewModel.newsUiState.value
 
             assertTrue(authorState is AuthorUiState.Success)
             assertTrue(newsUiState is NewsUiState.Success)
@@ -174,7 +174,7 @@ class AuthorViewModelTest {
 
     @Test
     fun uiStateAuthor_whenNewsBookmarked_thenShowBookmarkedNews() = runTest {
-        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.newUiState.collect() }
+        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.newsUiState.collect() }
 
         authorsRepository.sendAuthors(testInputAuthors.map { it.author })
         newsRepository.sendNewsResources(sampleNewsResources)
@@ -191,7 +191,7 @@ class AuthorViewModelTest {
         )
 
         assertTrue(
-            (viewModel.newUiState.value as NewsUiState.Success)
+            (viewModel.newsUiState.value as NewsUiState.Success)
                 .news
                 .first { it.newsResource.id == sampleNewsResources.first().id }
                 .isSaved


### PR DESCRIPTION
The name of UI state holding newsUIStateStream was misspelled as newUIState this creating confusion. Changed newUiState to newsUiState in AuthorViewModel.kt to avoid confusion.