### PR TITLE
Add Pixel C API 30 emulator to CI

### DIFF
--- a/.github/workflows/AndroidCIWithGmd.yaml
+++ b/.github/workflows/AndroidCIWithGmd.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        device-config: [ "pixel4api30aospatd" ]
+        device-config: [ "pixel4api30aospatd", "pixelcapi30aospatd" ]
 
     steps:
       - uses: actions/setup-java@v3

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/GradleManagedDevices.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/GradleManagedDevices.kt
@@ -30,7 +30,8 @@ internal fun configureGradleManagedDevices(
 ) {
     val deviceConfigs = listOf(
         DeviceConfig("Pixel 4", 30, "aosp-atd"),
-        DeviceConfig("Pixel 6", 31, "aosp")
+        DeviceConfig("Pixel 6", 31, "aosp"),
+        DeviceConfig("Pixel C", 30, "aosp-atd"),
     )
 
     commonExtension.testOptions {


### PR DESCRIPTION
Adds a Pixel C API 30 emulator to CI to run all tests on a tablet.

Fixes #353 