### PR TITLE
Provide true to LocalInspectionMode

### DIFF
--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -301,14 +302,18 @@ private fun ExpandedNewsResourcePreview(
     @PreviewParameter(UserNewsResourcePreviewParameterProvider::class)
     userNewsResources: List<UserNewsResource>,
 ) {
-    NiaTheme {
-        Surface {
-            NewsResourceCardExpanded(
-                userNewsResource = userNewsResources[0],
-                isBookmarked = true,
-                onToggleBookmark = {},
-                onClick = {},
-            )
+    CompositionLocalProvider(
+        LocalInspectionMode provides true
+    ) {
+        NiaTheme {
+            Surface {
+                NewsResourceCardExpanded(
+                    userNewsResource = userNewsResources[0],
+                    isBookmarked = true,
+                    onToggleBookmark = {},
+                    onClick = {},
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
When deploying the preview to the emulator, the image was not displayed.
So I fixed it so that the image set in the placeholder can be displayed in the emulator as well.

|before|after|
|---|---|
|![Screenshot_20230208_215957](https://user-images.githubusercontent.com/66447334/217550542-c160bb65-8229-4ea6-952e-1034c8d1d2a2.png)|![Screenshot_20230208_220014](https://user-images.githubusercontent.com/66447334/217550648-e35df1b7-3107-4885-b72c-56a05123d8f6.png)|

