### PR TITLE
Remove unnecessary text description for buttons on Interest page

### DIFF
--- a/feature/interests/src/main/res/values/strings.xml
+++ b/feature/interests/src/main/res/values/strings.xml
@@ -18,8 +18,8 @@
     <string name="interests">Interests</string>
     <string name="loading">Loading data</string>
     <string name="empty_header">"No available data"</string>
-    <string name="card_follow_button_content_desc">Follow interest button</string>
-    <string name="card_unfollow_button_content_desc">Unfollow interest button</string>
+    <string name="card_follow_button_content_desc">Follow interest</string>
+    <string name="card_unfollow_button_content_desc">Unfollow interest</string>
     <string name="top_app_bar_title">Interests</string>
     <string name="top_app_bar_action_menu">Menu</string>
     <string name="top_app_bar_action_search">Search</string>


### PR DESCRIPTION
TalkBack automatically appends 'button' to any `Button`s, so we don't need it in the content description