### PR TITLE
Replace deprecated package with namespace

### DIFF
--- a/ui-test-hilt-manifest/build.gradle.kts
+++ b/ui-test-hilt-manifest/build.gradle.kts
@@ -19,6 +19,10 @@ plugins {
     id("dagger.hilt.android.plugin")
 }
 
+android {
+    namespace = "com.google.samples.apps.nowinandroid.uitesthiltmanifest"
+}
+
 dependencies {
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)

--- a/ui-test-hilt-manifest/src/main/AndroidManifest.xml
+++ b/ui-test-hilt-manifest/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.apps.nowinandroid.uitesthiltmanifest">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <activity android:name=".HiltComponentActivity" />


### PR DESCRIPTION
```
package="com.google.samples.apps.nowinandroid.uitesthiltmanifest" found in source AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
```

For reference, this work was started in all these PRs:

- https://github.com/android/nowinandroid/pull/32
- https://github.com/android/nowinandroid/pull/333
- https://github.com/android/nowinandroid/pull/368
- https://github.com/android/nowinandroid/pull/460

This should be the last time we have to do this :)