### PR TITLE
Android-CI workflow -> GMD refactor

### DIFF
--- a/.github/workflows/AndroidCIWithGmd.yaml
+++ b/.github/workflows/AndroidCIWithGmd.yaml
@@ -9,14 +9,14 @@ on:
 jobs:
 
   android-ci:
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
     - uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
         java-version: '11'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Run instrumented tests with GMD
       continue-on-error: true

--- a/.github/workflows/AndroidCIWithGmd.yaml
+++ b/.github/workflows/AndroidCIWithGmd.yaml
@@ -12,20 +12,24 @@ jobs:
     runs-on: macos-12
 
     steps:
-    - uses: actions/setup-java@v3
-      with:
-        distribution: 'zulu'
-        java-version: '11'
-    - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - uses: actions/checkout@v3
 
-    - name: Run instrumented tests with GMD
-      continue-on-error: true
-      run: ./gradlew cleanManagedDevices --unused-only && ./gradlew pixel4api30DemoDebugAndroidTest -Dorg.gradle.workers.max=1  -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true --info
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
 
-    - name: Upload test reports
-      if: success() || failure()
-      uses: actions/upload-artifact@v3
-      with:
-        name: test-reports
-        path: |
-          '**/*/build/reports/androidTests/'
+      - name: Run instrumented tests with GMD
+        run: ./gradlew cleanManagedDevices --unused-only &&
+          ./gradlew pixel4api30DemoDebugAndroidTest -Dorg.gradle.workers.max=1
+          -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true --info
+
+      - name: Upload test reports
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-reports
+          path: |
+            '**/*/build/reports/androidTests/'

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import com.google.samples.apps.nowinandroid.NiaBuildType
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id("nowinandroid.android.application")
@@ -76,7 +77,7 @@ android {
         // TODO: Convert it as a convention plugin once Flamingo goes out (https://github.com/android/nowinandroid/issues/523)
         managedDevices {
             devices {
-                maybeCreate<com.android.build.api.dsl.ManagedVirtualDevice>("pixel4api30").apply {
+                maybeCreate<ManagedVirtualDevice>("pixel4api30").apply {
                     device = "Pixel 4"
                     apiLevel = 30
                     // ATDs currently support only API level 30.

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 // TODO: Remove once https://youtrack.jetbrains.com/issue/KTIJ-19369 is fixed
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
@@ -31,7 +34,8 @@ android {
             arg("room.schemaLocation", "$projectDir/schemas")
         }
 
-        testInstrumentationRunner = "com.google.samples.apps.nowinandroid.core.testing.NiaTestRunner"
+        testInstrumentationRunner =
+            "com.google.samples.apps.nowinandroid.core.testing.NiaTestRunner"
     }
     namespace = "com.google.samples.apps.nowinandroid.core.database"
 
@@ -39,7 +43,7 @@ android {
         // TODO: Convert it as a convention plugin once Flamingo goes out (https://github.com/android/nowinandroid/issues/523)
         managedDevices {
             devices {
-                maybeCreate<com.android.build.api.dsl.ManagedVirtualDevice>("pixel4api30").apply {
+                maybeCreate<ManagedVirtualDevice>("pixel4api30").apply {
                     device = "Pixel 4"
                     apiLevel = 30
                     // ATDs currently support only API level 30.

--- a/feature/bookmarks/build.gradle.kts
+++ b/feature/bookmarks/build.gradle.kts
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     id("nowinandroid.android.feature")
     id("nowinandroid.android.library.compose")
@@ -26,7 +29,7 @@ android {
         // TODO: Convert it as a convention plugin once Flamingo goes out (https://github.com/android/nowinandroid/issues/523)
         managedDevices {
             devices {
-                maybeCreate<com.android.build.api.dsl.ManagedVirtualDevice>("pixel4api30").apply {
+                maybeCreate<ManagedVirtualDevice>("pixel4api30").apply {
                     device = "Pixel 4"
                     apiLevel = 30
                     // ATDs currently support only API level 30.

--- a/feature/foryou/build.gradle.kts
+++ b/feature/foryou/build.gradle.kts
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     id("nowinandroid.android.feature")
     id("nowinandroid.android.library.compose")
@@ -26,7 +29,7 @@ android {
         // TODO: Convert it as a convention plugin once Flamingo goes out (https://github.com/android/nowinandroid/issues/523)
         managedDevices {
             devices {
-                maybeCreate<com.android.build.api.dsl.ManagedVirtualDevice>("pixel4api30").apply {
+                maybeCreate<ManagedVirtualDevice>("pixel4api30").apply {
                     device = "Pixel 4"
                     apiLevel = 30
                     // ATDs currently support only API level 30.

--- a/feature/interests/build.gradle.kts
+++ b/feature/interests/build.gradle.kts
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     id("nowinandroid.android.feature")
     id("nowinandroid.android.library.compose")
@@ -25,7 +28,7 @@ android {
         // TODO: Convert it as a convention plugin once Flamingo goes out (https://github.com/android/nowinandroid/issues/523)
         managedDevices {
             devices {
-                maybeCreate<com.android.build.api.dsl.ManagedVirtualDevice>("pixel4api30").apply {
+                maybeCreate<ManagedVirtualDevice>("pixel4api30").apply {
                     device = "Pixel 4"
                     apiLevel = 30
                     // ATDs currently support only API level 30.

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     id("nowinandroid.android.feature")
     id("nowinandroid.android.library.compose")
@@ -26,7 +29,7 @@ android {
         // TODO: Convert it as a convention plugin once Flamingo goes out (https://github.com/android/nowinandroid/issues/523)
         managedDevices {
             devices {
-                maybeCreate<com.android.build.api.dsl.ManagedVirtualDevice>("pixel4api30").apply {
+                maybeCreate<ManagedVirtualDevice>("pixel4api30").apply {
                     device = "Pixel 4"
                     apiLevel = 30
                     // ATDs currently support only API level 30.

--- a/feature/topic/build.gradle.kts
+++ b/feature/topic/build.gradle.kts
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     id("nowinandroid.android.feature")
     id("nowinandroid.android.library.compose")
@@ -26,7 +29,7 @@ android {
         // TODO: Convert it as a convention plugin once Flamingo goes out (https://github.com/android/nowinandroid/issues/523)
         managedDevices {
             devices {
-                maybeCreate<com.android.build.api.dsl.ManagedVirtualDevice>("pixel4api30").apply {
+                maybeCreate<ManagedVirtualDevice>("pixel4api30").apply {
                     device = "Pixel 4"
                     apiLevel = 30
                     // ATDs currently support only API level 30.


### PR DESCRIPTION
This PR is about updating the operating system to macOS-12 as the previous one was going to be deprecated, as well as updating the checkout to v3 to avoid the warnings in the panel; adding setup SDK action to accept the license which was missing from the beginning.

I also added imports instead of adding them directly with the codes.

As a reference, there was another PR with a similar topic, but it wasn't complete: https://github.com/android/nowinandroid/pull/483
