### PR TITLE
Increase touch target for radio button and text link in Settings page

### DIFF
--- a/feature/settings/src/main/java/com/google/samples/apps/nowinandroid/feature/settings/SettingsDialog.kt
+++ b/feature/settings/src/main/java/com/google/samples/apps/nowinandroid/feature/settings/SettingsDialog.kt
@@ -227,7 +227,7 @@ fun SettingsDialogThemeChooserRow(
                 role = Role.RadioButton,
                 onClick = onClick,
             )
-            .padding(8.dp),
+            .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         RadioButton(
@@ -285,6 +285,7 @@ private fun TextLink(text: String, url: String) {
         style = MaterialTheme.typography.labelLarge,
         color = MaterialTheme.colorScheme.primary,
         modifier = Modifier
+            .padding(vertical = 8.dp)
             .clickable {
                 ContextCompat.startActivity(context, launchResourceIntent, null)
             },


### PR DESCRIPTION
| Before | After |
| ------ | ---- |
| ![Screenshot_20230207-143619](https://user-images.githubusercontent.com/10851617/217170259-36957f6a-98ce-45db-8473-4cc27bb7c10a.png) | ![Screenshot_20230207-144207](https://user-images.githubusercontent.com/10851617/217169787-00f44862-bbb5-4b91-a6a4-0449a39ba359.png) |
| ![Screenshot_20230207-143613](https://user-images.githubusercontent.com/10851617/217170049-da98e2bf-e39e-4754-9ffa-405533712850.png) | ![Screenshot_20230207-144218](https://user-images.githubusercontent.com/10851617/217170177-48d82b27-1a0c-43b8-b7f8-9aa70318c458.png) |


