### PR TITLE
Remove unnecessary dependencies after releasing Android Studio Dolphin

### DIFF
--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -41,10 +41,4 @@ dependencies {
     api(libs.androidx.compose.runtime)
     lintPublish(project(":lint"))
     androidTestImplementation(project(":core:testing"))
-
-    // TODO : Remove these dependency once we upgrade to Android Studio Dolphin b/228889042
-    // These dependencies are currently necessary to render Compose previews
-    debugImplementation(libs.androidx.customview.poolingcontainer)
-    debugImplementation(libs.androidx.lifecycle.viewModelCompose)
-    debugImplementation(libs.androidx.savedstate.ktx)
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -33,12 +33,6 @@ dependencies {
     implementation(libs.coil.kt.compose)
     implementation(libs.kotlinx.datetime)
 
-    // TODO : Remove these dependency once we upgrade to Android Studio Dolphin b/228889042
-    // These dependencies are currently necessary to render Compose previews
-    debugImplementation(libs.androidx.customview.poolingcontainer)
-    debugImplementation(libs.androidx.lifecycle.runtimeCompose)
-    debugImplementation(libs.androidx.lifecycle.viewModelCompose)
-    debugImplementation(libs.androidx.savedstate.ktx)
 
     api(libs.androidx.compose.foundation)
     api(libs.androidx.compose.foundation.layout)


### PR DESCRIPTION
I cloned the codes today but I've got errors for rendering previews. I couldn't see any previews for ForYouScreen or other pages. I found that the problem is related to these dependencies that aren't needed in Android Studio Dolphin. I removed them and all previews shows correctly without any problem. 