### PR TITLE
adding NiaApp layout preview

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:designsystem"))
     implementation(project(":core:navigation"))
+    implementation(project(":core:model"))
 
     implementation(project(":sync:work"))
     implementation(project(":sync:sync-test"))

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -41,7 +41,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
-import androidx.compose.material3.windowsizeclass.WindowSizeClass.Companion
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -127,8 +126,7 @@ fun NiaApp(
                         )
                     }
 
-                    if(!LocalInspectionMode.current)
-                    {
+                    if (!LocalInspectionMode.current) {
                         NiaNavHost(
                             navController = appState.navController,
                             onBackClick = appState::onBackClick,
@@ -137,9 +135,7 @@ fun NiaApp(
                                 .padding(padding)
                                 .consumedWindowInsets(padding)
                         )
-                    }
-                    else
-                    {
+                    } else {
                         BoxWithConstraints {
                             NiaTheme {
                                 ForYouScreen(
@@ -242,7 +238,7 @@ private fun NiaBottomBar(
 }
 @ReferenceDevicePreviews
 @Composable
-fun NiaAppLayoutPreview(){
+fun NiaAppLayoutPreview() {
     val widthDp = Dp(LocalConfiguration.current.screenWidthDp.toFloat())
     val heightDp = Dp(LocalConfiguration.current.screenHeightDp.toFloat())
     val windowSizeClass = WindowSizeClass.calculateFromSize(DpSize(widthDp, heightDp))

--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/DevicePreviews.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/DevicePreviews.kt
@@ -19,6 +19,15 @@ package com.google.samples.apps.nowinandroid.core.ui
 import androidx.compose.ui.tooling.preview.Preview
 
 /**
+ * Multipreview annotation the maps to the Android Studio reference devices.
+ */
+@Preview(name = "1_phone", device = Devices.PHONE)
+@Preview(name = "2_foldable", device = Devices.FOLDABLE)
+@Preview(name = "3_tablet", device = Devices.TABLET)
+@Preview(name = "4_desktop", device = Devices.DESKTOP)
+annotation class ReferenceDevicePreviews
+
+/**
  * Multipreview annotation that represents various device sizes. Add this annotation to a composable
  * to render various devices.
  */

--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/ReferenceDevices.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/ReferenceDevices.kt
@@ -1,25 +1,28 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.google.samples.apps.nowinandroid.core.ui
 
+import androidx.annotation.StringDef
 import androidx.compose.ui.tooling.preview.Preview
 
-import androidx.annotation.StringDef
-
+/*
+ * TODO: Remove this file and instead use androidx.compose.ui.tooling.preview once this bug is
+ *  fixed - https://issuetracker.google.com/issues/254528382
+*/
 /**
  * List with the pre-defined devices available to be used in the preview.
  */

--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/ReferenceDevices.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/ReferenceDevices.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid.core.ui
+
+import androidx.compose.ui.tooling.preview.Preview
+
+import androidx.annotation.StringDef
+
+/**
+ * List with the pre-defined devices available to be used in the preview.
+ */
+object Devices {
+
+    // Reference devices
+    const val PHONE = "spec:shape=Normal,width=411,height=891,unit=dp,dpi=420"
+    const val FOLDABLE = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=420"
+    const val TABLET = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=420"
+    const val DESKTOP = "spec:shape=Normal,width=1920,height=1080,unit=dp,dpi=420"
+}
+
+/**
+ * Annotation for defining the [Preview] device to use.
+ * @suppress
+ */
+@Retention(AnnotationRetention.SOURCE)
+@StringDef(
+    open = true,
+    value = [
+        Devices.PHONE,
+        Devices.FOLDABLE,
+        Devices.TABLET,
+        Devices.DESKTOP,
+    ]
+)
+annotation class Device


### PR DESCRIPTION
Made it so that the NiaApp Composable shows a full layout preview that mimics the first app layout that a user will see when launching the app (the topics screen). Also added reference device multi preview that matches reference devices elsewhere in Studio (Layout Editor, Layout Validation, etc...) 