### PR TITLE
Fix settings dialog dismissed test on non-portrait phones

### DIFF
--- a/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
@@ -19,9 +19,11 @@ package com.google.samples.apps.nowinandroid.ui
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onLast
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -213,7 +215,12 @@ class NavigationTest {
             onNodeWithText(ok).performClick()
 
             // Check that the saved screen is still visible and selected.
-            onAllNodesWithText(saved).onLast().assertIsSelected()
+            onNode(
+                hasText(saved) and
+                    hasAnyAncestor(
+                        hasTestTag("NiaBottomBar") or hasTestTag("NiaNavRail"),
+                    ),
+            ).assertIsSelected()
         }
     }
 


### PR DESCRIPTION
Fixes #554 by using a more general selector for the saved navigation item that doesn't assume that the navigation bar is visible. This ensures that the test passes when running on a device where the navigation rail is displayed instead.