### PR TITLE
Fixes #341 Defines enter & exit animations for OverlayLoadingWheel on…

### DIFF
--- a/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -18,6 +18,10 @@ package com.google.samples.apps.nowinandroid.feature.foryou
 
 import android.app.Activity
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -193,7 +197,13 @@ internal fun ForYouScreen(
     AnimatedVisibility(
         visible = isSyncing ||
             feedState is NewsFeedUiState.Loading ||
-            onboardingUiState is OnboardingUiState.Loading
+            onboardingUiState is OnboardingUiState.Loading,
+        enter = slideInVertically(
+            initialOffsetY = { fullHeight -> -fullHeight },
+        ) + fadeIn(),
+        exit = slideOutVertically(
+            targetOffsetY = { fullHeight -> -fullHeight },
+        ) + fadeOut(),
     ) {
         val loadingContentDescription = stringResource(id = R.string.for_you_loading)
         Box(


### PR DESCRIPTION
… ForYouScreen

Also added fadeOut because just animating it all the way up off the screen makes it ugly.

https://user-images.githubusercontent.com/1853043/197698785-76ff7eff-40ac-4b7a-9b2c-9b3a23f21d62.mov
