### PR TITLE
Use only width to determine navigation UI

### DIFF
--- a/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationUiTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationUiTest.kt
@@ -91,7 +91,7 @@ class NavigationUiTest {
     }
 
     @Test
-    fun mediumWidth_compactHeight_showsNavigationBar() {
+    fun mediumWidth_compactHeight_showsNavigationRail() {
         composeTestRule.setContent {
             TestHarness(size = DpSize(610.dp, 400.dp)) {
                 BoxWithConstraints {
@@ -105,12 +105,12 @@ class NavigationUiTest {
             }
         }
 
-        composeTestRule.onNodeWithTag("NiaBottomBar").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("NiaNavRail").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("NiaNavRail").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("NiaBottomBar").assertDoesNotExist()
     }
 
     @Test
-    fun expandedWidth_compactHeight_showsNavigationBar() {
+    fun expandedWidth_compactHeight_showsNavigationRail() {
         composeTestRule.setContent {
             TestHarness(size = DpSize(900.dp, 400.dp)) {
                 BoxWithConstraints {
@@ -124,8 +124,8 @@ class NavigationUiTest {
             }
         }
 
-        composeTestRule.onNodeWithTag("NiaBottomBar").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("NiaNavRail").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("NiaNavRail").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("NiaBottomBar").assertDoesNotExist()
     }
 
     @Test

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
@@ -87,8 +87,7 @@ class NiaAppState(
         private set
 
     val shouldShowBottomBar: Boolean
-        get() = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact ||
-            windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
+        get() = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
 
     val shouldShowNavRail: Boolean
         get() = !shouldShowBottomBar

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
@@ -16,7 +16,6 @@
 
 package com.google.samples.apps.nowinandroid.ui
 
-import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable


### PR DESCRIPTION
This is to line up with the Material recommendation for the navigation UI.