### PR TITLE
Update docs/ArchitectureLearningJourney.md - Writing data

### DIFF
--- a/docs/ArchitectureLearningJourney.md
+++ b/docs/ArchitectureLearningJourney.md
@@ -192,9 +192,9 @@ Whenever the list of topics changes (for example, when a new topic is added), th
 
 To write data, the repository provides suspend functions. It is up to the caller to ensure that their execution is suitably scoped.
 
-_Example: Follow a topic_
+_Example: Follow a set of topics_
 
-Simply call `TopicsRepository.setFollowedTopicId` with the ID of the topic which the user wishes to follow.
+Simply call `UserDataRepository.setFollowedTopicIds` with the set of IDs of the topics the user wishes to follow.
 
 
 ### Data sources

--- a/docs/ArchitectureLearningJourney.md
+++ b/docs/ArchitectureLearningJourney.md
@@ -309,7 +309,7 @@ User actions are communicated from UI elements to ViewModels using regular metho
 
 **Example: Following a topic**
 
-The `InterestsScreen` takes a lambda expression named `followTopic` which is supplied from `InterestsViewModel.followTopic`. Each time the user taps on a topic to follow this method is called. The ViewModel then processes this action by informing the topics repository.
+The `InterestsScreen` takes a lambda expression named `followTopic` which is supplied from `InterestsViewModel.followTopic`. Each time the user taps on a topic to follow this method is called. The ViewModel then processes this action by informing the user data repository.
 
 
 ## Further reading

--- a/docs/ArchitectureLearningJourney.md
+++ b/docs/ArchitectureLearningJourney.md
@@ -192,9 +192,9 @@ Whenever the list of topics changes (for example, when a new topic is added), th
 
 To write data, the repository provides suspend functions. It is up to the caller to ensure that their execution is suitably scoped.
 
-_Example: Follow a set of topics_
+_Example: Follow a topic_
 
-Simply call `UserDataRepository.setFollowedTopicIds` with the set of IDs of the topics the user wishes to follow.
+Simply call `UserDataRepository.toggleFollowedTopicId` with the ID of the topic the user wishes to follow and `followed=true` to indicate that the topic should be followed (use `false` to unfollow a topic).
 
 
 ### Data sources


### PR DESCRIPTION
Love the learning journey documentation, but noticed an error. 

There is no `setFollowedTopicId` exposed by `TopicsRepository`. 

This section should instead refer to: 
`UserDataRepository.setFollowedTopicIds(followedTopicIds: Set<String>)` 
or if the single topic form is preferred: 
`UserDataRepository.toggleFollowedTopicId(followedTopicId: String, followed: Boolean)`.
