### PR TITLE
Allow InterestsItem to be skipped on recomposition

### DIFF
--- a/benchmark/src/main/java/com/google/samples/apps/nowinandroid/interests/InterestsActions.kt
+++ b/benchmark/src/main/java/com/google/samples/apps/nowinandroid/interests/InterestsActions.kt
@@ -19,6 +19,7 @@ package com.google.samples.apps.nowinandroid.interests
 import androidx.benchmark.macro.MacrobenchmarkScope
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.Direction
+import androidx.test.uiautomator.Until
 
 fun MacrobenchmarkScope.interestsScrollTopicsDownUp() {
     val topicsList = device.findObject(By.res("interests:topics"))
@@ -32,4 +33,15 @@ fun MacrobenchmarkScope.interestsScrollPeopleDownUp() {
     peopleList.fling(Direction.DOWN)
     device.waitForIdle()
     peopleList.fling(Direction.UP)
+}
+
+fun MacrobenchmarkScope.interestsWaitForTopics() {
+    device.wait(Until.hasObject(By.text("Accessibility")), 30_000)
+}
+
+fun MacrobenchmarkScope.interestsToggleBookmarked() {
+    val topicsList = device.findObject(By.res("interests:topics"))
+    val checkable = topicsList.findObject(By.checkable(true))
+    checkable.click()
+    device.waitForIdle()
 }

--- a/benchmark/src/main/java/com/google/samples/apps/nowinandroid/interests/TopicsScreenRecompositionBenchmark.kt
+++ b/benchmark/src/main/java/com/google/samples/apps/nowinandroid/interests/TopicsScreenRecompositionBenchmark.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid.interests
+
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.uiautomator.By
+import com.google.samples.apps.nowinandroid.PACKAGE_NAME
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TopicsScreenRecompositionBenchmark {
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun benchmarkStateChangeCompilationBaselineProfile() =
+        benchmarkStateChange(CompilationMode.Partial())
+
+    private fun benchmarkStateChange(compilationMode: CompilationMode) =
+        benchmarkRule.measureRepeated(
+            packageName = PACKAGE_NAME,
+            metrics = listOf(FrameTimingMetric()),
+            compilationMode = compilationMode,
+            iterations = 10,
+            startupMode = StartupMode.WARM,
+            setupBlock = {
+                // Start the app
+                pressHome()
+                startActivityAndWait()
+
+                // Navigate to interests screen
+                device.findObject(By.text("Interests")).click()
+                device.waitForIdle()
+            }
+        ) {
+            interestsWaitForTopics()
+            repeat(3) {
+                interestsToggleBookmarked()
+            }
+        }
+}

--- a/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/TabContent.kt
+++ b/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/TabContent.kt
@@ -46,14 +46,15 @@ fun TopicsTabContent(
         contentPadding = PaddingValues(top = 8.dp)
     ) {
         topics.forEach { followableTopic ->
-            item {
+            val topicId = followableTopic.topic.id
+            item(key = topicId) {
                 InterestsItem(
                     name = followableTopic.topic.name,
                     following = followableTopic.isFollowed,
                     description = followableTopic.topic.shortDescription,
                     topicImageUrl = followableTopic.topic.imageUrl,
-                    onClick = { onTopicClick(followableTopic.topic.id) },
-                    onFollowButtonClick = { onFollowButtonClick(followableTopic.topic.id, it) }
+                    onClick = { onTopicClick(topicId) },
+                    onFollowButtonClick = { onFollowButtonClick(topicId, it) }
                 )
             }
         }


### PR DESCRIPTION
Fixes #73 

<img width="290" alt="Screen Shot 2022-10-31 at 9 49 56 am" src="https://user-images.githubusercontent.com/19445/198905582-0e45786e-bdc3-4a7a-86f4-c94a3060a06a.png">

Also adds a benchmark for topics state change to ensure this optimisation actually achieved better performance. P90+ were all improved even with a slight hit to P50 which may just be noise. This deemed this simple change worth it.

```
Before Change
frameDurationCpuMs   P50   4.5,   P90  14.0,   P95  17.0,   P99  25.1
frameOverrunMs   P50  -11.4,   P90   1.9,   P95   2.9,   P99  11.2

After Change
frameDurationCpuMs   P50   5.0,   P90  12.2,   P95  15.1,   P99  18.1
frameOverrunMs   P50  -11.4,   P90  -0.1,   P95   1.1,   P99   3.6
```

### Failed experiments

**Deferring the read of topics list:**
I also tested what would happen by deferring the read of the topics list and making it an immutable list. This would allow more to be skipped higher up the chain, specifically `InterestsContent`. It lead to no gain, especially when compared with the increase in code complexity this did not seem worth it.

```
frameDurationCpuMs   P50   4.9,   P90  12.3,   P95  15.9,   P99  18.9
frameOverrunMs   P50  -11.1,   P90  -1.4,   P95   0.3,   P99   6.9
```

**Bottom Bar:**
On state change we can also see the bottom bar recomposing, this might look like an issue but fixing it via an immutable list for the top level destinations and pre-calculating the selected top destination to get the bottom bar to skip actually made a negligible difference to performance whilst greatly increasing code complexity. I deemed this change not worth it.

```
frameDurationCpuMs   P50   5.0,   P90  12.6,   P95  15.1,   P99  19.0
frameOverrunMs   P50  -11.4,   P90  -1.8,   P95   0.7,   P99   4.5
```