### PR TITLE
Remove newsResourceTitle from AnalyticsHelper.logNewsResourceOpened method

### DIFF
--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/AnalyticsExtensions.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/AnalyticsExtensions.kt
@@ -39,7 +39,7 @@ fun AnalyticsHelper.logScreenView(screenName: String) {
     )
 }
 
-fun AnalyticsHelper.logNewsResourceOpened(newsResourceId: String, newsResourceTitle: String) {
+fun AnalyticsHelper.logNewsResourceOpened(newsResourceId: String) {
     logEvent(
         event = AnalyticsEvent(
             type = "news_resource_opened",

--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
@@ -67,7 +67,6 @@ fun LazyGridScope.newsFeed(
                     onClick = {
                         analyticsHelper.logNewsResourceOpened(
                             newsResourceId = userNewsResource.id,
-                            newsResourceTitle = userNewsResource.title,
                         )
                         launchCustomChromeTab(context, resourceUrl, backgroundColor)
                     },

--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCardList.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCardList.kt
@@ -56,7 +56,6 @@ fun LazyListScope.userNewsResourceCardItems(
             onClick = {
                 analyticsHelper.logNewsResourceOpened(
                     newsResourceId = userNewsResource.id,
-                    newsResourceTitle = userNewsResource.title,
                 )
                 when (onItemClick) {
                     null -> launchCustomChromeTab(context, resourceUrl, backgroundColor)


### PR DESCRIPTION
The newsResourceTitle was declared as an argument, but was not used at all.
So I removed that variable for refactoring purposes.