### PR TITLE
Change user data fields to use maps instead of lists.

### DIFF
--- a/core/datastore/src/main/java/com/google/samples/apps/nowinandroid/core/datastore/ListToMapMigration.kt
+++ b/core/datastore/src/main/java/com/google/samples/apps/nowinandroid/core/datastore/ListToMapMigration.kt
@@ -19,32 +19,40 @@ package com.google.samples.apps.nowinandroid.core.datastore
 import androidx.datastore.core.DataMigration
 
 /**
- * Migrates saved ids from [Int] to [String] types
+ * Migrates from using lists to maps for user data.
  */
-object IntToStringIdsMigration : DataMigration<UserPreferences> {
+object ListToMapMigration : DataMigration<UserPreferences> {
 
     override suspend fun cleanUp() = Unit
 
     override suspend fun migrate(currentData: UserPreferences): UserPreferences =
         currentData.copy {
-            // Migrate topic ids
-            deprecatedFollowedTopicIds.clear()
-            deprecatedFollowedTopicIds.addAll(
-                currentData.deprecatedIntFollowedTopicIdsList.map(Int::toString)
+            // Migrate topic id lists
+            followedTopicIds.clear()
+            followedTopicIds.putAll(
+                currentData.deprecatedFollowedTopicIdsList.associateWith { true }
             )
-            deprecatedIntFollowedTopicIds.clear()
+            deprecatedFollowedTopicIds.clear()
 
             // Migrate author ids
-            deprecatedFollowedAuthorIds.clear()
-            deprecatedFollowedAuthorIds.addAll(
-                currentData.deprecatedIntFollowedAuthorIdsList.map(Int::toString)
+            followedAuthorIds.clear()
+            followedAuthorIds.putAll(
+                currentData.deprecatedFollowedAuthorIdsList.associateWith { true }
             )
-            deprecatedIntFollowedAuthorIds.clear()
+            deprecatedFollowedAuthorIds.clear()
+
+            // Migrate bookmarks
+            bookmarkedNewsResourceIds.clear()
+            bookmarkedNewsResourceIds.putAll(
+                currentData.deprecatedBookmarkedNewsResourceIdsList.associateWith { true }
+            )
+            deprecatedBookmarkedNewsResourceIds.clear()
 
             // Mark migration as complete
-            hasDoneIntToStringIdMigration = true
+            hasDoneListToMapMigration = true
         }
 
-    override suspend fun shouldMigrate(currentData: UserPreferences): Boolean =
-        !currentData.hasDoneIntToStringIdMigration
+    override suspend fun shouldMigrate(currentData: UserPreferences): Boolean {
+        return !currentData.hasDoneListToMapMigration
+    }
 }

--- a/core/datastore/src/main/proto/com/google/samples/apps/nowinandroid/data/user_preferences.proto
+++ b/core/datastore/src/main/proto/com/google/samples/apps/nowinandroid/data/user_preferences.proto
@@ -28,7 +28,14 @@ message UserPreferences {
     int32 newsResourceChangeListVersion = 6;
     repeated int32 deprecated_int_followed_author_ids = 7;
     bool has_done_int_to_string_id_migration = 8;
-    repeated string followed_topic_ids = 9;
-    repeated string followed_author_ids = 10;
-    repeated string bookmarked_news_resource_ids = 11;
+    repeated string deprecated_followed_topic_ids = 9;
+    repeated string deprecated_followed_author_ids = 10;
+    repeated string deprecated_bookmarked_news_resource_ids = 11;
+    bool has_done_list_to_map_migration = 12;
+
+    // Each map is used to store a set of string IDs. The bool has no meaning, but proto3 doesn't
+    // have a Set type so this is the closest we can get to a Set.
+    map<string, bool> followed_topic_ids = 13;
+    map<string, bool> followed_author_ids = 14;
+    map<string, bool> bookmarked_news_resource_ids = 15;
 }

--- a/core/datastore/src/test/java/com/google/samples/apps/nowinandroid/core/datastore/IntToStringIdsMigrationTest.kt
+++ b/core/datastore/src/test/java/com/google/samples/apps/nowinandroid/core/datastore/IntToStringIdsMigrationTest.kt
@@ -35,7 +35,7 @@ class IntToStringIdsMigrationTest {
         // Assert that there are no string topic ids yet
         assertEquals(
             emptyList<String>(),
-            preMigrationUserPreferences.followedTopicIdsList
+            preMigrationUserPreferences.deprecatedFollowedTopicIdsList
         )
 
         // Run the migration
@@ -45,7 +45,7 @@ class IntToStringIdsMigrationTest {
         // Assert the deprecated int topic ids have been migrated to the string topic ids
         assertEquals(
             userPreferences {
-                followedTopicIds.addAll(listOf("1", "2", "3"))
+                deprecatedFollowedTopicIds.addAll(listOf("1", "2", "3"))
                 hasDoneIntToStringIdMigration = true
             },
             postMigrationUserPreferences
@@ -64,7 +64,7 @@ class IntToStringIdsMigrationTest {
         // Assert that there are no string author ids yet
         assertEquals(
             emptyList<String>(),
-            preMigrationUserPreferences.followedAuthorIdsList
+            preMigrationUserPreferences.deprecatedFollowedAuthorIdsList
         )
 
         // Run the migration
@@ -74,7 +74,7 @@ class IntToStringIdsMigrationTest {
         // Assert the deprecated int author ids have been migrated to the string author ids
         assertEquals(
             userPreferences {
-                followedAuthorIds.addAll(listOf("4", "5", "6"))
+                deprecatedFollowedAuthorIds.addAll(listOf("4", "5", "6"))
                 hasDoneIntToStringIdMigration = true
             },
             postMigrationUserPreferences

--- a/core/datastore/src/test/java/com/google/samples/apps/nowinandroid/core/datastore/ListToMapMigrationTest.kt
+++ b/core/datastore/src/test/java/com/google/samples/apps/nowinandroid/core/datastore/ListToMapMigrationTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid.core.datastore
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+
+class ListToMapMigrationTest {
+
+    @Test
+    fun ListToMapMigration_should_migrate_topic_ids() = runTest {
+        // Set up existing preferences with topic ids
+        val preMigrationUserPreferences = userPreferences {
+            deprecatedFollowedTopicIds.addAll(listOf("1", "2", "3"))
+        }
+        // Assert that there are no topic ids in the map yet
+        Assert.assertEquals(
+            emptyMap<String, Boolean>(),
+            preMigrationUserPreferences.followedTopicIdsMap
+        )
+
+        // Run the migration
+        val postMigrationUserPreferences =
+            ListToMapMigration.migrate(preMigrationUserPreferences)
+
+        // Assert the deprecated topic ids have been migrated to the topic ids map
+        Assert.assertEquals(
+            mapOf("1" to true, "2" to true, "3" to true),
+            postMigrationUserPreferences.followedTopicIdsMap
+        )
+
+        // Assert that the migration has been marked complete
+        Assert.assertTrue(postMigrationUserPreferences.hasDoneListToMapMigration)
+    }
+
+    @Test
+    fun ListToMapMigration_should_migrate_author_ids() = runTest {
+        // Set up existing preferences with author ids
+        val preMigrationUserPreferences = userPreferences {
+            deprecatedFollowedAuthorIds.addAll(listOf("4", "5", "6"))
+        }
+        // Assert that there are no author ids in the map yet
+        Assert.assertEquals(
+            emptyMap<String, Boolean>(),
+            preMigrationUserPreferences.followedAuthorIdsMap
+        )
+
+        // Run the migration
+        val postMigrationUserPreferences =
+            ListToMapMigration.migrate(preMigrationUserPreferences)
+
+        // Assert the deprecated author ids have been migrated to the author ids map
+        Assert.assertEquals(
+            mapOf("4" to true, "5" to true, "6" to true),
+            postMigrationUserPreferences.followedAuthorIdsMap
+        )
+
+        // Assert that the migration has been marked complete
+        Assert.assertTrue(postMigrationUserPreferences.hasDoneListToMapMigration)
+    }
+
+    @Test
+    fun ListToMapMigration_should_migrate_bookmarks() = runTest {
+        // Set up existing preferences with bookmarks
+        val preMigrationUserPreferences = userPreferences {
+            deprecatedBookmarkedNewsResourceIds.addAll(listOf("7", "8", "9"))
+        }
+        // Assert that there are no bookmarks in the map yet
+        Assert.assertEquals(
+            emptyMap<String, Boolean>(),
+            preMigrationUserPreferences.bookmarkedNewsResourceIdsMap
+        )
+
+        // Run the migration
+        val postMigrationUserPreferences =
+            ListToMapMigration.migrate(preMigrationUserPreferences)
+
+        // Assert the deprecated bookmarks have been migrated to the bookmarks map
+        Assert.assertEquals(
+            mapOf("7" to true, "8" to true, "9" to true),
+            postMigrationUserPreferences.bookmarkedNewsResourceIdsMap
+        )
+
+        // Assert that the migration has been marked complete
+        Assert.assertTrue(postMigrationUserPreferences.hasDoneListToMapMigration)
+    }
+}

--- a/core/datastore/src/test/java/com/google/samples/apps/nowinandroid/core/datastore/UserPreferencesSerializerTest.kt
+++ b/core/datastore/src/test/java/com/google/samples/apps/nowinandroid/core/datastore/UserPreferencesSerializerTest.kt
@@ -39,8 +39,8 @@ class UserPreferencesSerializerTest {
     @Test
     fun writingAndReadingUserPreferences_outputsCorrectValue() = runTest {
         val expectedUserPreferences = userPreferences {
-            followedTopicIds.add("0")
-            followedTopicIds.add("1")
+            followedTopicIds.put("0", true)
+            followedTopicIds.put("1", true)
         }
 
         val outputStream = ByteArrayOutputStream()


### PR DESCRIPTION
When adding a single bookmark, the previous implementation of `NiaPreferencesDataSource` would read the whole list of bookmarks from user preferences, modify it, then write it back. 

This PR changes the proto data type for user data from `repeated string` (a list) to `map<string,bool>` which allows the reading and writing of single values. 

The benefits of this are: 

- it's more efficient
- it makes the read/write code easier to understand, negating the need for the `setList` and `editList` extension functions, which I found quite difficult to parse

The downsides are: 

- There is redundancy in the map with all values being set to `true`. I wanted a set but proto3 doesn't have a set type so this is the closest I could get. 

Comments/feedback welcome. 
