### PR TITLE
Opt in to experimental kotlinx.serialization API locally

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
@@ -57,8 +57,6 @@ internal fun Project.configureKotlinAndroid(
                 "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
                 "-opt-in=kotlinx.coroutines.FlowPreview",
                 "-opt-in=kotlin.Experimental",
-                // Enable experimental kotlinx serialization APIs
-                "-opt-in=kotlinx.serialization.ExperimentalSerializationApi"
             )
 
             // Set JVM target to 1.8

--- a/core/network/src/main/java/com/google/samples/apps/nowinandroid/core/network/retrofit/RetrofitNiaNetwork.kt
+++ b/core/network/src/main/java/com/google/samples/apps/nowinandroid/core/network/retrofit/RetrofitNiaNetwork.kt
@@ -25,6 +25,7 @@ import com.google.samples.apps.nowinandroid.core.network.model.NetworkTopic
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
@@ -99,7 +100,10 @@ class RetrofitNiaNetwork @Inject constructor(
                 )
                 .build()
         )
-        .addConverterFactory(networkJson.asConverterFactory("application/json".toMediaType()))
+        .addConverterFactory(
+            @OptIn(ExperimentalSerializationApi::class)
+            networkJson.asConverterFactory("application/json".toMediaType())
+        )
         .build()
         .create(RetrofitNiaNetworkApi::class.java)
 


### PR DESCRIPTION
Opt in to using the experimental `asConverterFactory` function locally instead of enabling experimental APIs module-wide