### PR TITLE
Fix renamed class markdown in ArchitectureLearningJourney.md

### DIFF
--- a/docs/ArchitectureLearningJourney.md
+++ b/docs/ArchitectureLearningJourney.md
@@ -70,7 +70,7 @@ Here's what's happening in each step. The easiest way to find the associated cod
   <tr>
    <td>2
    </td>
-   <td>The <code>ForYouViewModel</code> calls <code>GetSaveableNewsResourcesUseCase</code> to obtain a stream of news resources with their bookmarked/saved state. No items will be emitted into this stream until both the user and news repositories emit an item. While waiting, the feed state is set to <code>Loading</code>.
+   <td>The <code>ForYouViewModel</code> calls <code>GetUserNewsResourcesUseCase</code> to obtain a stream of news resources with their bookmarked/saved state. No items will be emitted into this stream until both the user and news repositories emit an item. While waiting, the feed state is set to <code>Loading</code>.
    </td>
    <td>Search for usages of <code>NewsFeedUiState.Loading</code>
    </td>
@@ -142,9 +142,9 @@ Here's what's happening in each step. The easiest way to find the associated cod
   <tr>
    <td>11
    </td>
-   <td><code>GetSaveableNewsResourcesUseCase</code> combines the list of news resources with the user data to emit a list of <code>SaveableNewsResource</code>s.  
+   <td><code>GetUserNewsResourcesUseCase</code> combines the list of news resources with the user data to emit a list of <code>SaveableNewsResource</code>s.  
    </td>
-   <td><code>GetSaveableNewsResourcesUseCase.invoke</code>
+   <td><code>GetUserNewsResourcesUseCase.invoke</code>
    </td>
   </tr>
   <tr>
@@ -254,7 +254,7 @@ The [domain layer](https://developer.android.com/topic/architecture/domain-layer
 
 These use cases are used to simplify and remove duplicate logic from ViewModels. They typically combine and transform data from repositories. 
 
-For example, `GetSaveableNewsResourcesUseCase` combines a stream (implemented using `Flow`) of `NewsResource`s from a `NewsRepository` with a stream of `UserData` objects from a `UserDataRepository` to create a stream of `SaveableNewsResource`s. This stream is used by various ViewModels to display news resources on screen with their bookmarked state.  
+For example, `GetUserNewsResourcesUseCase` combines a stream (implemented using `Flow`) of `NewsResource`s from a `NewsRepository` with a stream of `UserData` objects from a `UserDataRepository` to create a stream of `SaveableNewsResource`s. This stream is used by various ViewModels to display news resources on screen with their bookmarked state.  
 
 Notably, the domain layer in Now in Android _does not_ (for now) contain any use cases for event handling. Events are handled by the UI layer calling methods on repositories directly.
 

--- a/docs/ArchitectureLearningJourney.md
+++ b/docs/ArchitectureLearningJourney.md
@@ -254,7 +254,7 @@ The [domain layer](https://developer.android.com/topic/architecture/domain-layer
 
 These use cases are used to simplify and remove duplicate logic from ViewModels. They typically combine and transform data from repositories. 
 
-For example, `GetUserNewsResourcesUseCase` combines a stream (implemented using `Flow`) of `NewsResource`s from a `NewsRepository` with a stream of `UserData` objects from a `UserDataRepository` to create a stream of `SaveableNewsResource`s. This stream is used by various ViewModels to display news resources on screen with their bookmarked state.  
+For example, `GetUserNewsResourcesUseCase` combines a stream (implemented using `Flow`) of `NewsResource`s from a `NewsRepository` with a stream of `UserData` objects from a `UserDataRepository` to create a stream of `UserNewsResource`s. This stream is used by various ViewModels to display news resources on screen with their bookmarked state.  
 
 Notably, the domain layer in Now in Android _does not_ (for now) contain any use cases for event handling. Events are handled by the UI layer calling methods on repositories directly.
 

--- a/docs/ArchitectureLearningJourney.md
+++ b/docs/ArchitectureLearningJourney.md
@@ -142,7 +142,7 @@ Here's what's happening in each step. The easiest way to find the associated cod
   <tr>
    <td>11
    </td>
-   <td><code>GetUserNewsResourcesUseCase</code> combines the list of news resources with the user data to emit a list of <code>SaveableNewsResource</code>s.  
+   <td><code>GetUserNewsResourcesUseCase</code> combines the list of news resources with the user data to emit a list of <code>UserNewsResource</code>s.  
    </td>
    <td><code>GetUserNewsResourcesUseCase.invoke</code>
    </td>


### PR DESCRIPTION
Since GetSaveableNewsResourcesUseCase class is renamed to GetUserNewsResourcesUseCase [(commit)](https://github.com/android/nowinandroid/commit/464f28a07fac87d088bac975c8c29400aa211ae7), I fixed markdown in ArchitectureLearningJourney.md
