### PR TITLE
Remove the AndroidX snapshot repo from the list of repositories

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,15 +26,6 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        // Register the AndroidX snapshot repository first so snapshots don't attempt (and fail)
-        // to download from the non-snapshot repositories
-        maven(url = "https://androidx.dev/snapshots/builds/9042167/artifacts/repository") {
-            content {
-                // The AndroidX snapshot repository will only have androidx artifacts, don't
-                // bother trying to find other ones
-                includeGroupByRegex("androidx\\..*")
-            }
-        }
         google()
         mavenCentral()
     }


### PR DESCRIPTION
This repo is currently unused and every dependency fetch tries to go to this repo first as it's the first in the list (even though none will be found here) which adds several seconds to build times