### PR TITLE
Switch GMD to use a convention plugin

### DIFF
--- a/.github/workflows/AndroidCIWithGmd.yaml
+++ b/.github/workflows/AndroidCIWithGmd.yaml
@@ -10,6 +10,9 @@ jobs:
 
   android-ci:
     runs-on: macos-12
+    strategy:
+      matrix:
+        device-config: [ "pixel4api30aospatd" ]
 
     steps:
       - uses: actions/setup-java@v3
@@ -23,7 +26,7 @@ jobs:
 
       - name: Run instrumented tests with GMD
         run: ./gradlew cleanManagedDevices --unused-only &&
-          ./gradlew pixel4api30DemoDebugAndroidTest -Dorg.gradle.workers.max=1
+          ./gradlew ${{ matrix.device-config }}DemoDebugAndroidTest -Dorg.gradle.workers.max=1
           -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true --info
 
       - name: Upload test reports

--- a/.run/Generate Demo Baseline Profile.run.xml
+++ b/.run/Generate Demo Baseline Profile.run.xml
@@ -34,7 +34,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value=":benchmark:pixel6Api31DemoBenchmarkAndroidTest" />
+          <option value=":benchmark:pixel6Api31atdDemoBenchmarkAndroidTest" />
           <option value="--rerun" />
           <option value="--enable-display" />
         </list>

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -65,19 +65,6 @@ android {
 
     targetProjectPath = ":app"
     experimentalProperties["android.experimental.self-instrumenting"] = true
-
-    testOptions {
-        // TODO: Convert it as a convention plugin once Flamingo goes out (https://github.com/android/nowinandroid/issues/523)
-        managedDevices {
-            devices {
-                create<ManagedVirtualDevice>("pixel6Api31") {
-                    device = "Pixel 6"
-                    apiLevel = 31
-                    systemImageSource = "aosp"
-                }
-            }
-        }
-    }
 }
 
 dependencies {

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -17,6 +17,7 @@
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.dsl.ApplicationExtension
 import com.google.samples.apps.nowinandroid.configureFlavors
+import com.google.samples.apps.nowinandroid.configureGradleManagedDevices
 import com.google.samples.apps.nowinandroid.configureKotlinAndroid
 import com.google.samples.apps.nowinandroid.configurePrintApksTask
 import org.gradle.api.Plugin
@@ -35,6 +36,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 configureKotlinAndroid(this)
                 defaultConfig.targetSdk = 33
                 configureFlavors(this)
+                configureGradleManagedDevices(this)
             }
             extensions.configure<ApplicationAndroidComponentsExtension> {
                 configurePrintApksTask(this)

--- a/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
@@ -14,7 +14,9 @@
  *   limitations under the License.
  */
 
+import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.gradle.LibraryExtension
+import com.google.samples.apps.nowinandroid.configureGradleManagedDevices
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
@@ -35,6 +37,7 @@ class AndroidFeatureConventionPlugin : Plugin<Project> {
                     testInstrumentationRunner =
                         "com.google.samples.apps.nowinandroid.core.testing.NiaTestRunner"
                 }
+                configureGradleManagedDevices(this)
             }
 
             val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -18,6 +18,7 @@ import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.gradle.LibraryExtension
 import com.google.samples.apps.nowinandroid.configureFlavors
+import com.google.samples.apps.nowinandroid.configureGradleManagedDevices
 import com.google.samples.apps.nowinandroid.configureKotlinAndroid
 import com.google.samples.apps.nowinandroid.configurePrintApksTask
 import org.gradle.api.Plugin
@@ -40,6 +41,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 configureKotlinAndroid(this)
                 defaultConfig.targetSdk = 33
                 configureFlavors(this)
+                configureGradleManagedDevices(this)
             }
             extensions.configure<LibraryAndroidComponentsExtension> {
                 configurePrintApksTask(this)

--- a/build-logic/convention/src/main/kotlin/AndroidTestConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidTestConventionPlugin.kt
@@ -15,6 +15,7 @@
  */
 
 import com.android.build.gradle.TestExtension
+import com.google.samples.apps.nowinandroid.configureGradleManagedDevices
 import com.google.samples.apps.nowinandroid.configureKotlinAndroid
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -31,6 +32,7 @@ class AndroidTestConventionPlugin : Plugin<Project> {
             extensions.configure<TestExtension> {
                 configureKotlinAndroid(this)
                 defaultConfig.targetSdk = 31
+                configureGradleManagedDevices(this)
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/GradleManagedDevices.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/GradleManagedDevices.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid
+
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.ManagedVirtualDevice
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.invoke
+import java.util.Locale
+
+/**
+ * Configure project for Gradle managed devices
+ */
+internal fun configureGradleManagedDevices(
+    commonExtension: CommonExtension<*, *, *, *>,
+) {
+    val deviceConfigs = listOf(
+        DeviceConfig("Pixel 4", 30, "aosp-atd"),
+        DeviceConfig("Pixel 6", 31, "aosp")
+    )
+
+    commonExtension.testOptions {
+        managedDevices {
+            devices {
+                deviceConfigs.forEach { deviceConfig ->
+                    maybeCreate(deviceConfig.taskName, ManagedVirtualDevice::class.java).apply {
+                        device = deviceConfig.device
+                        apiLevel = deviceConfig.apiLevel
+                        systemImageSource = deviceConfig.systemImageSource
+                    }
+                }
+            }
+        }
+    }
+}
+
+private data class DeviceConfig(
+    val device: String,
+    val apiLevel: Int,
+    val systemImageSource: String,
+) {
+    val taskName = buildString {
+        append(device.toLowerCase(Locale.ROOT).replace(" ", ""))
+        append("api")
+        append(apiLevel.toString())
+        append(systemImageSource.replace("-", ""))
+    }
+}

--- a/feature/bookmarks/build.gradle.kts
+++ b/feature/bookmarks/build.gradle.kts
@@ -24,20 +24,6 @@ plugins {
 
 android {
     namespace = "com.google.samples.apps.nowinandroid.feature.bookmarks"
-
-    testOptions {
-        // TODO: Convert it as a convention plugin once Flamingo goes out (https://github.com/android/nowinandroid/issues/523)
-        managedDevices {
-            devices {
-                maybeCreate<ManagedVirtualDevice>("pixel4api30").apply {
-                    device = "Pixel 4"
-                    apiLevel = 30
-                    // ATDs currently support only API level 30.
-                    systemImageSource = "aosp-atd"
-                }
-            }
-        }
-    }
 }
 
 dependencies {

--- a/feature/foryou/build.gradle.kts
+++ b/feature/foryou/build.gradle.kts
@@ -24,20 +24,6 @@ plugins {
 
 android {
     namespace = "com.google.samples.apps.nowinandroid.feature.foryou"
-
-    testOptions {
-        // TODO: Convert it as a convention plugin once Flamingo goes out (https://github.com/android/nowinandroid/issues/523)
-        managedDevices {
-            devices {
-                maybeCreate<ManagedVirtualDevice>("pixel4api30").apply {
-                    device = "Pixel 4"
-                    apiLevel = 30
-                    // ATDs currently support only API level 30.
-                    systemImageSource = "aosp-atd"
-                }
-            }
-        }
-    }
 }
 
 dependencies {

--- a/feature/interests/build.gradle.kts
+++ b/feature/interests/build.gradle.kts
@@ -23,18 +23,4 @@ plugins {
 }
 android {
     namespace = "com.google.samples.apps.nowinandroid.feature.interests"
-
-    testOptions {
-        // TODO: Convert it as a convention plugin once Flamingo goes out (https://github.com/android/nowinandroid/issues/523)
-        managedDevices {
-            devices {
-                maybeCreate<ManagedVirtualDevice>("pixel4api30").apply {
-                    device = "Pixel 4"
-                    apiLevel = 30
-                    // ATDs currently support only API level 30.
-                    systemImageSource = "aosp-atd"
-                }
-            }
-        }
-    }
 }

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -24,18 +24,4 @@ plugins {
 
 android {
     namespace = "com.google.samples.apps.nowinandroid.feature.settings"
-
-    testOptions {
-        // TODO: Convert it as a convention plugin once Flamingo goes out (https://github.com/android/nowinandroid/issues/523)
-        managedDevices {
-            devices {
-                maybeCreate<ManagedVirtualDevice>("pixel4api30").apply {
-                    device = "Pixel 4"
-                    apiLevel = 30
-                    // ATDs currently support only API level 30.
-                    systemImageSource = "aosp-atd"
-                }
-            }
-        }
-    }
 }

--- a/feature/topic/build.gradle.kts
+++ b/feature/topic/build.gradle.kts
@@ -24,20 +24,6 @@ plugins {
 
 android {
     namespace = "com.google.samples.apps.nowinandroid.feature.topic"
-
-    testOptions {
-        // TODO: Convert it as a convention plugin once Flamingo goes out (https://github.com/android/nowinandroid/issues/523)
-        managedDevices {
-            devices {
-                maybeCreate<ManagedVirtualDevice>("pixel4api30").apply {
-                    device = "Pixel 4"
-                    apiLevel = 30
-                    // ATDs currently support only API level 30.
-                    systemImageSource = "aosp-atd"
-                }
-            }
-        }
-    }
 }
 
 dependencies {


### PR DESCRIPTION
Pulls out the GMD configuration into a convention plugin, so that we have a single place to define devices and configure all modules to use them.