### PR TITLE
Remove Search from top app bar

### DIFF
--- a/core/designsystem/src/main/java/com/google/samples/apps/nowinandroid/core/designsystem/component/TopAppBar.kt
+++ b/core/designsystem/src/main/java/com/google/samples/apps/nowinandroid/core/designsystem/component/TopAppBar.kt
@@ -70,6 +70,34 @@ fun NiaTopAppBar(
     )
 }
 
+/**
+ * Top app bar with action, displayed on the right
+ */
+@Composable
+fun NiaTopAppBar(
+    @StringRes titleRes: Int,
+    actionIcon: ImageVector,
+    actionIconContentDescription: String?,
+    modifier: Modifier = Modifier,
+    colors: TopAppBarColors = TopAppBarDefaults.centerAlignedTopAppBarColors(),
+    onActionClick: () -> Unit = {}
+) {
+    CenterAlignedTopAppBar(
+        title = { Text(text = stringResource(id = titleRes)) },
+        actions = {
+            IconButton(onClick = onActionClick) {
+                Icon(
+                    imageVector = actionIcon,
+                    contentDescription = actionIconContentDescription,
+                    tint = MaterialTheme.colorScheme.onSurface
+                )
+            }
+        },
+        colors = colors,
+        modifier = modifier
+    )
+}
+
 @Preview("Top App Bar")
 @Composable
 fun NiaTopAppBarPreview() {

--- a/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreen.kt
+++ b/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreen.kt
@@ -77,10 +77,6 @@ fun BookmarksScreen(
             topBar = {
                 NiaTopAppBar(
                     titleRes = R.string.top_app_bar_title_saved,
-                    navigationIcon = NiaIcons.Search,
-                    navigationIconContentDescription = stringResource(
-                        id = R.string.top_app_bar_action_search
-                    ),
                     actionIcon = NiaIcons.AccountCircle,
                     actionIconContentDescription = stringResource(
                         id = R.string.top_app_bar_action_menu

--- a/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -132,10 +132,6 @@ fun ForYouScreen(
             topBar = {
                 NiaTopAppBar(
                     titleRes = R.string.top_app_bar_title,
-                    navigationIcon = NiaIcons.Search,
-                    navigationIconContentDescription = stringResource(
-                        id = R.string.for_you_top_app_bar_action_search
-                    ),
                     actionIcon = NiaIcons.AccountCircle,
                     actionIconContentDescription = stringResource(
                         id = R.string.for_you_top_app_bar_action_my_account

--- a/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsScreen.kt
+++ b/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsScreen.kt
@@ -96,10 +96,6 @@ fun InterestsScreen(
 
         NiaTopAppBar(
             titleRes = R.string.interests,
-            navigationIcon = NiaIcons.Search,
-            navigationIconContentDescription = stringResource(
-                id = R.string.interests_top_app_bar_action_seearch
-            ),
             actionIcon = NiaIcons.MoreVert,
             actionIconContentDescription = stringResource(
                 id = R.string.interests_top_app_bar_action_menu


### PR DESCRIPTION
We can reintroduce the search icon on the top app bar when we implement the functionality.