### PR TITLE
Migrate package from core:domain to namespace in build.gradle file

### DIFF
--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -19,6 +19,10 @@ plugins {
     kotlin("kapt")
 }
 
+android {
+    namespace = "com.google.samples.apps.nowinandroid.core.domain"
+}
+
 dependencies {
 
     implementation(project(":core:data"))

--- a/core/domain/src/main/AndroidManifest.xml
+++ b/core/domain/src/main/AndroidManifest.xml
@@ -14,4 +14,4 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest package="com.google.samples.apps.nowinandroid.core.domain" />
+<manifest />


### PR DESCRIPTION
Migrate package from core:domain to namespace in build.gradle file. To be compliant with AGP 8+