### PR TITLE
Set visibility modifier of composable preview to private

### DIFF
--- a/core/designsystem/src/main/java/com/google/samples/apps/nowinandroid/core/designsystem/component/TopAppBar.kt
+++ b/core/designsystem/src/main/java/com/google/samples/apps/nowinandroid/core/designsystem/component/TopAppBar.kt
@@ -104,7 +104,7 @@ fun NiaTopAppBar(
 @OptIn(ExperimentalMaterial3Api::class)
 @Preview("Top App Bar")
 @Composable
-fun NiaTopAppBarPreview() {
+private fun NiaTopAppBarPreview() {
     NiaTopAppBar(
         titleRes = android.R.string.untitled,
         navigationIcon = NiaIcons.Search,

--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
@@ -106,7 +106,7 @@ sealed interface NewsFeedUiState {
 
 @Preview
 @Composable
-fun NewsFeedLoadingPreview() {
+private fun NewsFeedLoadingPreview() {
     NiaTheme {
         LazyVerticalGrid(columns = GridCells.Adaptive(300.dp)) {
             newsFeed(
@@ -120,7 +120,7 @@ fun NewsFeedLoadingPreview() {
 @Preview
 @Preview(device = Devices.TABLET)
 @Composable
-fun NewsFeedContentPreview() {
+private fun NewsFeedContentPreview() {
     NiaTheme {
         LazyVerticalGrid(columns = GridCells.Adaptive(300.dp)) {
             newsFeed(

--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
@@ -256,7 +256,7 @@ fun NewsResourceTopics(
 
 @Preview("Bookmark Button")
 @Composable
-fun BookmarkButtonPreview() {
+private fun BookmarkButtonPreview() {
     NiaTheme {
         Surface {
             BookmarkButton(isBookmarked = false, onClick = { })
@@ -266,7 +266,7 @@ fun BookmarkButtonPreview() {
 
 @Preview("Bookmark Button Bookmarked")
 @Composable
-fun BookmarkButtonBookmarkedPreview() {
+private fun BookmarkButtonBookmarkedPreview() {
     NiaTheme {
         Surface {
             BookmarkButton(isBookmarked = true, onClick = { })
@@ -276,7 +276,7 @@ fun BookmarkButtonBookmarkedPreview() {
 
 @Preview("NewsResourceCardExpanded")
 @Composable
-fun ExpandedNewsResourcePreview() {
+private fun ExpandedNewsResourcePreview() {
     NiaTheme {
         Surface {
             NewsResourceCardExpanded(

--- a/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreen.kt
+++ b/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreen.kt
@@ -195,7 +195,7 @@ private fun BookmarksGridPreview() {
 
 @Preview
 @Composable
-fun EmptyStatePreview() {
+private fun EmptyStatePreview() {
     NiaTheme {
         EmptyState()
     }

--- a/feature/settings/src/main/java/com/google/samples/apps/nowinandroid/feature/settings/SettingsDialog.kt
+++ b/feature/settings/src/main/java/com/google/samples/apps/nowinandroid/feature/settings/SettingsDialog.kt
@@ -255,7 +255,7 @@ private fun TextLink(text: String, url: String) {
 
 @Preview
 @Composable
-fun PreviewSettingsDialog() {
+private fun PreviewSettingsDialog() {
     NiaTheme {
         SettingsDialog(
             onDismiss = {},
@@ -273,7 +273,7 @@ fun PreviewSettingsDialog() {
 
 @Preview
 @Composable
-fun PreviewSettingsDialogLoading() {
+private fun PreviewSettingsDialogLoading() {
     NiaTheme {
         SettingsDialog(
             onDismiss = {},


### PR DESCRIPTION
Because it is a composable preview, it's better to make it private because it's not a public function