### PR TITLE
Coil reference url fixed

### DIFF
--- a/app/src/main/java/com/google/samples/apps/nowinandroid/NiaApplication.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/NiaApplication.kt
@@ -39,7 +39,7 @@ class NiaApplication : Application(), ImageLoaderFactory {
      * format. During Coil's initialization it will call `applicationContext.newImageLoader()` to
      * obtain an ImageLoader.
      *
-     * @see https://github.com/coil-kt/coil/blob/main/coil-singleton/src/main/java/coil/Coil.kt#L63
+     * @see <a href="https://github.com/coil-kt/coil/blob/main/coil-singleton/src/main/java/coil/Coil.kt">Coil</a>
      */
     override fun newImageLoader(): ImageLoader {
         return ImageLoader.Builder(this)


### PR DESCRIPTION
I added Coil URL inside an anchor tag so that the user can see it properly in the browser

Before:- 
<img width="640" alt="image" src="https://user-images.githubusercontent.com/53827314/211280552-754b67c1-c96b-48c4-bdb6-02959193506f.png">

After:- 
<img width="671" alt="image" src="https://user-images.githubusercontent.com/53827314/211280448-f2739ac5-8365-40f8-9532-8e05223e70aa.png">
