### PR TITLE
Fix formatting for a trailing comma

### DIFF
--- a/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -306,7 +306,7 @@ private fun TopicSelection(
     ) {
         items(
             items = onboardingUiState.topics,
-            key = { it.topic.id }
+            key = { it.topic.id },
         ) {
             SingleTopicButton(
                 name = it.topic.name,


### PR DESCRIPTION
Follow-up to #543, adds a missing comma to a file that was changed while that PR was in the process of being submitted