### PR TITLE
Exclude `baseline-prof.txt` from IntelliJ IDEA indexing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
     id("nowinandroid.android.hilt")
     id("jacoco")
     id("nowinandroid.firebase-perf")
+    id("idea")
 }
 
 android {
@@ -126,5 +127,12 @@ configurations.configureEach {
         force(libs.junit4)
         // Temporary workaround for https://issuetracker.google.com/174733673
         force("org.objenesis:objenesis:2.6")
+    }
+}
+
+// Exclude baseline-prof.txt from indexing
+idea {
+    module {
+        excludeDirs = excludeDirs + file("src/main/baseline-prof.txt")
     }
 }


### PR DESCRIPTION
... as it pollutes search results and wastes precious indexing time.

Here is how it will appear after this change:

![image](https://user-images.githubusercontent.com/1921278/208267919-a1108587-0351-4435-ac0d-d71bb7517fb9.png)
