### PR TITLE
Refactor | Added extension functions

### DIFF
--- a/app/src/main/java/com/google/samples/apps/nowinandroid/MainActivityViewModel.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/MainActivityViewModel.kt
@@ -22,12 +22,11 @@ import com.google.samples.apps.nowinandroid.MainActivityUiState.Loading
 import com.google.samples.apps.nowinandroid.MainActivityUiState.Success
 import com.google.samples.apps.nowinandroid.core.data.repository.UserDataRepository
 import com.google.samples.apps.nowinandroid.core.model.data.UserData
+import com.google.samples.apps.nowinandroid.core.ui.stateInViewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(
@@ -35,11 +34,7 @@ class MainActivityViewModel @Inject constructor(
 ) : ViewModel() {
     val uiState: StateFlow<MainActivityUiState> = userDataRepository.userDataStream.map {
         Success(it)
-    }.stateIn(
-        scope = viewModelScope,
-        initialValue = Loading,
-        started = SharingStarted.WhileSubscribed(5_000)
-    )
+    }.stateInViewModelScope(viewModelScope, initialValue = Loading)
 }
 
 sealed interface MainActivityUiState {

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/MainActivityViewModel.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/MainActivityViewModel.kt
@@ -22,7 +22,7 @@ import com.google.samples.apps.nowinandroid.MainActivityUiState.Loading
 import com.google.samples.apps.nowinandroid.MainActivityUiState.Success
 import com.google.samples.apps.nowinandroid.core.data.repository.UserDataRepository
 import com.google.samples.apps.nowinandroid.core.model.data.UserData
-import com.google.samples.apps.nowinandroid.core.ui.stateInViewModelScope
+import com.google.samples.apps.nowinandroid.core.ui.stateInScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.StateFlow
@@ -34,7 +34,7 @@ class MainActivityViewModel @Inject constructor(
 ) : ViewModel() {
     val uiState: StateFlow<MainActivityUiState> = userDataRepository.userDataStream.map {
         Success(it)
-    }.stateInViewModelScope(viewModelScope, initialValue = Loading)
+    }.stateInScope(viewModelScope, initialValue = Loading)
 }
 
 sealed interface MainActivityUiState {

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
@@ -36,6 +36,7 @@ import androidx.navigation.navOptions
 import androidx.tracing.trace
 import com.google.samples.apps.nowinandroid.core.data.util.NetworkMonitor
 import com.google.samples.apps.nowinandroid.core.ui.TrackDisposableJank
+import com.google.samples.apps.nowinandroid.core.ui.stateInCoroutineScope
 import com.google.samples.apps.nowinandroid.feature.bookmarks.navigation.bookmarksRoute
 import com.google.samples.apps.nowinandroid.feature.bookmarks.navigation.navigateToBookmarks
 import com.google.samples.apps.nowinandroid.feature.foryou.navigation.forYouNavigationRoute
@@ -47,9 +48,7 @@ import com.google.samples.apps.nowinandroid.navigation.TopLevelDestination.BOOKM
 import com.google.samples.apps.nowinandroid.navigation.TopLevelDestination.FOR_YOU
 import com.google.samples.apps.nowinandroid.navigation.TopLevelDestination.INTERESTS
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 
 @Composable
 fun rememberNiaAppState(
@@ -95,11 +94,7 @@ class NiaAppState(
 
     val isOffline = networkMonitor.isOnline
         .map(Boolean::not)
-        .stateIn(
-            scope = coroutineScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = false
-        )
+        .stateInCoroutineScope(coroutineScope, initialValue = false)
 
     /**
      * Map of top level destinations to be used in the TopBar, BottomBar and NavRail. The key is the

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
@@ -36,7 +36,7 @@ import androidx.navigation.navOptions
 import androidx.tracing.trace
 import com.google.samples.apps.nowinandroid.core.data.util.NetworkMonitor
 import com.google.samples.apps.nowinandroid.core.ui.TrackDisposableJank
-import com.google.samples.apps.nowinandroid.core.ui.stateInCoroutineScope
+import com.google.samples.apps.nowinandroid.core.ui.stateInScope
 import com.google.samples.apps.nowinandroid.feature.bookmarks.navigation.bookmarksRoute
 import com.google.samples.apps.nowinandroid.feature.bookmarks.navigation.navigateToBookmarks
 import com.google.samples.apps.nowinandroid.feature.foryou.navigation.forYouNavigationRoute
@@ -94,7 +94,7 @@ class NiaAppState(
 
     val isOffline = networkMonitor.isOnline
         .map(Boolean::not)
-        .stateInCoroutineScope(coroutineScope, initialValue = false)
+        .stateInScope(coroutineScope, initialValue = false)
 
     /**
      * Map of top level destinations to be used in the TopBar, BottomBar and NavRail. The key is the

--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/Extenstions.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/Extenstions.kt
@@ -23,23 +23,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 
 /**
- * This is a helper extension function to make it easier to use [Flow.stateIn] within a ViewModel.
+ * This is a helper extension function for making it easier to use [Flow.stateIn] within a ViewModel or etc.
  * @Returns a [StateFlow] that shares the latest value emitted by the original [Flow] and starts
  * with the [initialValue].
  */
-fun <T> Flow<T>.stateInViewModelScope(
-    viewModelScope: CoroutineScope,
+fun <T> Flow<T>.stateInScope(
+    coroutineScope: CoroutineScope,
     started: SharingStarted = SharingStarted.WhileSubscribed(5_000),
     initialValue: T
-): StateFlow<T> = stateIn(viewModelScope, started, initialValue)
-
-/**
- * This is a helper extension function to make it easier to use [Flow.stateIn] within a [CoroutineScope].
- * @Returns a [StateFlow] that shares the latest value emitted by the original [Flow] and starts
- * with the [initialValue].
- */
-fun <T> Flow<T>.stateInCoroutineScope(
-    viewModelScope: CoroutineScope,
-    started: SharingStarted = SharingStarted.WhileSubscribed(5_000),
-    initialValue: T
-): StateFlow<T> = stateIn(viewModelScope, started, initialValue)
+): StateFlow<T> = stateIn(coroutineScope, started, initialValue)

--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/Extenstions.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/Extenstions.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid.core.ui
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * This is a helper extension function to make it easier to use [Flow.stateIn] within a ViewModel.
+ * @Returns a [StateFlow] that shares the latest value emitted by the original [Flow] and starts
+ * with the [initialValue].
+ */
+fun <T> Flow<T>.stateInViewModelScope(
+    viewModelScope: CoroutineScope,
+    started: SharingStarted = SharingStarted.WhileSubscribed(5_000),
+    initialValue: T
+): StateFlow<T> = stateIn(viewModelScope, started, initialValue)
+
+/**
+ * This is a helper extension function to make it easier to use [Flow.stateIn] within a [CoroutineScope].
+ * @Returns a [StateFlow] that shares the latest value emitted by the original [Flow] and starts
+ * with the [initialValue].
+ */
+fun <T> Flow<T>.stateInCoroutineScope(
+    viewModelScope: CoroutineScope,
+    started: SharingStarted = SharingStarted.WhileSubscribed(5_000),
+    initialValue: T
+): StateFlow<T> = stateIn(viewModelScope, started, initialValue)

--- a/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorScreen.kt
+++ b/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorScreen.kt
@@ -61,8 +61,6 @@ import com.google.samples.apps.nowinandroid.core.model.data.previewNewsResources
 import com.google.samples.apps.nowinandroid.core.ui.DevicePreviews
 import com.google.samples.apps.nowinandroid.core.ui.TrackScrollJank
 import com.google.samples.apps.nowinandroid.core.ui.newsResourceCardItems
-import com.google.samples.apps.nowinandroid.feature.author.AuthorViewModel.AuthorUiState
-import com.google.samples.apps.nowinandroid.feature.author.AuthorViewModel.NewsUiState
 
 @OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable

--- a/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorScreen.kt
+++ b/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorScreen.kt
@@ -61,6 +61,8 @@ import com.google.samples.apps.nowinandroid.core.model.data.previewNewsResources
 import com.google.samples.apps.nowinandroid.core.ui.DevicePreviews
 import com.google.samples.apps.nowinandroid.core.ui.TrackScrollJank
 import com.google.samples.apps.nowinandroid.core.ui.newsResourceCardItems
+import com.google.samples.apps.nowinandroid.feature.author.AuthorViewModel.AuthorUiState
+import com.google.samples.apps.nowinandroid.feature.author.AuthorViewModel.NewsUiState
 
 @OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable

--- a/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorViewModel.kt
+++ b/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorViewModel.kt
@@ -62,12 +62,16 @@ class AuthorViewModel @Inject constructor(
         .newsUiStateStream(authorId = authorArgs.authorId)
         .stateInScope(viewModelScope, initialValue = NewsUiState.Loading)
 
-    fun followAuthorToggle(followed: Boolean) = viewModelScope.launch {
-        userDataRepository.toggleFollowedAuthorId(authorArgs.authorId, followed)
+    fun followAuthorToggle(followed: Boolean) {
+        viewModelScope.launch {
+            userDataRepository.toggleFollowedAuthorId(authorArgs.authorId, followed)
+        }
     }
 
-    fun bookmarkNews(newsResourceId: String, bookmarked: Boolean) = viewModelScope.launch {
-        userDataRepository.updateNewsResourceBookmark(newsResourceId, bookmarked)
+    fun bookmarkNews(newsResourceId: String, bookmarked: Boolean) {
+        viewModelScope.launch {
+            userDataRepository.updateNewsResourceBookmark(newsResourceId, bookmarked)
+        }
     }
 
     private fun authorUiStateStream(

--- a/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorViewModel.kt
+++ b/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorViewModel.kt
@@ -34,12 +34,12 @@ import com.google.samples.apps.nowinandroid.core.result.asResult
 import com.google.samples.apps.nowinandroid.core.ui.stateInViewModelScope
 import com.google.samples.apps.nowinandroid.feature.author.navigation.AuthorArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @HiltViewModel
 class AuthorViewModel @Inject constructor(

--- a/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorViewModel.kt
+++ b/feature/author/src/main/java/com/google/samples/apps/nowinandroid/feature/author/AuthorViewModel.kt
@@ -31,7 +31,7 @@ import com.google.samples.apps.nowinandroid.core.result.Result.Error
 import com.google.samples.apps.nowinandroid.core.result.Result.Loading
 import com.google.samples.apps.nowinandroid.core.result.Result.Success
 import com.google.samples.apps.nowinandroid.core.result.asResult
-import com.google.samples.apps.nowinandroid.core.ui.stateInViewModelScope
+import com.google.samples.apps.nowinandroid.core.ui.stateInScope
 import com.google.samples.apps.nowinandroid.feature.author.navigation.AuthorArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -56,11 +56,11 @@ class AuthorViewModel @Inject constructor(
         authorId = authorArgs.authorId,
         userDataRepository = userDataRepository,
         authorsRepository = authorsRepository
-    ).stateInViewModelScope(viewModelScope, initialValue = AuthorUiState.Loading)
+    ).stateInScope(viewModelScope, initialValue = AuthorUiState.Loading)
 
     val newsUiState: StateFlow<NewsUiState> = getSaveableNewsResourcesStream
         .newsUiStateStream(authorId = authorArgs.authorId)
-        .stateInViewModelScope(viewModelScope, initialValue = NewsUiState.Loading)
+        .stateInScope(viewModelScope, initialValue = NewsUiState.Loading)
 
     fun followAuthorToggle(followed: Boolean) = viewModelScope.launch {
         userDataRepository.toggleFollowedAuthorId(authorArgs.authorId, followed)

--- a/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModel.kt
+++ b/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModel.kt
@@ -23,14 +23,13 @@ import com.google.samples.apps.nowinandroid.core.domain.GetSaveableNewsResources
 import com.google.samples.apps.nowinandroid.core.domain.model.SaveableNewsResource
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState.Loading
+import com.google.samples.apps.nowinandroid.core.ui.stateInViewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -44,15 +43,9 @@ class BookmarksViewModel @Inject constructor(
         .map { newsResources -> newsResources.filter(SaveableNewsResource::isSaved) } // Only show bookmarked news resources.
         .map<List<SaveableNewsResource>, NewsFeedUiState>(NewsFeedUiState::Success)
         .onStart { emit(Loading) }
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = Loading
-        )
+        .stateInViewModelScope(viewModelScope, initialValue = Loading)
 
-    fun removeFromSavedResources(newsResourceId: String) {
-        viewModelScope.launch {
-            userDataRepository.updateNewsResourceBookmark(newsResourceId, false)
-        }
+    fun removeFromSavedResources(newsResourceId: String) = viewModelScope.launch {
+        userDataRepository.updateNewsResourceBookmark(newsResourceId, false)
     }
 }

--- a/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModel.kt
+++ b/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModel.kt
@@ -45,7 +45,9 @@ class BookmarksViewModel @Inject constructor(
         .onStart { emit(Loading) }
         .stateInScope(viewModelScope, initialValue = Loading)
 
-    fun removeFromSavedResources(newsResourceId: String) = viewModelScope.launch {
-        userDataRepository.updateNewsResourceBookmark(newsResourceId, false)
+    fun removeFromSavedResources(newsResourceId: String) {
+        viewModelScope.launch {
+            userDataRepository.updateNewsResourceBookmark(newsResourceId, false)
+        }
     }
 }

--- a/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModel.kt
+++ b/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModel.kt
@@ -23,7 +23,7 @@ import com.google.samples.apps.nowinandroid.core.domain.GetSaveableNewsResources
 import com.google.samples.apps.nowinandroid.core.domain.model.SaveableNewsResource
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState.Loading
-import com.google.samples.apps.nowinandroid.core.ui.stateInViewModelScope
+import com.google.samples.apps.nowinandroid.core.ui.stateInScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.StateFlow
@@ -43,7 +43,7 @@ class BookmarksViewModel @Inject constructor(
         .map { newsResources -> newsResources.filter(SaveableNewsResource::isSaved) } // Only show bookmarked news resources.
         .map<List<SaveableNewsResource>, NewsFeedUiState>(NewsFeedUiState::Success)
         .onStart { emit(Loading) }
-        .stateInViewModelScope(viewModelScope, initialValue = Loading)
+        .stateInScope(viewModelScope, initialValue = Loading)
 
     fun removeFromSavedResources(newsResourceId: String) = viewModelScope.launch {
         userDataRepository.updateNewsResourceBookmark(newsResourceId, false)

--- a/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouViewModel.kt
+++ b/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouViewModel.kt
@@ -25,7 +25,7 @@ import com.google.samples.apps.nowinandroid.core.domain.GetSaveableNewsResources
 import com.google.samples.apps.nowinandroid.core.domain.GetSortedFollowableAuthorsStreamUseCase
 import com.google.samples.apps.nowinandroid.core.domain.model.SaveableNewsResource
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState
-import com.google.samples.apps.nowinandroid.core.ui.stateInViewModelScope
+import com.google.samples.apps.nowinandroid.core.ui.stateInScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -51,7 +51,7 @@ class ForYouViewModel @Inject constructor(
 
     val isSyncing = syncStatusMonitor
         .isSyncing
-        .stateInViewModelScope(viewModelScope, initialValue = false)
+        .stateInScope(viewModelScope, initialValue = false)
 
     val feedState: StateFlow<NewsFeedUiState> =
         userDataRepository.userDataStream
@@ -75,7 +75,7 @@ class ForYouViewModel @Inject constructor(
             // As the selected topics and topic state changes, this will cancel the old feed
             // monitoring and start the new one.
             .flatMapLatest { it }
-            .stateInViewModelScope(viewModelScope, initialValue = NewsFeedUiState.Loading)
+            .stateInScope(viewModelScope, initialValue = NewsFeedUiState.Loading)
 
     val onboardingUiState: StateFlow<OnboardingUiState> =
         combine(
@@ -91,7 +91,7 @@ class ForYouViewModel @Inject constructor(
             } else {
                 OnboardingUiState.NotShown
             }
-        }.stateInViewModelScope(viewModelScope, initialValue = OnboardingUiState.Loading)
+        }.stateInScope(viewModelScope, initialValue = OnboardingUiState.Loading)
 
     fun updateTopicSelection(topicId: String, isChecked: Boolean) = viewModelScope.launch {
         userDataRepository.toggleFollowedTopicId(topicId, isChecked)

--- a/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouViewModel.kt
+++ b/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouViewModel.kt
@@ -93,12 +93,16 @@ class ForYouViewModel @Inject constructor(
             }
         }.stateInScope(viewModelScope, initialValue = OnboardingUiState.Loading)
 
-    fun updateTopicSelection(topicId: String, isChecked: Boolean) = viewModelScope.launch {
-        userDataRepository.toggleFollowedTopicId(topicId, isChecked)
+    fun updateTopicSelection(topicId: String, isChecked: Boolean) {
+        viewModelScope.launch {
+            userDataRepository.toggleFollowedTopicId(topicId, isChecked)
+        }
     }
 
-    fun updateAuthorSelection(authorId: String, isChecked: Boolean) = viewModelScope.launch {
-        userDataRepository.toggleFollowedAuthorId(authorId, isChecked)
+    fun updateAuthorSelection(authorId: String, isChecked: Boolean) {
+        viewModelScope.launch {
+            userDataRepository.toggleFollowedAuthorId(authorId, isChecked)
+        }
     }
 
     fun updateNewsResourceSaved(newsResourceId: String, isChecked: Boolean) {
@@ -107,8 +111,10 @@ class ForYouViewModel @Inject constructor(
         }
     }
 
-    fun dismissOnboarding() = viewModelScope.launch {
-        userDataRepository.setShouldHideOnboarding(true)
+    fun dismissOnboarding() {
+        viewModelScope.launch {
+            userDataRepository.setShouldHideOnboarding(true)
+        }
     }
 }
 

--- a/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsViewModel.kt
+++ b/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsViewModel.kt
@@ -24,14 +24,13 @@ import com.google.samples.apps.nowinandroid.core.domain.GetSortedFollowableAutho
 import com.google.samples.apps.nowinandroid.core.domain.TopicSortField
 import com.google.samples.apps.nowinandroid.core.domain.model.FollowableAuthor
 import com.google.samples.apps.nowinandroid.core.domain.model.FollowableTopic
+import com.google.samples.apps.nowinandroid.core.ui.stateInViewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -54,22 +53,14 @@ class InterestsViewModel @Inject constructor(
         getSortedFollowableAuthorsStream(),
         getFollowableTopicsStream(sortBy = TopicSortField.NAME),
         InterestsUiState::Interests
-    ).stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5_000),
-        initialValue = InterestsUiState.Loading
-    )
+    ).stateInViewModelScope(viewModelScope, initialValue = InterestsUiState.Loading)
 
-    fun followTopic(followedTopicId: String, followed: Boolean) {
-        viewModelScope.launch {
-            userDataRepository.toggleFollowedTopicId(followedTopicId, followed)
-        }
+    fun followTopic(followedTopicId: String, followed: Boolean) = viewModelScope.launch {
+        userDataRepository.toggleFollowedTopicId(followedTopicId, followed)
     }
 
-    fun followAuthor(followedAuthorId: String, followed: Boolean) {
-        viewModelScope.launch {
-            userDataRepository.toggleFollowedAuthorId(followedAuthorId, followed)
-        }
+    fun followAuthor(followedAuthorId: String, followed: Boolean) = viewModelScope.launch {
+        userDataRepository.toggleFollowedAuthorId(followedAuthorId, followed)
     }
 
     fun switchTab(newIndex: Int) {

--- a/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsViewModel.kt
+++ b/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsViewModel.kt
@@ -55,12 +55,16 @@ class InterestsViewModel @Inject constructor(
         InterestsUiState::Interests
     ).stateInScope(viewModelScope, initialValue = InterestsUiState.Loading)
 
-    fun followTopic(followedTopicId: String, followed: Boolean) = viewModelScope.launch {
-        userDataRepository.toggleFollowedTopicId(followedTopicId, followed)
+    fun followTopic(followedTopicId: String, followed: Boolean) {
+        viewModelScope.launch {
+            userDataRepository.toggleFollowedTopicId(followedTopicId, followed)
+        }
     }
 
-    fun followAuthor(followedAuthorId: String, followed: Boolean) = viewModelScope.launch {
-        userDataRepository.toggleFollowedAuthorId(followedAuthorId, followed)
+    fun followAuthor(followedAuthorId: String, followed: Boolean) {
+        viewModelScope.launch {
+            userDataRepository.toggleFollowedAuthorId(followedAuthorId, followed)
+        }
     }
 
     fun switchTab(newIndex: Int) {

--- a/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsViewModel.kt
+++ b/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsViewModel.kt
@@ -24,7 +24,7 @@ import com.google.samples.apps.nowinandroid.core.domain.GetSortedFollowableAutho
 import com.google.samples.apps.nowinandroid.core.domain.TopicSortField
 import com.google.samples.apps.nowinandroid.core.domain.model.FollowableAuthor
 import com.google.samples.apps.nowinandroid.core.domain.model.FollowableTopic
-import com.google.samples.apps.nowinandroid.core.ui.stateInViewModelScope
+import com.google.samples.apps.nowinandroid.core.ui.stateInScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -53,7 +53,7 @@ class InterestsViewModel @Inject constructor(
         getSortedFollowableAuthorsStream(),
         getFollowableTopicsStream(sortBy = TopicSortField.NAME),
         InterestsUiState::Interests
-    ).stateInViewModelScope(viewModelScope, initialValue = InterestsUiState.Loading)
+    ).stateInScope(viewModelScope, initialValue = InterestsUiState.Loading)
 
     fun followTopic(followedTopicId: String, followed: Boolean) = viewModelScope.launch {
         userDataRepository.toggleFollowedTopicId(followedTopicId, followed)

--- a/feature/settings/src/main/java/com/google/samples/apps/nowinandroid/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/google/samples/apps/nowinandroid/feature/settings/SettingsViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.samples.apps.nowinandroid.core.data.repository.UserDataRepository
 import com.google.samples.apps.nowinandroid.core.model.data.DarkThemeConfig
 import com.google.samples.apps.nowinandroid.core.model.data.ThemeBrand
+import com.google.samples.apps.nowinandroid.core.ui.stateInViewModelScope
 import com.google.samples.apps.nowinandroid.feature.settings.SettingsUiState.Loading
 import com.google.samples.apps.nowinandroid.feature.settings.SettingsUiState.Success
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -28,7 +29,6 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -44,29 +44,23 @@ class SettingsViewModel @Inject constructor(
                         darkThemeConfig = userData.darkThemeConfig
                     )
                 )
-            }
-            .stateIn(
-                scope = viewModelScope,
-                // Starting eagerly means the user data is ready when the SettingsDialog is laid out
-                // for the first time. Without this, due to b/221643630 the layout is done using the
-                // "Loading" text, then replaced with the user editable fields once loaded, however,
-                // the layout height doesn't change meaning all the fields are squashed into a small
-                // scrollable column.
-                // TODO: Change to SharingStarted.WhileSubscribed(5_000) when b/221643630 is fixed
-                started = SharingStarted.Eagerly,
-                initialValue = Loading
-            )
+            }.stateInViewModelScope(viewModelScope, SharingStarted.Eagerly, Loading)
 
-    fun updateThemeBrand(themeBrand: ThemeBrand) {
-        viewModelScope.launch {
-            userDataRepository.setThemeBrand(themeBrand)
-        }
+    /**
+     * Starting eagerly means the user data is ready when the SettingsDialog is laid out
+     * for the first time. Without this, due to b/221643630 the layout is done using the
+     * "Loading" text, then replaced with the user editable fields once loaded, however,
+     * the layout height doesn't change meaning all the fields are squashed into a small
+     * scrollable column.
+     * TODO: Change to SharingStarted.WhileSubscribed(5_000) when b/221643630 is fixed
+     */
+
+    fun updateThemeBrand(themeBrand: ThemeBrand) = viewModelScope.launch {
+        userDataRepository.setThemeBrand(themeBrand)
     }
 
-    fun updateDarkThemeConfig(darkThemeConfig: DarkThemeConfig) {
-        viewModelScope.launch {
-            userDataRepository.setDarkThemeConfig(darkThemeConfig)
-        }
+    fun updateDarkThemeConfig(darkThemeConfig: DarkThemeConfig) = viewModelScope.launch {
+        userDataRepository.setDarkThemeConfig(darkThemeConfig)
     }
 }
 

--- a/feature/settings/src/main/java/com/google/samples/apps/nowinandroid/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/google/samples/apps/nowinandroid/feature/settings/SettingsViewModel.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.samples.apps.nowinandroid.core.data.repository.UserDataRepository
 import com.google.samples.apps.nowinandroid.core.model.data.DarkThemeConfig
 import com.google.samples.apps.nowinandroid.core.model.data.ThemeBrand
-import com.google.samples.apps.nowinandroid.core.ui.stateInViewModelScope
+import com.google.samples.apps.nowinandroid.core.ui.stateInScope
 import com.google.samples.apps.nowinandroid.feature.settings.SettingsUiState.Loading
 import com.google.samples.apps.nowinandroid.feature.settings.SettingsUiState.Success
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -44,7 +44,7 @@ class SettingsViewModel @Inject constructor(
                         darkThemeConfig = userData.darkThemeConfig
                     )
                 )
-            }.stateInViewModelScope(viewModelScope, SharingStarted.Eagerly, Loading)
+            }.stateInScope(viewModelScope, SharingStarted.Eagerly, Loading)
 
     /**
      * Starting eagerly means the user data is ready when the SettingsDialog is laid out

--- a/feature/topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
@@ -119,7 +119,7 @@ internal fun TopicScreen(
                         uiState = topicUiState.followableTopic,
                     )
                 }
-                TopicBody(
+                topicBody(
                     name = topicUiState.followableTopic.topic.name,
                     description = topicUiState.followableTopic.topic.longDescription,
                     news = newsUiState,
@@ -134,7 +134,7 @@ internal fun TopicScreen(
     }
 }
 
-private fun LazyListScope.TopicBody(
+private fun LazyListScope.topicBody(
     name: String,
     description: String,
     news: NewsUiState,
@@ -204,7 +204,7 @@ private fun LazyListScope.TopicCards(
 private fun TopicBodyPreview() {
     NiaTheme {
         LazyColumn {
-            TopicBody(
+            topicBody(
                 "Jetpack Compose", "Lorem ipsum maximum",
                 NewsUiState.Success(emptyList()), "", { _, _ -> }
             )

--- a/feature/topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt
@@ -64,12 +64,16 @@ class TopicViewModel @Inject constructor(
         getSaveableNewsResourcesStream = getSaveableNewsResourcesStream
     ).stateInScope(viewModelScope, initialValue = NewsUiState.Loading)
 
-    fun followTopicToggle(followed: Boolean) = viewModelScope.launch {
-        userDataRepository.toggleFollowedTopicId(topicArgs.topicId, followed)
+    fun followTopicToggle(followed: Boolean) {
+        viewModelScope.launch {
+            userDataRepository.toggleFollowedTopicId(topicArgs.topicId, followed)
+        }
     }
 
-    fun bookmarkNews(newsResourceId: String, bookmarked: Boolean) = viewModelScope.launch {
-        userDataRepository.updateNewsResourceBookmark(newsResourceId, bookmarked)
+    fun bookmarkNews(newsResourceId: String, bookmarked: Boolean) {
+        viewModelScope.launch {
+            userDataRepository.updateNewsResourceBookmark(newsResourceId, bookmarked)
+        }
     }
 }
 

--- a/feature/topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt
@@ -31,7 +31,7 @@ import com.google.samples.apps.nowinandroid.core.result.Result.Error
 import com.google.samples.apps.nowinandroid.core.result.Result.Loading
 import com.google.samples.apps.nowinandroid.core.result.Result.Success
 import com.google.samples.apps.nowinandroid.core.result.asResult
-import com.google.samples.apps.nowinandroid.core.ui.stateInViewModelScope
+import com.google.samples.apps.nowinandroid.core.ui.stateInScope
 import com.google.samples.apps.nowinandroid.feature.topic.navigation.TopicArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -56,13 +56,13 @@ class TopicViewModel @Inject constructor(
         topicId = topicArgs.topicId,
         userDataRepository = userDataRepository,
         topicsRepository = topicsRepository
-    ).stateInViewModelScope(viewModelScope, initialValue = TopicUiState.Loading)
+    ).stateInScope(viewModelScope, initialValue = TopicUiState.Loading)
 
     val newUiState: StateFlow<NewsUiState> = newsUiStateStream(
         topicId = topicArgs.topicId,
         userDataRepository = userDataRepository,
         getSaveableNewsResourcesStream = getSaveableNewsResourcesStream
-    ).stateInViewModelScope(viewModelScope, initialValue = NewsUiState.Loading)
+    ).stateInScope(viewModelScope, initialValue = NewsUiState.Loading)
 
     fun followTopicToggle(followed: Boolean) = viewModelScope.launch {
         userDataRepository.toggleFollowedTopicId(topicArgs.topicId, followed)
@@ -140,12 +140,12 @@ private fun newsUiStateStream(
         .asResult()
         .map { newsToBookmarksResult ->
             when (newsToBookmarksResult) {
-                is Result.Success -> {
+                is Success -> {
                     val (news, bookmarks) = newsToBookmarksResult.data
                     NewsUiState.Success(news)
                 }
-                is Result.Loading -> NewsUiState.Loading
-                is Result.Error -> NewsUiState.Error
+                is Loading -> NewsUiState.Loading
+                is Error -> NewsUiState.Error
             }
         }
 }

--- a/feature/topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt
@@ -27,16 +27,18 @@ import com.google.samples.apps.nowinandroid.core.domain.model.FollowableTopic
 import com.google.samples.apps.nowinandroid.core.domain.model.SaveableNewsResource
 import com.google.samples.apps.nowinandroid.core.model.data.Topic
 import com.google.samples.apps.nowinandroid.core.result.Result
+import com.google.samples.apps.nowinandroid.core.result.Result.Error
+import com.google.samples.apps.nowinandroid.core.result.Result.Loading
+import com.google.samples.apps.nowinandroid.core.result.Result.Success
 import com.google.samples.apps.nowinandroid.core.result.asResult
+import com.google.samples.apps.nowinandroid.core.ui.stateInViewModelScope
 import com.google.samples.apps.nowinandroid.feature.topic.navigation.TopicArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -45,7 +47,6 @@ class TopicViewModel @Inject constructor(
     stringDecoder: StringDecoder,
     private val userDataRepository: UserDataRepository,
     topicsRepository: TopicsRepository,
-    // newsRepository: NewsRepository,
     getSaveableNewsResourcesStream: GetSaveableNewsResourcesStreamUseCase
 ) : ViewModel() {
 
@@ -55,34 +56,20 @@ class TopicViewModel @Inject constructor(
         topicId = topicArgs.topicId,
         userDataRepository = userDataRepository,
         topicsRepository = topicsRepository
-    )
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = TopicUiState.Loading
-        )
+    ).stateInViewModelScope(viewModelScope, initialValue = TopicUiState.Loading)
 
     val newUiState: StateFlow<NewsUiState> = newsUiStateStream(
         topicId = topicArgs.topicId,
         userDataRepository = userDataRepository,
         getSaveableNewsResourcesStream = getSaveableNewsResourcesStream
-    )
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = NewsUiState.Loading
-        )
+    ).stateInViewModelScope(viewModelScope, initialValue = NewsUiState.Loading)
 
-    fun followTopicToggle(followed: Boolean) {
-        viewModelScope.launch {
-            userDataRepository.toggleFollowedTopicId(topicArgs.topicId, followed)
-        }
+    fun followTopicToggle(followed: Boolean) = viewModelScope.launch {
+        userDataRepository.toggleFollowedTopicId(topicArgs.topicId, followed)
     }
 
-    fun bookmarkNews(newsResourceId: String, bookmarked: Boolean) {
-        viewModelScope.launch {
-            userDataRepository.updateNewsResourceBookmark(newsResourceId, bookmarked)
-        }
+    fun bookmarkNews(newsResourceId: String, bookmarked: Boolean) = viewModelScope.launch {
+        userDataRepository.updateNewsResourceBookmark(newsResourceId, bookmarked)
     }
 }
 
@@ -92,9 +79,9 @@ private fun topicUiStateStream(
     topicsRepository: TopicsRepository,
 ): Flow<TopicUiState> {
     // Observe the followed topics, as they could change over time.
-    val followedTopicIdsStream: Flow<Set<String>> =
-        userDataRepository.userDataStream
-            .map { it.followedTopics }
+    val followedTopicIdsStream: Flow<Set<String>> = userDataRepository
+        .userDataStream
+        .map { it.followedTopics }
 
     // Observe topic information
     val topicStream: Flow<Topic> = topicsRepository.getTopic(
@@ -108,25 +95,26 @@ private fun topicUiStateStream(
     )
         .asResult()
         .map { followedTopicToTopicResult ->
-            when (followedTopicToTopicResult) {
-                is Result.Success -> {
-                    val (followedTopics, topic) = followedTopicToTopicResult.data
-                    val followed = followedTopics.contains(topicId)
-                    TopicUiState.Success(
-                        followableTopic = FollowableTopic(
-                            topic = topic,
-                            isFollowed = followed
-                        )
-                    )
-                }
-                is Result.Loading -> {
-                    TopicUiState.Loading
-                }
-                is Result.Error -> {
-                    TopicUiState.Error
-                }
-            }
+            handleTopicResult(followedTopicToTopicResult, topicId)
         }
+}
+
+private fun handleTopicResult(
+    followedTopicToTopicResult: Result<Pair<Set<String>, Topic>>,
+    topicId: String
+) = when (followedTopicToTopicResult) {
+    is Success -> {
+        val (followedTopics, topic) = followedTopicToTopicResult.data
+        val followed = followedTopics.contains(topicId)
+        TopicUiState.Success(
+            followableTopic = FollowableTopic(
+                topic = topic,
+                isFollowed = followed
+            )
+        )
+    }
+    is Loading -> TopicUiState.Loading
+    is Error -> TopicUiState.Error
 }
 
 private fun newsUiStateStream(
@@ -156,12 +144,8 @@ private fun newsUiStateStream(
                     val (news, bookmarks) = newsToBookmarksResult.data
                     NewsUiState.Success(news)
                 }
-                is Result.Loading -> {
-                    NewsUiState.Loading
-                }
-                is Result.Error -> {
-                    NewsUiState.Error
-                }
+                is Result.Loading -> NewsUiState.Loading
+                is Result.Error -> NewsUiState.Error
             }
         }
 }


### PR DESCRIPTION
This PR is about polishing codes, and using extension functions for `StateIn()` (mostly in ViewModels).

Basically, all of the `StateIn()` functions inside ViewModels were following/using the same pattern, so I decided to create two extension functions for use in both `ViewModel`s using `viewModelScope`, as well as `CoroutineScope` outside of `ViewModels`. 
