### PR TITLE
Add convention plugin for Git hooks setup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
     id("nowinandroid.android.hilt")
     id("jacoco")
     id("nowinandroid.firebase-perf")
+    id("nowinandroid.git-hooks")
 }
 
 android {

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -72,5 +72,9 @@ gradlePlugin {
             id = "nowinandroid.firebase-perf"
             implementationClass = "FirebasePerfConventionPlugin"
         }
+        register("gitHooks") {
+            id = "nowinandroid.git-hooks"
+            implementationClass = "GitHooksConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/GitHooksConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GitHooksConventionPlugin.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *  
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class GitHooksConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            tasks.register("setupGitHooks") {
+                val prePushHook = file(".git/hooks/pre-push")
+                val commitMsgHook = file(".git/hooks/commit-msg")
+                val hooksInstalled = commitMsgHook.exists()
+                    && prePushHook.exists()
+                    && prePushHook.readBytes().contentEquals(file("tools/pre-push").readBytes())
+
+                if (!hooksInstalled) {
+                    exec {
+                        commandLine("tools/setup.sh")
+                        workingDir = rootProject.projectDir
+                    }
+                }
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -54,17 +54,3 @@ include(":feature:topic")
 include(":lint")
 include(":sync:work")
 include(":sync:sync-test")
-
-
-val prePushHook = file(".git/hooks/pre-push")
-val commitMsgHook = file(".git/hooks/commit-msg")
-val hooksInstalled = commitMsgHook.exists()
-    && prePushHook.exists()
-    && prePushHook.readBytes().contentEquals(file("tools/pre-push").readBytes())
-
-if (!hooksInstalled) {
-    exec {
-        commandLine("tools/setup.sh")
-        workingDir = rootProject.projectDir
-    }
-}


### PR DESCRIPTION
Closes #315.

As @alexvanyo suggested:
> I think we recently added running `tools/setup.sh` automatically as part of syncing, which shouldn't be necessary for just cloning and running the project.
> 
> We should probably run it instead inside a Gradle task that can be invoked manually if desired?

I have created the `GitHooksConventionPlugin` that registers a task named `setupGitHooks`. The task does the same as before.