### PR TITLE
Updated background composable for gradient

### DIFF
--- a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -87,21 +87,22 @@ fun NiaApp(
         windowSizeClass = windowSizeClass
     ),
 ) {
-    val showGradientBackground = appState.currentTopLevelDestination == TopLevelDestination.FOR_YOU
+    val shouldShowGradientBackground =
+        appState.currentTopLevelDestination == TopLevelDestination.FOR_YOU
 
     NiaBackground {
         NiaGradientBackground(
-            topColor = if (showGradientBackground) {
+            topColor = if (shouldShowGradientBackground) {
                 LocalGradientColors.current.top
             } else {
                 Color.Unspecified
             },
-            bottomColor = if (showGradientBackground) {
+            bottomColor = if (shouldShowGradientBackground) {
                 LocalGradientColors.current.bottom
             } else {
                 Color.Unspecified
             },
-            containerColor = if (showGradientBackground) {
+            containerColor = if (shouldShowGradientBackground) {
                 LocalGradientColors.current.container
             } else {
                 Color.Unspecified

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -66,6 +66,7 @@ import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaTopAp
 import com.google.samples.apps.nowinandroid.core.designsystem.icon.Icon.DrawableResourceIcon
 import com.google.samples.apps.nowinandroid.core.designsystem.icon.Icon.ImageVectorIcon
 import com.google.samples.apps.nowinandroid.core.designsystem.icon.NiaIcons
+import com.google.samples.apps.nowinandroid.core.designsystem.theme.GradientColors
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.LocalGradientColors
 import com.google.samples.apps.nowinandroid.feature.settings.R as settingsR
 import com.google.samples.apps.nowinandroid.feature.settings.SettingsDialog
@@ -92,20 +93,10 @@ fun NiaApp(
 
     NiaBackground {
         NiaGradientBackground(
-            topColor = if (shouldShowGradientBackground) {
-                LocalGradientColors.current.top
+            gradientColors = if (shouldShowGradientBackground) {
+                LocalGradientColors.current
             } else {
-                Color.Unspecified
-            },
-            bottomColor = if (shouldShowGradientBackground) {
-                LocalGradientColors.current.bottom
-            } else {
-                Color.Unspecified
-            },
-            containerColor = if (shouldShowGradientBackground) {
-                LocalGradientColors.current.container
-            } else {
-                Color.Unspecified
+                GradientColors()
             },
         ) {
             val snackbarHostState = remember { SnackbarHostState() }

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -66,6 +66,7 @@ import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaTopAp
 import com.google.samples.apps.nowinandroid.core.designsystem.icon.Icon.DrawableResourceIcon
 import com.google.samples.apps.nowinandroid.core.designsystem.icon.Icon.ImageVectorIcon
 import com.google.samples.apps.nowinandroid.core.designsystem.icon.NiaIcons
+import com.google.samples.apps.nowinandroid.core.designsystem.theme.LocalGradientColors
 import com.google.samples.apps.nowinandroid.feature.settings.R as settingsR
 import com.google.samples.apps.nowinandroid.feature.settings.SettingsDialog
 import com.google.samples.apps.nowinandroid.navigation.NiaNavHost
@@ -86,101 +87,112 @@ fun NiaApp(
         windowSizeClass = windowSizeClass
     ),
 ) {
-    val background: @Composable (@Composable () -> Unit) -> Unit =
-        when (appState.currentTopLevelDestination) {
-            TopLevelDestination.FOR_YOU -> {
-                content ->
-                NiaGradientBackground(content = content)
-            }
-            else -> { content -> NiaBackground(content = content) }
-        }
+    val showGradientBackground = appState.currentTopLevelDestination == TopLevelDestination.FOR_YOU
 
-    background {
-        val snackbarHostState = remember { SnackbarHostState() }
-
-        val isOffline by appState.isOffline.collectAsStateWithLifecycle()
-
-        // If user is not connected to the internet show a snack bar to inform them.
-        val notConnectedMessage = stringResource(R.string.not_connected)
-        LaunchedEffect(isOffline) {
-            if (isOffline) snackbarHostState.showSnackbar(
-                message = notConnectedMessage,
-                duration = Indefinite
-            )
-        }
-
-        if (appState.shouldShowSettingsDialog) {
-            SettingsDialog(
-                onDismiss = { appState.setShowSettingsDialog(false) }
-            )
-        }
-
-        Scaffold(
-            modifier = Modifier.semantics {
-                testTagsAsResourceId = true
+    NiaBackground {
+        NiaGradientBackground(
+            topColor = if (showGradientBackground) {
+                LocalGradientColors.current.top
+            } else {
+                Color.Unspecified
             },
-            containerColor = Color.Transparent,
-            contentColor = MaterialTheme.colorScheme.onBackground,
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
-            snackbarHost = { SnackbarHost(snackbarHostState) },
-            bottomBar = {
-                if (appState.shouldShowBottomBar) {
-                    NiaBottomBar(
-                        destinations = appState.topLevelDestinations,
-                        onNavigateToDestination = appState::navigateToTopLevelDestination,
-                        currentDestination = appState.currentDestination,
-                        modifier = Modifier.testTag("NiaBottomBar")
-                    )
-                }
-            }
-        ) { padding ->
-            Row(
-                Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-                    .consumedWindowInsets(padding)
-                    .windowInsetsPadding(
-                        WindowInsets.safeDrawing.only(
-                            WindowInsetsSides.Horizontal
-                        )
-                    )
-            ) {
-                if (appState.shouldShowNavRail) {
-                    NiaNavRail(
-                        destinations = appState.topLevelDestinations,
-                        onNavigateToDestination = appState::navigateToTopLevelDestination,
-                        currentDestination = appState.currentDestination,
-                        modifier = Modifier
-                            .testTag("NiaNavRail")
-                            .safeDrawingPadding()
-                    )
-                }
+            bottomColor = if (showGradientBackground) {
+                LocalGradientColors.current.bottom
+            } else {
+                Color.Unspecified
+            },
+            containerColor = if (showGradientBackground) {
+                LocalGradientColors.current.container
+            } else {
+                Color.Unspecified
+            },
+        ) {
+            val snackbarHostState = remember { SnackbarHostState() }
 
-                Column(Modifier.fillMaxSize()) {
-                    // Show the top app bar on top level destinations.
-                    val destination = appState.currentTopLevelDestination
-                    if (destination != null) {
-                        NiaTopAppBar(
-                            titleRes = destination.titleTextId,
-                            actionIcon = NiaIcons.Settings,
-                            actionIconContentDescription = stringResource(
-                                id = settingsR.string.top_app_bar_action_icon_description
-                            ),
-                            colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                                containerColor = Color.Transparent
-                            ),
-                            onActionClick = { appState.setShowSettingsDialog(true) }
+            val isOffline by appState.isOffline.collectAsStateWithLifecycle()
+
+            // If user is not connected to the internet show a snack bar to inform them.
+            val notConnectedMessage = stringResource(R.string.not_connected)
+            LaunchedEffect(isOffline) {
+                if (isOffline) snackbarHostState.showSnackbar(
+                    message = notConnectedMessage,
+                    duration = Indefinite
+                )
+            }
+
+            if (appState.shouldShowSettingsDialog) {
+                SettingsDialog(
+                    onDismiss = { appState.setShowSettingsDialog(false) }
+                )
+            }
+
+            Scaffold(
+                modifier = Modifier.semantics {
+                    testTagsAsResourceId = true
+                },
+                containerColor = Color.Transparent,
+                contentColor = MaterialTheme.colorScheme.onBackground,
+                contentWindowInsets = WindowInsets(0, 0, 0, 0),
+                snackbarHost = { SnackbarHost(snackbarHostState) },
+                bottomBar = {
+                    if (appState.shouldShowBottomBar) {
+                        NiaBottomBar(
+                            destinations = appState.topLevelDestinations,
+                            onNavigateToDestination = appState::navigateToTopLevelDestination,
+                            currentDestination = appState.currentDestination,
+                            modifier = Modifier.testTag("NiaBottomBar")
+                        )
+                    }
+                }
+            ) { padding ->
+                Row(
+                    Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .consumedWindowInsets(padding)
+                        .windowInsetsPadding(
+                            WindowInsets.safeDrawing.only(
+                                WindowInsetsSides.Horizontal
+                            )
+                        )
+                ) {
+                    if (appState.shouldShowNavRail) {
+                        NiaNavRail(
+                            destinations = appState.topLevelDestinations,
+                            onNavigateToDestination = appState::navigateToTopLevelDestination,
+                            currentDestination = appState.currentDestination,
+                            modifier = Modifier
+                                .testTag("NiaNavRail")
+                                .safeDrawingPadding()
                         )
                     }
 
-                    NiaNavHost(
-                        navController = appState.navController,
-                        onBackClick = appState::onBackClick
-                    )
-                }
+                    Column(Modifier.fillMaxSize()) {
+                        // Show the top app bar on top level destinations.
+                        val destination = appState.currentTopLevelDestination
+                        if (destination != null) {
+                            NiaTopAppBar(
+                                titleRes = destination.titleTextId,
+                                actionIcon = NiaIcons.Settings,
+                                actionIconContentDescription = stringResource(
+                                    id = settingsR.string.top_app_bar_action_icon_description
+                                ),
+                                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                                    containerColor = Color.Transparent
+                                ),
+                                onActionClick = { appState.setShowSettingsDialog(true) }
+                            )
+                        }
 
-                // TODO: We may want to add padding or spacer when the snackbar is shown so that
-                //  content doesn't display behind it.
+                        NiaNavHost(
+                            navController = appState.navController,
+                            onBackClick = appState::onBackClick
+                        )
+                    }
+
+                    // TODO: We may want to add padding or spacer when the snackbar is shown so that
+                    //  content doesn't display behind it.
+                }
             }
         }
     }

--- a/core/designsystem/src/main/java/com/google/samples/apps/nowinandroid/core/designsystem/component/Background.kt
+++ b/core/designsystem/src/main/java/com/google/samples/apps/nowinandroid/core/designsystem/component/Background.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.google.samples.apps.nowinandroid.core.designsystem.theme.GradientColors
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.LocalBackgroundTheme
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.LocalGradientColors
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
@@ -69,23 +70,23 @@ fun NiaBackground(
  * of a [Box] within a [Surface].
  *
  * @param modifier Modifier to be applied to the background.
- * @param topColor The top gradient color to be rendered.
- * @param bottomColor The bottom gradient color to be rendered.
- * @param containerColor The container color over which the gradient will be rendered.
+ * @param gradientColors The gradient colors to be rendered.
  * @param content The background content.
  */
 @Composable
 fun NiaGradientBackground(
     modifier: Modifier = Modifier,
-    topColor: Color = LocalGradientColors.current.top,
-    bottomColor: Color = LocalGradientColors.current.bottom,
-    containerColor: Color = LocalGradientColors.current.container,
+    gradientColors: GradientColors = LocalGradientColors.current,
     content: @Composable () -> Unit
 ) {
-    val currentTopColor by rememberUpdatedState(topColor)
-    val currentBottomColor by rememberUpdatedState(bottomColor)
+    val currentTopColor by rememberUpdatedState(gradientColors.top)
+    val currentBottomColor by rememberUpdatedState(gradientColors.bottom)
     Surface(
-        color = if (containerColor == Color.Unspecified) Color.Transparent else containerColor,
+        color = if (gradientColors.container == Color.Unspecified) {
+            Color.Transparent
+        } else {
+            gradientColors.container
+        },
         modifier = modifier.fillMaxSize()
     ) {
         Box(

--- a/core/designsystem/src/main/java/com/google/samples/apps/nowinandroid/core/designsystem/theme/Gradient.kt
+++ b/core/designsystem/src/main/java/com/google/samples/apps/nowinandroid/core/designsystem/theme/Gradient.kt
@@ -22,6 +22,10 @@ import androidx.compose.ui.graphics.Color
 
 /**
  * A class to model gradient color values for Now in Android.
+ *
+ * @param top The top gradient color to be rendered.
+ * @param bottom The bottom gradient color to be rendered.
+ * @param container The container gradient color over which the gradient will be rendered.
  */
 @Immutable
 data class GradientColors(


### PR DESCRIPTION
This PR changes how the overall background composable is applied, to ensure that state isn't lost when switching between the two.

One option here would be `movableContentOf`, but that would be more complicated and when trying that out, was running into issues with the animation looking smooth.

The other option which this PR uses is always calling into both background functions, but effectively disabling the gradient one if we don't actually want to show it.

This fixes #415 and #349 