### PR TITLE
Improve network pooling and avoid startup image fetches.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -129,7 +129,6 @@ dependencies {
     implementation(libs.androidx.profileinstaller)
 
     implementation(libs.coil.kt)
-    implementation(libs.coil.kt.svg)
 }
 
 // androidx.test is forcing JUnit, 4.12. This forces it to use 4.13

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/NiaApplication.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/NiaApplication.kt
@@ -19,33 +19,24 @@ package com.google.samples.apps.nowinandroid
 import android.app.Application
 import coil.ImageLoader
 import coil.ImageLoaderFactory
-import coil.decode.SvgDecoder
 import com.google.samples.apps.nowinandroid.sync.initializers.Sync
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
+import javax.inject.Provider
 
 /**
  * [Application] class for NiA
  */
 @HiltAndroidApp
 class NiaApplication : Application(), ImageLoaderFactory {
+    @Inject
+    lateinit var imageLoader: Provider<ImageLoader>
+
     override fun onCreate() {
         super.onCreate()
         // Initialize Sync; the system responsible for keeping data in the app up to date.
         Sync.initialize(context = this)
     }
 
-    /**
-     * Since we're displaying SVGs in the app, Coil needs an ImageLoader which supports this
-     * format. During Coil's initialization it will call `applicationContext.newImageLoader()` to
-     * obtain an ImageLoader.
-     *
-     * @see <a href="https://github.com/coil-kt/coil/blob/main/coil-singleton/src/main/java/coil/Coil.kt">Coil</a>
-     */
-    override fun newImageLoader(): ImageLoader {
-        return ImageLoader.Builder(this)
-            .components {
-                add(SvgDecoder.Factory())
-            }
-            .build()
-    }
+    override fun newImageLoader(): ImageLoader = imageLoader.get()
 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -51,4 +51,7 @@ dependencies {
     implementation(libs.okhttp.logging)
     implementation(libs.retrofit.core)
     implementation(libs.retrofit.kotlin.serialization)
+
+    implementation(libs.coil.kt)
+    implementation(libs.coil.kt.svg)
 }

--- a/core/network/src/main/java/com/google/samples/apps/nowinandroid/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/google/samples/apps/nowinandroid/core/network/di/NetworkModule.kt
@@ -17,6 +17,10 @@
 package com.google.samples.apps.nowinandroid.core.network.di
 
 import android.content.Context
+import coil.ImageLoader
+import coil.decode.SvgDecoder
+import coil.util.DebugLogger
+import com.google.samples.apps.nowinandroid.core.network.BuildConfig
 import com.google.samples.apps.nowinandroid.core.network.fake.FakeAssetManager
 import dagger.Module
 import dagger.Provides
@@ -24,6 +28,9 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import javax.inject.Singleton
 
 @Module
@@ -41,4 +48,44 @@ object NetworkModule {
     fun providesFakeAssetManager(
         @ApplicationContext context: Context,
     ): FakeAssetManager = FakeAssetManager(context.assets::open)
+
+    @Provides
+    @Singleton
+    fun okHttpCallFactory(): Call.Factory = OkHttpClient.Builder()
+        .addInterceptor(
+            HttpLoggingInterceptor()
+                .apply {
+                    if (BuildConfig.DEBUG) {
+                        setLevel(HttpLoggingInterceptor.Level.BODY)
+                    }
+                }
+        )
+        .build()
+
+    /**
+     * Since we're displaying SVGs in the app, Coil needs an ImageLoader which supports this
+     * format. During Coil's initialization it will call `applicationContext.newImageLoader()` to
+     * obtain an ImageLoader.
+     *
+     * @see <a href="https://github.com/coil-kt/coil/blob/main/coil-singleton/src/main/java/coil/Coil.kt">Coil</a>
+     */
+    @Provides
+    @Singleton
+    fun imageLoader(
+        okHttpCallFactory: Call.Factory,
+        @ApplicationContext application: Context,
+    ): ImageLoader = ImageLoader.Builder(application)
+        .callFactory(okHttpCallFactory)
+        .components {
+            add(SvgDecoder.Factory())
+        }
+        // Assume most content images are versioned urls
+        // but some problematic images are fetching each time
+        .respectCacheHeaders(false)
+        .apply {
+            if (BuildConfig.DEBUG) {
+                logger(DebugLogger())
+            }
+        }
+        .build()
 }

--- a/core/network/src/main/java/com/google/samples/apps/nowinandroid/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/google/samples/apps/nowinandroid/core/network/di/NetworkModule.kt
@@ -58,7 +58,7 @@ object NetworkModule {
                     if (BuildConfig.DEBUG) {
                         setLevel(HttpLoggingInterceptor.Level.BODY)
                     }
-                }
+                },
         )
         .build()
 

--- a/core/network/src/main/java/com/google/samples/apps/nowinandroid/core/network/retrofit/RetrofitNiaNetwork.kt
+++ b/core/network/src/main/java/com/google/samples/apps/nowinandroid/core/network/retrofit/RetrofitNiaNetwork.kt
@@ -25,9 +25,8 @@ import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFact
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import okhttp3.Call
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -69,26 +68,19 @@ private data class NetworkResponse<T>(
     val data: T,
 )
 
+
 /**
  * [Retrofit] backed [NiaNetworkDataSource]
  */
 @Singleton
 class RetrofitNiaNetwork @Inject constructor(
     networkJson: Json,
+    okhttpCallFactory: Call.Factory
 ) : NiaNetworkDataSource {
 
     private val networkApi = Retrofit.Builder()
         .baseUrl(NiaBaseUrl)
-        .client(
-            OkHttpClient.Builder()
-                .addInterceptor(
-                    // TODO: Decide logging logic
-                    HttpLoggingInterceptor().apply {
-                        setLevel(HttpLoggingInterceptor.Level.BODY)
-                    },
-                )
-                .build(),
-        )
+        .callFactory(okhttpCallFactory)
         .addConverterFactory(
             @OptIn(ExperimentalSerializationApi::class)
             networkJson.asConverterFactory("application/json".toMediaType()),

--- a/core/network/src/main/java/com/google/samples/apps/nowinandroid/core/network/retrofit/RetrofitNiaNetwork.kt
+++ b/core/network/src/main/java/com/google/samples/apps/nowinandroid/core/network/retrofit/RetrofitNiaNetwork.kt
@@ -68,14 +68,13 @@ private data class NetworkResponse<T>(
     val data: T,
 )
 
-
 /**
  * [Retrofit] backed [NiaNetworkDataSource]
  */
 @Singleton
 class RetrofitNiaNetwork @Inject constructor(
     networkJson: Json,
-    okhttpCallFactory: Call.Factory
+    okhttpCallFactory: Call.Factory,
 ) : NiaNetworkDataSource {
 
     private val networkApi = Retrofit.Builder()


### PR DESCRIPTION
Coil and Retrofit can share an OkHttp instance, taking more advantage of connection pooling.

Also one problematic image is not cacheable, causing in my local testing a request on every app startup.

 https://developer.android.com/images/social/android-developers.png

Change-Id: If747fb0833d31ce7c9bedffd400160e979bc945e