### PR TITLE
Update to wrapper 7.6 and use --rerun task

### DIFF
--- a/.run/Generate Demo Baseline Profile.run.xml
+++ b/.run/Generate Demo Baseline Profile.run.xml
@@ -16,22 +16,27 @@
 -->
 <component name="ProjectRunConfigurationManager">
   <!--
-  Baseline Profiles improve code execution speed by around 30% from the first launch by avoiding interpretation and just-in-time (JIT) compilation steps for included code paths.
+  Baseline Profiles improve code execution speed by around 30% from the first launch by avoiding
+  interpretation and just-in-time (JIT) compilation steps for included code paths.
   More information at http://d.android.com/baseline-profiles.
+
+  In this run configuration we leverage rerun parameter that always reruns the requested task regardless of cache.
+  We also leverage enable-display parameter to be able to verify the generator works as intended.
   -->
   <configuration default="false" name="Generate Demo Baseline Profile" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <!-- TODO Once we use Gradle wrapper 7.6, we can use rerun instead of rerun-tasks that will skip cache only for one task -->
-      <option name="scriptParameters" value="--rerun-tasks -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile" />
+      <option name="scriptParameters" value="-Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile" />
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
         <list>
           <option value=":benchmark:pixel6Api31DemoBenchmarkAndroidTest" />
+          <option value="--rerun" />
+          <option value="--enable-display" />
         </list>
       </option>
       <option name="vmOptions" />

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle wrapper 7.6 adds --rerun task that will always run the required task regardless of cache.
Until now we had to use --rerun-tasks, which ignore cache for all tasks.

Also added --enable-display parameter to GMD, so that emulator doesn't run in headless mode locally and we're able to verify the generator runs properly.