### PR TITLE
Remove viewModel as Composable parameters

### DIFF
--- a/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreen.kt
+++ b/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreen.kt
@@ -67,8 +67,8 @@ import com.google.samples.apps.nowinandroid.core.ui.newsFeed
 internal fun BookmarksRoute(
     onTopicClick: (String) -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: BookmarksViewModel = hiltViewModel(),
 ) {
+    val viewModel: BookmarksViewModel = hiltViewModel()
     val feedState by viewModel.feedUiState.collectAsStateWithLifecycle()
     BookmarksScreen(
         feedState = feedState,

--- a/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -93,8 +93,8 @@ import com.google.samples.apps.nowinandroid.core.ui.newsFeed
 internal fun ForYouRoute(
     onTopicClick: (String) -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: ForYouViewModel = hiltViewModel(),
 ) {
+    val viewModel: ForYouViewModel = hiltViewModel()
     val onboardingUiState by viewModel.onboardingUiState.collectAsStateWithLifecycle()
     val feedState by viewModel.feedState.collectAsStateWithLifecycle()
     val isSyncing by viewModel.isSyncing.collectAsStateWithLifecycle()

--- a/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsScreen.kt
+++ b/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/InterestsScreen.kt
@@ -38,8 +38,8 @@ import com.google.samples.apps.nowinandroid.core.ui.TrackScreenViewEvent
 internal fun InterestsRoute(
     onTopicClick: (String) -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: InterestsViewModel = hiltViewModel(),
 ) {
+    val viewModel: InterestsViewModel = hiltViewModel()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     InterestsScreen(

--- a/feature/settings/src/main/java/com/google/samples/apps/nowinandroid/feature/settings/SettingsDialog.kt
+++ b/feature/settings/src/main/java/com/google/samples/apps/nowinandroid/feature/settings/SettingsDialog.kt
@@ -68,8 +68,8 @@ import com.google.samples.apps.nowinandroid.feature.settings.SettingsUiState.Suc
 @Composable
 fun SettingsDialog(
     onDismiss: () -> Unit,
-    viewModel: SettingsViewModel = hiltViewModel(),
 ) {
+    val viewModel: SettingsViewModel = hiltViewModel()
     val settingsUiState by viewModel.settingsUiState.collectAsStateWithLifecycle()
     SettingsDialog(
         onDismiss = onDismiss,

--- a/feature/topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/java/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
@@ -66,8 +66,8 @@ internal fun TopicRoute(
     onBackClick: () -> Unit,
     onTopicClick: (String) -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: TopicViewModel = hiltViewModel(),
 ) {
+    val viewModel: TopicViewModel = hiltViewModel()
     val topicUiState: TopicUiState by viewModel.topicUiState.collectAsStateWithLifecycle()
     val newsUiState: NewsUiState by viewModel.newUiState.collectAsStateWithLifecycle()
 


### PR DESCRIPTION
Follow up from [this slack discussion](https://kotlinlang.slack.com/archives/CJLTWPH7S/p1678882128432169). I find passing `ViewModels` as parameters is confusing because it hints at the possibility of passing a different `ViewModel` class for preview/testing. Given that `ViewModels` are final classes, it's pretty hard to change in tests. Or is there another reason to do so?

I'm opening this PR for discussion. 

Also ping @manuelvicnt, I think this practice dates from [this video](https://www.youtube.com/watch?v=0z_dwBGQQWQ) but things might have changed since then? Or is it still a good thing to do?