### PR TITLE
Migrate packages to namespaces in build files

### DIFF
--- a/app-nia-catalog/build.gradle.kts
+++ b/app-nia-catalog/build.gradle.kts
@@ -32,6 +32,7 @@ android {
             excludes.add("/META-INF/{AL2.0,LGPL2.1}")
         }
     }
+    namespace = "com.google.samples.apps.niacatalog"
 }
 
 dependencies {

--- a/app-nia-catalog/src/main/AndroidManifest.xml
+++ b/app-nia-catalog/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.niacatalog">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import com.google.samples.apps.nowinandroid.Flavor
-import com.google.samples.apps.nowinandroid.FlavorDimension
 
 plugins {
     id("nowinandroid.android.application")
@@ -75,6 +73,7 @@ android {
             isIncludeAndroidResources = true
         }
     }
+    namespace = "com.google.samples.apps.nowinandroid"
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
      limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.google.samples.apps.nowinandroid">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -19,6 +19,10 @@ plugins {
     id("nowinandroid.android.hilt")
 }
 
+android {
+    namespace = "com.google.samples.apps.nowinandroid.core.common"
+}
+
 dependencies {
     implementation(libs.kotlinx.coroutines.android)
     testImplementation(project(":core:testing"))

--- a/core/common/src/main/AndroidManifest.xml
+++ b/core/common/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.core.common">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/core/data-test/build.gradle.kts
+++ b/core/data-test/build.gradle.kts
@@ -18,6 +18,10 @@ plugins {
     id("nowinandroid.android.hilt")
 }
 
+android {
+    namespace = "com.google.samples.apps.nowinandroid.core.data.test"
+}
+
 dependencies {
     api(project(":core:data"))
     implementation(project(":core:testing"))

--- a/core/data-test/src/main/AndroidManifest.xml
+++ b/core/data-test/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.core.data.test">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -20,6 +20,10 @@ plugins {
     id("kotlinx-serialization")
 }
 
+android {
+    namespace = "com.google.samples.apps.nowinandroid.core.data"
+}
+
 dependencies {
     implementation(project(":core:common"))
     implementation(project(":core:model"))

--- a/core/data/src/main/AndroidManifest.xml
+++ b/core/data/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.core.data">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -33,6 +33,7 @@ android {
 
         testInstrumentationRunner = "com.google.samples.apps.nowinandroid.core.testing.NiaTestRunner"
     }
+    namespace = "com.google.samples.apps.nowinandroid.core.database"
 }
 
 dependencies {

--- a/core/database/src/main/AndroidManifest.xml
+++ b/core/database/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.core.database">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/core/datastore-test/build.gradle.kts
+++ b/core/datastore-test/build.gradle.kts
@@ -18,6 +18,10 @@ plugins {
     id("nowinandroid.android.hilt")
 }
 
+android {
+    namespace = "com.google.samples.apps.nowinandroid.core.datastore.test"
+}
+
 dependencies {
     api(project(":core:datastore"))
     implementation(project(":core:testing"))

--- a/core/datastore-test/src/main/AndroidManifest.xml
+++ b/core/datastore-test/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.core.datastore.test">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -32,6 +32,7 @@ android {
     defaultConfig {
         consumerProguardFiles("consumer-proguard-rules.pro")
     }
+    namespace = "com.google.samples.apps.nowinandroid.core.datastore"
 }
 
 // Setup protobuf configuration, generating lite Java and Kotlin classes

--- a/core/datastore/src/main/AndroidManifest.xml
+++ b/core/datastore/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.core.datastore">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -26,6 +26,7 @@ android {
     lint {
         checkDependencies = true
     }
+    namespace = "com.google.samples.apps.nowinandroid.core.designsystem"
 }
 
 dependencies {

--- a/core/designsystem/src/main/AndroidManifest.xml
+++ b/core/designsystem/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.core.designsystem">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -21,6 +21,10 @@ plugins {
     id("nowinandroid.android.hilt")
 }
 
+android {
+    namespace = "com.google.samples.apps.nowinandroid.core.navigation"
+}
+
 dependencies {
     api(libs.androidx.hilt.navigation.compose)
     api(libs.androidx.navigation.compose)

--- a/core/navigation/src/main/AndroidManifest.xml
+++ b/core/navigation/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.core.navigation">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -26,6 +26,7 @@ android {
     buildFeatures {
         buildConfig = true
     }
+    namespace = "com.google.samples.apps.nowinandroid.core.network"
 }
 
 secrets {

--- a/core/network/src/main/AndroidManifest.xml
+++ b/core/network/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.core.network">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
 
 </manifest>

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -18,6 +18,10 @@ plugins {
     id("nowinandroid.android.hilt")
 }
 
+android {
+    namespace = "com.google.samples.apps.nowinandroid.core.testing"
+}
+
 dependencies {
     implementation(project(":core:common"))
     implementation(project(":core:data"))

--- a/core/testing/src/main/AndroidManifest.xml
+++ b/core/testing/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.core.testing">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -19,6 +19,10 @@ plugins {
     id("nowinandroid.android.library.jacoco")
 }
 
+android {
+    namespace = "com.google.samples.apps.nowinandroid.core.ui"
+}
+
 dependencies {
     implementation(project(":core:designsystem"))
     implementation(project(":core:model"))

--- a/core/ui/src/main/AndroidManifest.xml
+++ b/core/ui/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.core.ui">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/feature/author/build.gradle.kts
+++ b/feature/author/build.gradle.kts
@@ -19,6 +19,10 @@ plugins {
     id("nowinandroid.android.library.jacoco")
 }
 
+android {
+    namespace = "com.google.samples.apps.nowinandroid.feature.author"
+}
+
 dependencies {
     implementation(libs.kotlinx.datetime)
 }

--- a/feature/author/src/main/AndroidManifest.xml
+++ b/feature/author/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.feature.author">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/feature/bookmarks/build.gradle.kts
+++ b/feature/bookmarks/build.gradle.kts
@@ -19,6 +19,10 @@ plugins {
     id("nowinandroid.android.library.jacoco")
 }
 
+android {
+    namespace = "com.google.samples.apps.nowinandroid.feature.bookmarks"
+}
+
 dependencies {
     implementation(libs.androidx.compose.material3.windowSizeClass)
 }

--- a/feature/bookmarks/src/main/AndroidManifest.xml
+++ b/feature/bookmarks/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.feature.bookmarks">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/feature/foryou/build.gradle.kts
+++ b/feature/foryou/build.gradle.kts
@@ -19,6 +19,10 @@ plugins {
     id("nowinandroid.android.library.jacoco")
 }
 
+android {
+    namespace = "com.google.samples.apps.nowinandroid.feature.foryou"
+}
+
 dependencies {
     implementation(libs.kotlinx.datetime)
 

--- a/feature/foryou/src/main/AndroidManifest.xml
+++ b/feature/foryou/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.feature.foryou">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/feature/interests/build.gradle.kts
+++ b/feature/interests/build.gradle.kts
@@ -18,3 +18,6 @@ plugins {
     id("nowinandroid.android.library.compose")
     id("nowinandroid.android.library.jacoco")
 }
+android {
+    namespace = "com.google.samples.apps.nowinandroid.feature.interests"
+}

--- a/feature/interests/src/main/AndroidManifest.xml
+++ b/feature/interests/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.feature.interests">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/feature/topic/build.gradle.kts
+++ b/feature/topic/build.gradle.kts
@@ -19,6 +19,10 @@ plugins {
     id("nowinandroid.android.library.jacoco")
 }
 
+android {
+    namespace = "com.google.samples.apps.nowinandroid.feature.topic"
+}
+
 dependencies {
     implementation(libs.kotlinx.datetime)
 }

--- a/feature/topic/src/main/AndroidManifest.xml
+++ b/feature/topic/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.feature.topic">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/sync/sync-test/build.gradle.kts
+++ b/sync/sync-test/build.gradle.kts
@@ -18,6 +18,10 @@ plugins {
     id("nowinandroid.android.hilt")
 }
 
+android {
+    namespace = "com.google.samples.apps.nowinandroid.core.sync.test"
+}
+
 dependencies {
     api(project(":sync:work"))
     implementation(project(":core:data"))

--- a/sync/sync-test/src/main/AndroidManifest.xml
+++ b/sync/sync-test/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.core.sync.test">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/sync/work/build.gradle.kts
+++ b/sync/work/build.gradle.kts
@@ -23,6 +23,7 @@ android {
     defaultConfig {
         testInstrumentationRunner = "com.google.samples.apps.nowinandroid.core.testing.NiaTestRunner"
     }
+    namespace = "com.google.samples.apps.nowinandroid.sync"
 }
 
 dependencies {

--- a/sync/work/src/main/AndroidManifest.xml
+++ b/sync/work/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
      limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.google.samples.apps.nowinandroid.sync">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application>
         <provider


### PR DESCRIPTION
Migrate packages to namespaces in build files to prepare for AGP 8 breaking changes and show best practice