### PR TITLE
Typo fix for search & Remove the redundant "interests" prefix

### DIFF
--- a/feature/interests/src/androidTest/java/com/google/samples/apps/nowinandroid/interests/InterestsScreenTest.kt
+++ b/feature/interests/src/androidTest/java/com/google/samples/apps/nowinandroid/interests/InterestsScreenTest.kt
@@ -52,12 +52,12 @@ class InterestsScreenTest {
     @Before
     fun setup() {
         composeTestRule.activity.apply {
-            interestsLoading = getString(R.string.interests_loading)
-            interestsEmptyHeader = getString(R.string.interests_empty_header)
+            interestsLoading = getString(R.string.loading)
+            interestsEmptyHeader = getString(R.string.empty_header)
             interestsTopicCardFollowButton =
-                getString(R.string.interests_card_follow_button_content_desc)
+                getString(R.string.card_follow_button_content_desc)
             interestsTopicCardUnfollowButton =
-                getString(R.string.interests_card_unfollow_button_content_desc)
+                getString(R.string.card_unfollow_button_content_desc)
         }
     }
 

--- a/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsItem.kt
+++ b/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsItem.kt
@@ -76,7 +76,7 @@ fun InterestsItem(
                 Icon(
                     imageVector = NiaIcons.Add,
                     contentDescription = stringResource(
-                        id = string.interests_card_follow_button_content_desc
+                        id = string.card_follow_button_content_desc
                     )
                 )
             },
@@ -84,7 +84,7 @@ fun InterestsItem(
                 Icon(
                     imageVector = NiaIcons.Check,
                     contentDescription = stringResource(
-                        id = string.interests_card_unfollow_button_content_desc
+                        id = string.card_unfollow_button_content_desc
                     )
                 )
             }

--- a/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsScreen.kt
+++ b/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsScreen.kt
@@ -65,7 +65,7 @@ internal fun InterestsScreen(
             InterestsUiState.Loading ->
                 NiaLoadingWheel(
                     modifier = modifier,
-                    contentDesc = stringResource(id = R.string.interests_loading),
+                    contentDesc = stringResource(id = R.string.loading),
                 )
             is InterestsUiState.Interests ->
                 TopicsTabContent(
@@ -81,7 +81,7 @@ internal fun InterestsScreen(
 
 @Composable
 private fun InterestsEmptyScreen() {
-    Text(text = stringResource(id = R.string.interests_empty_header))
+    Text(text = stringResource(id = R.string.empty_header))
 }
 
 @DevicePreviews

--- a/feature/interests/src/main/res/values/strings.xml
+++ b/feature/interests/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
      Copyright 2022 The Android Open Source Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,13 +14,12 @@
      limitations under the License.
 -->
 <resources>
-    <!-- TODO: Remove the redundant "interests" prefix -->
     <string name="interests">Interests</string>
-    <string name="interests_loading">Loading data</string>
-    <string name="interests_empty_header">"No available data"</string>
-    <string name="interests_card_follow_button_content_desc">Follow interest button</string>
-    <string name="interests_card_unfollow_button_content_desc">Unfollow interest button</string>
-    <string name="interests_top_app_bar_title">Interests</string>
-    <string name="interests_top_app_bar_action_menu">Menu</string>
-    <string name="interests_top_app_bar_action_search">Search</string>
+    <string name="loading">Loading data</string>
+    <string name="empty_header">"No available data"</string>
+    <string name="card_follow_button_content_desc">Follow interest button</string>
+    <string name="card_unfollow_button_content_desc">Unfollow interest button</string>
+    <string name="top_app_bar_title">Interests</string>
+    <string name="top_app_bar_action_menu">Menu</string>
+    <string name="top_app_bar_action_search">Search</string>
 </resources>

--- a/feature/interests/src/main/res/values/strings.xml
+++ b/feature/interests/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
      Copyright 2022 The Android Open Source Project
 
      Licensed under the Apache License, Version 2.0 (the "License");

--- a/feature/interests/src/main/res/values/strings.xml
+++ b/feature/interests/src/main/res/values/strings.xml
@@ -23,5 +23,5 @@
     <string name="interests_card_unfollow_button_content_desc">Unfollow interest button</string>
     <string name="interests_top_app_bar_title">Interests</string>
     <string name="interests_top_app_bar_action_menu">Menu</string>
-    <string name="interests_top_app_bar_action_seearch">Search</string>
+    <string name="interests_top_app_bar_action_search">Search</string>
 </resources>


### PR DESCRIPTION
#500 interests_top_app_bar_action_seearch is misspelled in strings.xml which should actually be interests_top_app_bar_action_search. According to TODO task remove the redundant "interests" prefix in string.xml.