### PR TITLE
`onItemClick` parameter removed in NewsResourceCardList

### DIFF
--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCardList.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCardList.kt
@@ -37,7 +37,6 @@ import com.google.samples.apps.nowinandroid.core.domain.model.UserNewsResource
 fun LazyListScope.userNewsResourceCardItems(
     items: List<UserNewsResource>,
     onToggleBookmark: (item: UserNewsResource) -> Unit,
-    onItemClick: ((item: UserNewsResource) -> Unit)? = null,
     onTopicClick: (String) -> Unit,
     itemModifier: Modifier = Modifier,
 ) = items(
@@ -58,10 +57,6 @@ fun LazyListScope.userNewsResourceCardItems(
                     newsResourceId = userNewsResource.id,
                     newsResourceTitle = userNewsResource.title,
                 )
-                when (onItemClick) {
-                    null -> launchCustomChromeTab(context, resourceUrl, backgroundColor)
-                    else -> onItemClick(userNewsResource)
-                }
             },
             onTopicClick = onTopicClick,
             modifier = itemModifier,

--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCardList.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCardList.kt
@@ -31,8 +31,7 @@ import com.google.samples.apps.nowinandroid.core.domain.model.UserNewsResource
  * [UserNewsResource]s.
  *
  * [onToggleBookmark] defines the action invoked when a user wishes to bookmark an item
- * [onItemClick] optional parameter for action to be performed when the card is clicked. The
- * default action launches an intent matching the card.
+ * The default action launches an intent matching the card.
  */
 fun LazyListScope.userNewsResourceCardItems(
     items: List<UserNewsResource>,


### PR DESCRIPTION
Fixes: #614 

Removed on `onItemClick` parameter from NewsResourceCardList