### PR TITLE
Use dryRunMode.enabled=true for benchmarks

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -90,7 +90,7 @@ jobs:
           disable-animations: true
           disk-size: 6000M
           heap-size: 600M
-          script: ./gradlew connectedProdDebugAndroidTest -x :benchmark:connectedProdBenchmarkAndroidTest
+          script: ./gradlew connectedProdDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.dryRunMode.enable=true
 
       - name: Upload test reports
         if: always()


### PR DESCRIPTION

This will allow running benchmarks on emulator and runs only 1 iteration of the benchmark to verify behavior.

Change-Id: I3ea3ffce1a2777c90db5d801a43186fd81cc3631
Fixes #428  //Add plugin classpath//com.googke.firebase:16.1.0/not required
<