### PR TITLE
ViewHolder pattern for news feed

### DIFF
--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/NewsRepository.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/NewsRepository.kt
@@ -21,18 +21,23 @@ import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
 import kotlinx.coroutines.flow.Flow
 
 /**
+ * Query parameters for fetching news resources
+ */
+data class NewsResourceQuery(
+    /**
+     * Topics to filter the fetched news resources by, or null for no filtering.
+     */
+    val filterTopicIds: Set<String>? = null
+)
+
+/**
  * Data layer implementation for [NewsResource]
  */
 interface NewsRepository : Syncable {
     /**
      * Returns available news resources as a stream.
      */
-    fun getNewsResources(): Flow<List<NewsResource>>
-
-    /**
-     * Returns available news resources as a stream filtered by topics.
-     */
     fun getNewsResources(
-        filterTopicIds: Set<String> = emptySet(),
+        query: NewsResourceQuery,
     ): Flow<List<NewsResource>>
 }

--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepository.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepository.kt
@@ -43,17 +43,12 @@ class OfflineFirstNewsRepository @Inject constructor(
     private val topicDao: TopicDao,
     private val network: NiaNetworkDataSource,
 ) : NewsRepository {
-
-    override fun getNewsResources(): Flow<List<NewsResource>> =
-        newsResourceDao.getNewsResources()
+    override fun getNewsResources(query: NewsResourceQuery): Flow<List<NewsResource>> =
+        newsResourceDao.getNewsResources(
+            filterTopicIds = query.filterTopicIds ?: emptySet(),
+            useFilterTopicIds = query.filterTopicIds != null
+        )
             .map { it.map(PopulatedNewsResource::asExternalModel) }
-
-    override fun getNewsResources(
-        filterTopicIds: Set<String>
-    ): Flow<List<NewsResource>> = newsResourceDao.getNewsResources(
-        filterTopicIds = filterTopicIds
-    )
-        .map { it.map(PopulatedNewsResource::asExternalModel) }
 
     override suspend fun syncWith(synchronizer: Synchronizer) =
         synchronizer.changeListSync(

--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/fake/FakeNewsRepository.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/fake/FakeNewsRepository.kt
@@ -19,6 +19,7 @@ package com.google.samples.apps.nowinandroid.core.data.repository.fake
 import com.google.samples.apps.nowinandroid.core.data.Synchronizer
 import com.google.samples.apps.nowinandroid.core.data.model.asEntity
 import com.google.samples.apps.nowinandroid.core.data.repository.NewsRepository
+import com.google.samples.apps.nowinandroid.core.data.repository.NewsResourceQuery
 import com.google.samples.apps.nowinandroid.core.database.model.NewsResourceEntity
 import com.google.samples.apps.nowinandroid.core.database.model.asExternalModel
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
@@ -42,27 +43,21 @@ class FakeNewsRepository @Inject constructor(
     @Dispatcher(IO) private val ioDispatcher: CoroutineDispatcher,
     private val datasource: FakeNiaNetworkDataSource
 ) : NewsRepository {
-
-    override fun getNewsResources(): Flow<List<NewsResource>> =
-        flow {
-            emit(
-                datasource.getNewsResources()
-                    .map(NetworkNewsResource::asEntity)
-                    .map(NewsResourceEntity::asExternalModel)
-            )
-        }.flowOn(ioDispatcher)
-
-    override fun getNewsResources(
-        filterTopicIds: Set<String>,
-    ): Flow<List<NewsResource>> =
+    override fun getNewsResources(query: NewsResourceQuery): Flow<List<NewsResource>> =
         flow {
             emit(
                 datasource
                     .getNewsResources()
-                    .filter { it.topics.intersect(filterTopicIds).isNotEmpty() }
+                    .let { newsResources ->
+                        when (val filterTopicIds = query.filterTopicIds) {
+                            null -> newsResources
+                            else -> newsResources.filter {
+                                it.topics.intersect(filterTopicIds).isNotEmpty()
+                            }
+                        }
+                    }
                     .map(NetworkNewsResource::asEntity)
                     .map(NewsResourceEntity::asExternalModel)
-
             )
         }.flowOn(ioDispatcher)
 

--- a/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
+++ b/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
@@ -80,10 +80,15 @@ class OfflineFirstNewsRepositoryTest {
     fun offlineFirstNewsRepository_news_resources_stream_is_backed_by_news_resource_dao() =
         runTest {
             assertEquals(
-                newsResourceDao.getNewsResources()
+                newsResourceDao.getNewsResources(
+                    filterTopicIds = emptySet(),
+                    useFilterTopicIds = false,
+                )
                     .first()
                     .map(PopulatedNewsResource::asExternalModel),
-                subject.getNewsResources()
+                subject.getNewsResources(
+                    NewsResourceQuery()
+                )
                     .first()
             )
         }
@@ -94,11 +99,14 @@ class OfflineFirstNewsRepositoryTest {
             assertEquals(
                 newsResourceDao.getNewsResources(
                     filterTopicIds = filteredInterestsIds,
+                    useFilterTopicIds = true,
                 )
                     .first()
                     .map(PopulatedNewsResource::asExternalModel),
                 subject.getNewsResources(
-                    filterTopicIds = filteredInterestsIds,
+                    NewsResourceQuery(
+                        filterTopicIds = filteredInterestsIds,
+                    )
                 )
                     .first()
             )
@@ -106,7 +114,9 @@ class OfflineFirstNewsRepositoryTest {
             assertEquals(
                 emptyList(),
                 subject.getNewsResources(
-                    filterTopicIds = nonPresentInterestsIds,
+                    NewsResourceQuery(
+                        filterTopicIds = nonPresentInterestsIds,
+                    )
                 )
                     .first()
             )
@@ -121,7 +131,10 @@ class OfflineFirstNewsRepositoryTest {
                 .map(NetworkNewsResource::asEntity)
                 .map(NewsResourceEntity::asExternalModel)
 
-            val newsResourcesFromDb = newsResourceDao.getNewsResources()
+            val newsResourcesFromDb = newsResourceDao.getNewsResources(
+                filterTopicIds = emptySet(),
+                useFilterTopicIds = false,
+            )
                 .first()
                 .map(PopulatedNewsResource::asExternalModel)
 
@@ -161,7 +174,10 @@ class OfflineFirstNewsRepositoryTest {
 
             subject.syncWith(synchronizer)
 
-            val newsResourcesFromDb = newsResourceDao.getNewsResources()
+            val newsResourcesFromDb = newsResourceDao.getNewsResources(
+                filterTopicIds = emptySet(),
+                useFilterTopicIds = false,
+            )
                 .first()
                 .map(PopulatedNewsResource::asExternalModel)
 
@@ -201,7 +217,10 @@ class OfflineFirstNewsRepositoryTest {
                 .map(NewsResourceEntity::asExternalModel)
                 .filter { it.id in changeListIds }
 
-            val newsResourcesFromDb = newsResourceDao.getNewsResources()
+            val newsResourcesFromDb = newsResourceDao.getNewsResources(
+                filterTopicIds = emptySet(),
+                useFilterTopicIds = false,
+            )
                 .first()
                 .map(PopulatedNewsResource::asExternalModel)
 

--- a/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNewsResourceDao.kt
+++ b/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNewsResourceDao.kt
@@ -52,18 +52,20 @@ class TestNewsResourceDao : NewsResourceDao {
 
     internal var topicCrossReferences: List<NewsResourceTopicCrossRef> = listOf()
 
-    override fun getNewsResources(): Flow<List<PopulatedNewsResource>> =
-        entitiesStateFlow.map {
-            it.map(NewsResourceEntity::asPopulatedNewsResource)
-        }
-
     override fun getNewsResources(
-        filterTopicIds: Set<String>
+        filterTopicIds: Set<String>,
+        useFilterTopicIds: Boolean
     ): Flow<List<PopulatedNewsResource>> =
-        getNewsResources()
-            .map { resources ->
-                resources.filter { resource ->
-                    resource.topics.any { it.id in filterTopicIds }
+        entitiesStateFlow
+            .map { it.map(NewsResourceEntity::asPopulatedNewsResource) }
+            .map { populatedNewsResources ->
+                when {
+                    useFilterTopicIds ->
+                        populatedNewsResources
+                            .filter { populatedNewsResource ->
+                                populatedNewsResource.topics.any { it.id in filterTopicIds }
+                            }
+                    else -> populatedNewsResources
                 }
             }
 

--- a/core/database/src/androidTest/java/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceDaoTest.kt
+++ b/core/database/src/androidTest/java/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceDaoTest.kt
@@ -73,7 +73,10 @@ class NewsResourceDaoTest {
             newsResourceEntities
         )
 
-        val savedNewsResourceEntities = newsResourceDao.getNewsResources()
+        val savedNewsResourceEntities = newsResourceDao.getNewsResources(
+            filterTopicIds = emptySet(),
+            useFilterTopicIds = false
+        )
             .first()
 
         assertEquals(
@@ -135,6 +138,7 @@ class NewsResourceDaoTest {
             filterTopicIds = topicEntities
                 .map(TopicEntity::id)
                 .toSet(),
+            useFilterTopicIds = true,
         ).first()
 
         assertEquals(
@@ -175,7 +179,10 @@ class NewsResourceDaoTest {
             assertEquals(
                 toKeep.map(NewsResourceEntity::id)
                     .toSet(),
-                newsResourceDao.getNewsResources().first()
+                newsResourceDao.getNewsResources(
+                    filterTopicIds = emptySet(),
+                    useFilterTopicIds = false,
+                ).first()
                     .map { it.entity.id }
                     .toSet()
             )

--- a/core/database/src/main/java/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceDao.kt
+++ b/core/database/src/main/java/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceDao.kt
@@ -34,29 +34,26 @@ import kotlinx.coroutines.flow.Flow
  */
 @Dao
 interface NewsResourceDao {
-    @Transaction
-    @Query(
-        value = """
-            SELECT * FROM news_resources
-            ORDER BY publish_date DESC
-    """
-    )
-    fun getNewsResources(): Flow<List<PopulatedNewsResource>>
 
     @Transaction
     @Query(
         value = """
             SELECT * FROM news_resources
-            WHERE id in
-            (
-                SELECT news_resource_id FROM news_resources_topics
-                WHERE topic_id IN (:filterTopicIds)
-            )
+            WHERE 
+                CASE WHEN :useFilterTopicIds
+                    THEN id IN
+                        (
+                            SELECT news_resource_id FROM news_resources_topics
+                            WHERE topic_id IN (:filterTopicIds)
+                        )
+                    ELSE 1
+                END
             ORDER BY publish_date DESC
     """
     )
     fun getNewsResources(
-        filterTopicIds: Set<String> = emptySet(),
+        filterTopicIds: Set<String>,
+        useFilterTopicIds: Boolean
     ): Flow<List<PopulatedNewsResource>>
 
     /**

--- a/core/domain/src/main/java/com/google/samples/apps/nowinandroid/core/domain/GetUserNewsResourcesUseCase.kt
+++ b/core/domain/src/main/java/com/google/samples/apps/nowinandroid/core/domain/GetUserNewsResourcesUseCase.kt
@@ -17,6 +17,7 @@
 package com.google.samples.apps.nowinandroid.core.domain
 
 import com.google.samples.apps.nowinandroid.core.data.repository.NewsRepository
+import com.google.samples.apps.nowinandroid.core.data.repository.NewsResourceQuery
 import com.google.samples.apps.nowinandroid.core.data.repository.UserDataRepository
 import com.google.samples.apps.nowinandroid.core.domain.model.UserNewsResource
 import com.google.samples.apps.nowinandroid.core.domain.model.mapToUserNewsResources
@@ -38,17 +39,13 @@ class GetUserNewsResourcesUseCase @Inject constructor(
     /**
      * Returns a list of UserNewsResources which match the supplied set of topic ids.
      *
-     * @param filterTopicIds - A set of topic ids used to filter the list of news resources. If
-     * this is empty the list of news resources will not be filtered.
+     * @param newsResourceQuery - Query parameters for the request.
      */
     operator fun invoke(
-        filterTopicIds: Set<String> = emptySet()
+        newsResourceQuery: NewsResourceQuery
     ): Flow<List<UserNewsResource>> =
-        if (filterTopicIds.isEmpty()) {
-            newsRepository.getNewsResources()
-        } else {
-            newsRepository.getNewsResources(filterTopicIds = filterTopicIds)
-        }.mapToUserNewsResources(userDataRepository.userData)
+        newsRepository.getNewsResources(query = newsResourceQuery)
+            .mapToUserNewsResources(userDataRepository.userData)
 }
 
 private fun Flow<List<NewsResource>>.mapToUserNewsResources(

--- a/core/domain/src/test/java/com/google/samples/apps/nowinandroid/core/domain/GetUserNewsResourcesUseCaseTest.kt
+++ b/core/domain/src/test/java/com/google/samples/apps/nowinandroid/core/domain/GetUserNewsResourcesUseCaseTest.kt
@@ -16,6 +16,7 @@
 
 package com.google.samples.apps.nowinandroid.core.domain
 
+import com.google.samples.apps.nowinandroid.core.data.repository.NewsResourceQuery
 import com.google.samples.apps.nowinandroid.core.domain.model.mapToUserNewsResources
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResourceType.Video
@@ -45,7 +46,7 @@ class GetUserNewsResourcesUseCaseTest {
     fun whenNoFilters_allNewsResourcesAreReturned() = runTest {
 
         // Obtain the user news resources stream.
-        val userNewsResources = useCase()
+        val userNewsResources = useCase(NewsResourceQuery())
 
         // Send some news resources and user data into the data repositories.
         newsRepository.sendNewsResources(sampleNewsResources)
@@ -69,7 +70,11 @@ class GetUserNewsResourcesUseCaseTest {
     fun whenFilteredByTopicId_matchingNewsResourcesAreReturned() = runTest {
 
         // Obtain a stream of user news resources for the given topic id.
-        val userNewsResources = useCase(filterTopicIds = setOf(sampleTopic1.id))
+        val userNewsResources = useCase(
+            NewsResourceQuery(
+                filterTopicIds = setOf(sampleTopic1.id),
+            )
+        )
 
         // Send test data into the repositories.
         newsRepository.sendNewsResources(sampleNewsResources)

--- a/core/testing/src/main/java/com/google/samples/apps/nowinandroid/core/testing/repository/TestNewsRepository.kt
+++ b/core/testing/src/main/java/com/google/samples/apps/nowinandroid/core/testing/repository/TestNewsRepository.kt
@@ -18,6 +18,7 @@ package com.google.samples.apps.nowinandroid.core.testing.repository
 
 import com.google.samples.apps.nowinandroid.core.data.Synchronizer
 import com.google.samples.apps.nowinandroid.core.data.repository.NewsRepository
+import com.google.samples.apps.nowinandroid.core.data.repository.NewsResourceQuery
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
 import com.google.samples.apps.nowinandroid.core.model.data.Topic
 import kotlinx.coroutines.channels.BufferOverflow
@@ -33,14 +34,16 @@ class TestNewsRepository : NewsRepository {
     private val newsResourcesFlow: MutableSharedFlow<List<NewsResource>> =
         MutableSharedFlow(replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 
-    override fun getNewsResources(): Flow<List<NewsResource>> = newsResourcesFlow
-
-    override fun getNewsResources(filterTopicIds: Set<String>): Flow<List<NewsResource>> =
-        getNewsResources().map { newsResources ->
-            newsResources.filter {
-                it.topics.map(Topic::id).intersect(filterTopicIds).isNotEmpty()
+    override fun getNewsResources(query: NewsResourceQuery): Flow<List<NewsResource>> =
+        newsResourcesFlow
+            .map { newsResources ->
+                when (val filterTopicIds = query.filterTopicIds) {
+                    null -> newsResources
+                    else -> newsResources.filter {
+                        it.topics.map(Topic::id).intersect(filterTopicIds).isNotEmpty()
+                    }
+                }
             }
-        }
 
     /**
      * A test-only API to allow controlling the list of news resources from tests.

--- a/feature/bookmarks/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreenTest.kt
+++ b/feature/bookmarks/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreenTest.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import com.google.samples.apps.nowinandroid.core.domain.model.previewUserNewsResources
-import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.Rule
@@ -49,7 +48,7 @@ class BookmarksScreenTest {
     fun loading_showsLoadingSpinner() {
         composeTestRule.setContent {
             BookmarksScreen(
-                feedState = NewsFeedUiState.Loading,
+                bookmarkItems = listOf(BookmarkItem.Loading),
                 removeFromBookmarks = { }
             )
         }
@@ -65,9 +64,9 @@ class BookmarksScreenTest {
     fun feed_whenHasBookmarks_showsBookmarks() {
         composeTestRule.setContent {
             BookmarksScreen(
-                feedState = NewsFeedUiState.Success(
-                    previewUserNewsResources.take(2)
-                ),
+                bookmarkItems = previewUserNewsResources
+                    .take(2)
+                    .map(BookmarkItem::News),
                 removeFromBookmarks = { }
             )
         }
@@ -103,9 +102,9 @@ class BookmarksScreenTest {
 
         composeTestRule.setContent {
             BookmarksScreen(
-                feedState = NewsFeedUiState.Success(
-                    previewUserNewsResources.take(2)
-                ),
+                bookmarkItems = previewUserNewsResources
+                    .take(2)
+                    .map(BookmarkItem::News),
                 removeFromBookmarks = { newsResourceId ->
                     assertEquals(previewUserNewsResources[0].id, newsResourceId)
                     removeFromBookmarksCalled = true
@@ -137,7 +136,7 @@ class BookmarksScreenTest {
     fun feed_whenHasNoBookmarks_showsEmptyState() {
         composeTestRule.setContent {
             BookmarksScreen(
-                feedState = NewsFeedUiState.Success(emptyList()),
+                bookmarkItems = emptyList(),
                 removeFromBookmarks = { }
             )
         }

--- a/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarkItem.kt
+++ b/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarkItem.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid.feature.bookmarks
+
+import com.google.samples.apps.nowinandroid.core.domain.model.UserNewsResource
+import com.google.samples.apps.nowinandroid.feature.bookmarks.BookmarkItem.Loading
+import com.google.samples.apps.nowinandroid.feature.bookmarks.BookmarkItem.News
+
+sealed class BookmarkItem {
+
+    object Loading : BookmarkItem()
+
+    data class News(
+        val userNewsResource: UserNewsResource
+    ) : BookmarkItem()
+}
+
+val BookmarkItem.key: String
+    get() = when (this) {
+        Loading -> "loading"
+        is News -> userNewsResource.id
+    }
+
+val BookmarkItem.contentType: String
+    get() = when (this) {
+        Loading -> "loading"
+        is News -> "news"
+    }

--- a/feature/foryou/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreenTest.kt
+++ b/feature/foryou/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreenTest.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.test.performScrollToNode
 import com.google.samples.apps.nowinandroid.core.domain.model.FollowableTopic
 import com.google.samples.apps.nowinandroid.core.domain.model.previewUserNewsResources
 import com.google.samples.apps.nowinandroid.core.model.data.Topic
-import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState
+import com.google.samples.apps.nowinandroid.feature.foryou.ForYouItem.News.Loaded
 import org.junit.Rule
 import org.junit.Test
 
@@ -51,8 +51,9 @@ class ForYouScreenTest {
             BoxWithConstraints {
                 ForYouScreen(
                     isSyncing = false,
-                    onboardingUiState = OnboardingUiState.Loading,
-                    feedState = NewsFeedUiState.Loading,
+                    forYouItems = listOf(
+                        ForYouItem.OnBoarding(OnboardingUiState.Loading)
+                    ),
                     onTopicCheckedChanged = { _, _ -> },
                     saveFollowedTopics = {},
                     onNewsResourcesCheckedChanged = { _, _ -> }
@@ -73,8 +74,7 @@ class ForYouScreenTest {
             BoxWithConstraints {
                 ForYouScreen(
                     isSyncing = true,
-                    onboardingUiState = OnboardingUiState.NotShown,
-                    feedState = NewsFeedUiState.Success(emptyList()),
+                    forYouItems = emptyList(),
                     onTopicCheckedChanged = { _, _ -> },
                     saveFollowedTopics = {},
                     onNewsResourcesCheckedChanged = { _, _ -> }
@@ -95,12 +95,12 @@ class ForYouScreenTest {
             BoxWithConstraints {
                 ForYouScreen(
                     isSyncing = false,
-                    onboardingUiState =
-                    OnboardingUiState.Shown(
-                        topics = testTopics,
-                    ),
-                    feedState = NewsFeedUiState.Success(
-                        feed = emptyList()
+                    forYouItems = listOf(
+                        ForYouItem.OnBoarding(
+                            OnboardingUiState.Shown(
+                                topics = testTopics,
+                            )
+                        )
                     ),
                     onTopicCheckedChanged = { _, _ -> },
                     saveFollowedTopics = {},
@@ -135,15 +135,15 @@ class ForYouScreenTest {
             BoxWithConstraints {
                 ForYouScreen(
                     isSyncing = false,
-                    onboardingUiState =
-                    OnboardingUiState.Shown(
-                        // Follow one topic
-                        topics = testTopics.mapIndexed { index, testTopic ->
-                            testTopic.copy(isFollowed = index == 1)
-                        }
-                    ),
-                    feedState = NewsFeedUiState.Success(
-                        feed = emptyList()
+                    forYouItems = listOf(
+                        ForYouItem.OnBoarding(
+                            OnboardingUiState.Shown(
+                                // Follow one topic
+                                topics = testTopics.mapIndexed { index, testTopic ->
+                                    testTopic.copy(isFollowed = index == 1)
+                                }
+                            )
+                        )
                     ),
                     onTopicCheckedChanged = { _, _ -> },
                     saveFollowedTopics = {},
@@ -178,9 +178,14 @@ class ForYouScreenTest {
             BoxWithConstraints {
                 ForYouScreen(
                     isSyncing = false,
-                    onboardingUiState =
-                    OnboardingUiState.Shown(topics = testTopics),
-                    feedState = NewsFeedUiState.Loading,
+                    forYouItems = listOf(
+                        ForYouItem.OnBoarding(
+                            OnboardingUiState.Shown(
+                                topics = testTopics
+                            )
+                        ),
+                        ForYouItem.News.Loading
+                    ),
                     onTopicCheckedChanged = { _, _ -> },
                     saveFollowedTopics = {},
                     onNewsResourcesCheckedChanged = { _, _ -> }
@@ -201,8 +206,7 @@ class ForYouScreenTest {
             BoxWithConstraints {
                 ForYouScreen(
                     isSyncing = false,
-                    onboardingUiState = OnboardingUiState.NotShown,
-                    feedState = NewsFeedUiState.Loading,
+                    forYouItems = listOf(ForYouItem.News.Loading),
                     onTopicCheckedChanged = { _, _ -> },
                     saveFollowedTopics = {},
                     onNewsResourcesCheckedChanged = { _, _ -> }
@@ -222,10 +226,7 @@ class ForYouScreenTest {
         composeTestRule.setContent {
             ForYouScreen(
                 isSyncing = false,
-                onboardingUiState = OnboardingUiState.NotShown,
-                feedState = NewsFeedUiState.Success(
-                    feed = previewUserNewsResources
-                ),
+                forYouItems = previewUserNewsResources.map(::Loaded),
                 onTopicCheckedChanged = { _, _ -> },
                 saveFollowedTopics = {},
                 onNewsResourcesCheckedChanged = { _, _ -> }

--- a/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouItems.kt
+++ b/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouItems.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid.feature.foryou
+
+import com.google.samples.apps.nowinandroid.core.domain.model.UserNewsResource
+
+/**
+ * Types of items that can show up in the "For you" grid
+ */
+sealed class ForYouItem {
+    data class OnBoarding(
+        val onboardingUiState: OnboardingUiState
+    ) : ForYouItem()
+
+    sealed class News : ForYouItem() {
+        object Loading : News()
+        data class Loaded(
+            val userNewsResource: UserNewsResource
+        ) : News()
+    }
+}
+
+val ForYouItem.key: String
+    get() = when (val item = this) {
+        is ForYouItem.News -> when (item) {
+            is ForYouItem.News.Loading -> LOADING_KEY
+            is ForYouItem.News.Loaded -> item.userNewsResource.id
+        }
+        is ForYouItem.OnBoarding -> ONBOARDING_KEY
+    }
+
+val ForYouItem.contentType: String
+    get() = when (val item = this) {
+        is ForYouItem.News -> when (item) {
+            is ForYouItem.News.Loading -> "news-loading-item"
+            is ForYouItem.News.Loaded -> "news-loaded-item"
+        }
+        is ForYouItem.OnBoarding -> "onboarding-item"
+    }
+
+private const val LOADING_KEY = "loading"
+private const val ONBOARDING_KEY = "onboarding"

--- a/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -43,7 +44,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridCells.Adaptive
 import androidx.compose.foundation.lazy.grid.GridItemSpan
-import androidx.compose.foundation.lazy.grid.LazyGridScope
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -82,13 +83,10 @@ import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaIconT
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaOverlayLoadingWheel
 import com.google.samples.apps.nowinandroid.core.designsystem.icon.NiaIcons
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
-import com.google.samples.apps.nowinandroid.core.domain.model.FollowableTopic
 import com.google.samples.apps.nowinandroid.core.domain.model.previewUserNewsResources
-import com.google.samples.apps.nowinandroid.core.model.data.previewTopics
 import com.google.samples.apps.nowinandroid.core.ui.DevicePreviews
-import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState
+import com.google.samples.apps.nowinandroid.core.ui.NewsItem
 import com.google.samples.apps.nowinandroid.core.ui.TrackScrollJank
-import com.google.samples.apps.nowinandroid.core.ui.newsFeed
 
 @OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
@@ -96,33 +94,38 @@ internal fun ForYouRoute(
     modifier: Modifier = Modifier,
     viewModel: ForYouViewModel = hiltViewModel()
 ) {
-    val onboardingUiState by viewModel.onboardingUiState.collectAsStateWithLifecycle()
-    val feedState by viewModel.feedState.collectAsStateWithLifecycle()
     val isSyncing by viewModel.isSyncing.collectAsStateWithLifecycle()
+    val forYouItems by viewModel.forYouItems.collectAsStateWithLifecycle()
+    val lazyGridState = rememberLazyGridState()
 
     ForYouScreen(
         isSyncing = isSyncing,
-        onboardingUiState = onboardingUiState,
-        feedState = feedState,
+        forYouItems = forYouItems,
         onTopicCheckedChanged = viewModel::updateTopicSelection,
         saveFollowedTopics = viewModel::dismissOnboarding,
         onNewsResourcesCheckedChanged = viewModel::updateNewsResourceSaved,
-        modifier = modifier
+        modifier = modifier,
+        lazyGridState = lazyGridState
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun ForYouScreen(
     isSyncing: Boolean,
-    onboardingUiState: OnboardingUiState,
-    feedState: NewsFeedUiState,
+    forYouItems: List<ForYouItem>,
     onTopicCheckedChanged: (String, Boolean) -> Unit,
     saveFollowedTopics: () -> Unit,
     onNewsResourcesCheckedChanged: (String, Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    lazyGridState: LazyGridState = rememberLazyGridState(),
 ) {
-    val isOnboardingLoading = onboardingUiState is OnboardingUiState.Loading
-    val isFeedLoading = feedState is NewsFeedUiState.Loading
+    val isOnboardingLoading = forYouItems.any {
+        it is ForYouItem.OnBoarding && it.onboardingUiState is OnboardingUiState.Loading
+    }
+    val isFeedLoading = forYouItems.any {
+        it is ForYouItem.News.Loading
+    }
 
     // Workaround to call Activity.reportFullyDrawn from Jetpack Compose.
     // This code should be called when the UI is ready for use
@@ -142,8 +145,7 @@ internal fun ForYouScreen(
         }
     }
 
-    val state = rememberLazyGridState()
-    TrackScrollJank(scrollableState = state, stateName = "forYou:feed")
+    TrackScrollJank(scrollableState = lazyGridState, stateName = "forYou:feed")
 
     LazyVerticalGrid(
         columns = Adaptive(300.dp),
@@ -153,39 +155,54 @@ internal fun ForYouScreen(
         modifier = modifier
             .fillMaxSize()
             .testTag("forYou:feed"),
-        state = state
+        state = lazyGridState
     ) {
-        onboarding(
-            onboardingUiState = onboardingUiState,
-            onTopicCheckedChanged = onTopicCheckedChanged,
-            saveFollowedTopics = saveFollowedTopics,
-            // Custom LayoutModifier to remove the enforced parent 16.dp contentPadding
-            // from the LazyVerticalGrid and enable edge-to-edge scrolling for this section
-            interestsItemModifier = Modifier.layout { measurable, constraints ->
-                val placeable = measurable.measure(
-                    constraints.copy(
-                        maxWidth = constraints.maxWidth + 32.dp.roundToPx()
+        items(
+            items = forYouItems,
+            key = ForYouItem::key,
+            contentType = ForYouItem::contentType,
+            span = { item ->
+                when (item) {
+                    is ForYouItem.OnBoarding -> GridItemSpan(maxLineSpan)
+                    is ForYouItem.News -> GridItemSpan(1)
+                }
+            },
+            itemContent = { item ->
+                when (item) {
+                    is ForYouItem.News -> when (item) {
+                        is ForYouItem.News.Loading -> Unit
+                        is ForYouItem.News.Loaded -> NewsItem(
+                            modifier = Modifier.animateItemPlacement(),
+                            userNewsResource = item.userNewsResource,
+                            onNewsResourcesCheckedChanged = onNewsResourcesCheckedChanged,
+                        )
+                    }
+                    is ForYouItem.OnBoarding -> OnboardingItem(
+                        onboardingUiState = item.onboardingUiState,
+                        onTopicCheckedChanged = onTopicCheckedChanged,
+                        saveFollowedTopics = saveFollowedTopics,
+                        // Custom LayoutModifier to remove the enforced parent 16.dp contentPadding
+                        // from the LazyVerticalGrid and enable edge-to-edge scrolling for this section
+                        interestsItemModifier = Modifier
+                            .layout { measurable, constraints ->
+                                val placeable = measurable.measure(
+                                    constraints.copy(
+                                        maxWidth = constraints.maxWidth + 32.dp.roundToPx()
+                                    )
+                                )
+                                layout(placeable.width, placeable.height) {
+                                    placeable.place(0, 0)
+                                }
+                            }
+                            .animateItemPlacement()
                     )
-                )
-                layout(placeable.width, placeable.height) {
-                    placeable.place(0, 0)
                 }
             }
         )
-
-        newsFeed(
-            feedState = feedState,
-            onNewsResourcesCheckedChanged = onNewsResourcesCheckedChanged,
-        )
-
-        item(span = { GridItemSpan(maxLineSpan) }) {
-            Column {
-                Spacer(modifier = Modifier.height(8.dp))
-                // Add space for the content to clear the "offline" snackbar.
-                // TODO: Check that the Scaffold handles this correctly in NiaApp
-                // if (isOffline) Spacer(modifier = Modifier.height(48.dp))
-                Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
-            }
+        item {
+            SpacerItem(
+                modifier = Modifier.animateItemPlacement(),
+            )
         }
     }
     AnimatedVisibility(
@@ -216,7 +233,8 @@ internal fun ForYouScreen(
  * Depending on the [onboardingUiState], this might emit no items.
  *
  */
-private fun LazyGridScope.onboarding(
+@Composable
+fun OnboardingItem(
     onboardingUiState: OnboardingUiState,
     onTopicCheckedChanged: (String, Boolean) -> Unit,
     saveFollowedTopics: () -> Unit,
@@ -228,49 +246,58 @@ private fun LazyGridScope.onboarding(
         OnboardingUiState.NotShown -> Unit
 
         is OnboardingUiState.Shown -> {
-            item(span = { GridItemSpan(maxLineSpan) }) {
-                Column(modifier = interestsItemModifier) {
-                    Text(
-                        text = stringResource(R.string.onboarding_guidance_title),
-                        textAlign = TextAlign.Center,
+            Column(modifier = interestsItemModifier) {
+                Text(
+                    text = stringResource(R.string.onboarding_guidance_title),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 24.dp),
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = stringResource(R.string.onboarding_guidance_subtitle),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp, start = 16.dp, end = 16.dp),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                TopicSelection(
+                    onboardingUiState,
+                    onTopicCheckedChanged,
+                    Modifier.padding(bottom = 8.dp)
+                )
+                // Done button
+                Row(
+                    horizontalArrangement = Arrangement.Center,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    NiaButton(
+                        onClick = saveFollowedTopics,
+                        enabled = onboardingUiState.isDismissable,
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 24.dp),
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    Text(
-                        text = stringResource(R.string.onboarding_guidance_subtitle),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 8.dp, start = 16.dp, end = 16.dp),
-                        textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                    TopicSelection(
-                        onboardingUiState,
-                        onTopicCheckedChanged,
-                        Modifier.padding(bottom = 8.dp)
-                    )
-                    // Done button
-                    Row(
-                        horizontalArrangement = Arrangement.Center,
-                        modifier = Modifier.fillMaxWidth()
+                            .padding(horizontal = 40.dp)
+                            .width(364.dp)
                     ) {
-                        NiaButton(
-                            onClick = saveFollowedTopics,
-                            enabled = onboardingUiState.isDismissable,
-                            modifier = Modifier
-                                .padding(horizontal = 40.dp)
-                                .width(364.dp)
-                        ) {
-                            Text(
-                                text = stringResource(R.string.done)
-                            )
-                        }
+                        Text(
+                            text = stringResource(R.string.done)
+                        )
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun SpacerItem(modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        Spacer(modifier = Modifier.height(8.dp))
+        // Add space for the content to clear the "offline" snackbar.
+        // TODO: Check that the Scaffold handles this correctly in NiaApp
+        // if (isOffline) Spacer(modifier = Modifier.height(48.dp))
+        Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing))
     }
 }
 
@@ -393,10 +420,7 @@ fun ForYouScreenPopulatedFeed() {
         NiaTheme {
             ForYouScreen(
                 isSyncing = false,
-                onboardingUiState = OnboardingUiState.NotShown,
-                feedState = NewsFeedUiState.Success(
-                    feed = previewUserNewsResources
-                ),
+                forYouItems = previewUserNewsResources.map(ForYouItem.News::Loaded),
                 onTopicCheckedChanged = { _, _ -> },
                 saveFollowedTopics = {},
                 onNewsResourcesCheckedChanged = { _, _ -> }
@@ -412,10 +436,7 @@ fun ForYouScreenOfflinePopulatedFeed() {
         NiaTheme {
             ForYouScreen(
                 isSyncing = false,
-                onboardingUiState = OnboardingUiState.NotShown,
-                feedState = NewsFeedUiState.Success(
-                    feed = previewUserNewsResources
-                ),
+                forYouItems = emptyList(),
                 onTopicCheckedChanged = { _, _ -> },
                 saveFollowedTopics = {},
                 onNewsResourcesCheckedChanged = { _, _ -> }
@@ -431,12 +452,7 @@ fun ForYouScreenTopicSelection() {
         NiaTheme {
             ForYouScreen(
                 isSyncing = false,
-                onboardingUiState = OnboardingUiState.Shown(
-                    topics = previewTopics.map { FollowableTopic(it, false) },
-                ),
-                feedState = NewsFeedUiState.Success(
-                    feed = previewUserNewsResources
-                ),
+                forYouItems = emptyList(),
                 onTopicCheckedChanged = { _, _ -> },
                 saveFollowedTopics = {},
                 onNewsResourcesCheckedChanged = { _, _ -> }
@@ -452,8 +468,7 @@ fun ForYouScreenLoading() {
         NiaTheme {
             ForYouScreen(
                 isSyncing = false,
-                onboardingUiState = OnboardingUiState.Loading,
-                feedState = NewsFeedUiState.Loading,
+                forYouItems = emptyList(),
                 onTopicCheckedChanged = { _, _ -> },
                 saveFollowedTopics = {},
                 onNewsResourcesCheckedChanged = { _, _ -> }
@@ -469,10 +484,7 @@ fun ForYouScreenPopulatedAndLoading() {
         NiaTheme {
             ForYouScreen(
                 isSyncing = true,
-                onboardingUiState = OnboardingUiState.Loading,
-                feedState = NewsFeedUiState.Success(
-                    feed = previewUserNewsResources
-                ),
+                forYouItems = emptyList(),
                 onTopicCheckedChanged = { _, _ -> },
                 saveFollowedTopics = {},
                 onNewsResourcesCheckedChanged = { _, _ -> }

--- a/feature/topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt
@@ -19,6 +19,7 @@ package com.google.samples.apps.nowinandroid.feature.topic
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.samples.apps.nowinandroid.core.data.repository.NewsResourceQuery
 import com.google.samples.apps.nowinandroid.core.data.repository.TopicsRepository
 import com.google.samples.apps.nowinandroid.core.data.repository.UserDataRepository
 import com.google.samples.apps.nowinandroid.core.decoder.StringDecoder
@@ -64,7 +65,7 @@ class TopicViewModel @Inject constructor(
     val newUiState: StateFlow<NewsUiState> = newsUiState(
         topicId = topicArgs.topicId,
         userDataRepository = userDataRepository,
-        getSaveableNewsResources = getSaveableNewsResources
+        getUserNewsResources = getSaveableNewsResources
     )
         .stateIn(
             scope = viewModelScope,
@@ -130,12 +131,14 @@ private fun topicUiState(
 
 private fun newsUiState(
     topicId: String,
-    getSaveableNewsResources: GetUserNewsResourcesUseCase,
+    getUserNewsResources: GetUserNewsResourcesUseCase,
     userDataRepository: UserDataRepository,
 ): Flow<NewsUiState> {
     // Observe news
-    val newsStream: Flow<List<UserNewsResource>> = getSaveableNewsResources(
-        filterTopicIds = setOf(element = topicId),
+    val newsStream: Flow<List<UserNewsResource>> = getUserNewsResources(
+        NewsResourceQuery(
+            filterTopicIds = setOf(element = topicId)
+        ),
     )
 
     // Observe bookmarks


### PR DESCRIPTION
This is a draft PR. All tests do not currently pass.

This PR uses the `ViewHolder` pattern for the rendering of lists in the `ForYou` and `Bookmarks` screens.

At the moment, we use the `LazyGridScope.newsFeed(...)` extension to reuse the news feed across different screens. The ViewHolder pattern from the RecyclerView seems to do this just as well if not better bc:

###  Return of control to the call site

The use of the ViewHolder pattern returns control of the behavior and appearance of the list to the call site. The animateItemPlacement modifier can be passed to list items now allowing for animating items as the user edits the list either by changing interests or bookmarking items. This allows us to pass modifiers to each item in the grid. In the case of the PR, it's the 1animateItemContent()` modifier:

```kotlin
itemContent = { item ->
                when (item) {
                    is ForYouItem.News -> when (item) {
                        is ForYouItem.News.Loading -> Unit
                        is ForYouItem.News.Loaded -> NewsItem(
                            modifier = Modifier.animateItemPlacement(),
                            ...,
                        )
                    }
                    is ForYouItem.OnBoarding -> OnboardingItem(
                        ...
                        interestsItemModifier = Modifier
                            .animateItemPlacement()
                    )
                }
            }
```


### Code portability
Reuse of the news item is no longer confined to the LazyGridScope.

### Code readability

The list rendered is exposed as state in a single list from the screen level state holder. Anyone reading the code can immediately see that the screen presents a heterogenous list:

```kotlin
    val forYouItems: StateFlow<List<ForYouItem>> =
        combine(
            onboardingItems,
            newsItems,
            List<ForYouItem>::plus
        )
            .stateIn(
                scope = viewModelScope,
                started = SharingStarted.WhileSubscribed(5_000),
                initialValue = listOf(
                    ForYouItem.OnBoarding(OnboardingUiState.Loading),
                    ForYouItem.News.Loading,
                )
            )
```

