### PR TITLE
Wire up backend requested sync

### DIFF
--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepository.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepository.kt
@@ -75,7 +75,7 @@ class OfflineFirstNewsRepository @Inject constructor(
             modelDeleter = newsResourceDao::deleteNewsResources,
             modelUpdater = { changedIds ->
                 val userData = niaPreferencesDataSource.userData.first()
-                val hasOnBoarded = userData.shouldHideOnboarding
+                val hasOnboarded = userData.shouldHideOnboarding
                 val followedTopicIds = userData.followedTopics
 
                 // TODO: Make this more efficient, there is no need to retrieve populated

--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepository.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepository.kt
@@ -80,8 +80,8 @@ class OfflineFirstNewsRepository @Inject constructor(
 
                 // TODO: Make this more efficient, there is no need to retrieve populated
                 //  news resources when all that's needed are the ids
-                val existingFollowedChangedNewsResourceIds = when {
-                    hasOnBoarded -> newsResourceDao.getNewsResources(
+                val existingNewsResourceIdsThatHaveChanged = when {
+                    hasOnboarded -> newsResourceDao.getNewsResources(
                         useFilterTopicIds = true,
                         filterTopicIds = followedTopicIds,
                         useFilterNewsIds = true,
@@ -94,6 +94,7 @@ class OfflineFirstNewsRepository @Inject constructor(
                     else -> emptySet()
                 }
 
+                // Obtain the news resources which have changed from the network and upsert them locally
                 changedIds.chunked(SYNC_BATCH_SIZE).forEach { chunkedIds ->
                     val networkNewsResources = network.getNewsResources(ids = chunkedIds)
 
@@ -118,12 +119,12 @@ class OfflineFirstNewsRepository @Inject constructor(
                     )
                 }
 
-                if (hasOnBoarded) {
+                if (hasOnboarded) {
                     val addedNewsResources = newsResourceDao.getNewsResources(
                         useFilterTopicIds = true,
                         filterTopicIds = followedTopicIds,
                         useFilterNewsIds = true,
-                        filterNewsIds = changedIds.toSet() - existingFollowedChangedNewsResourceIds,
+                        filterNewsIds = changedIds.toSet() - existingNewsResourceIdsThatHaveChanged,
                     )
                         .first()
                         .map(PopulatedNewsResource::asExternalModel)

--- a/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
+++ b/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
@@ -312,13 +312,15 @@ class OfflineFirstNewsRepositoryTest {
 
             subject.syncWith(synchronizer)
 
+            val followedNewsResourcesFromNetwork = networkNewsResources
+                .filter { (it.topics intersect followedTopicIds).isNotEmpty() }
+                .map(NetworkNewsResource::id)
+                .sorted()
+
             // Notifier should have been called with only news resources that have topics
             // that the user follows
             assertEquals(
-                expected = networkNewsResources
-                    .filter { (it.topics intersect followedTopicIds).isNotEmpty() }
-                    .map(NetworkNewsResource::id)
-                    .sorted(),
+                expected = followedNewsResourcesFromNetwork,
                 actual = notifier.addedNewsResources.first().map(NewsResource::id).sorted(),
             )
         }

--- a/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
+++ b/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
@@ -312,7 +312,7 @@ class OfflineFirstNewsRepositoryTest {
 
             subject.syncWith(synchronizer)
 
-            val followedNewsResourcesFromNetwork = networkNewsResources
+            val followedNewsResourceIdsFromNetwork = networkNewsResources
                 .filter { (it.topics intersect followedTopicIds).isNotEmpty() }
                 .map(NetworkNewsResource::id)
                 .sorted()

--- a/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
+++ b/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
@@ -320,7 +320,7 @@ class OfflineFirstNewsRepositoryTest {
             // Notifier should have been called with only news resources that have topics
             // that the user follows
             assertEquals(
-                expected = followedNewsResourcesFromNetwork,
+                expected = followedNewsResourceIdsFromNetwork,
                 actual = notifier.addedNewsResources.first().map(NewsResource::id).sorted(),
             )
         }

--- a/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
+++ b/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
@@ -34,6 +34,7 @@ import com.google.samples.apps.nowinandroid.core.database.model.asExternalModel
 import com.google.samples.apps.nowinandroid.core.datastore.NiaPreferencesDataSource
 import com.google.samples.apps.nowinandroid.core.datastore.test.testUserPreferencesDataStore
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
+import com.google.samples.apps.nowinandroid.core.model.data.Topic
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkChangeList
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkNewsResource
 import com.google.samples.apps.nowinandroid.core.testing.notifications.TestNotifier
@@ -46,12 +47,15 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class OfflineFirstNewsRepositoryTest {
 
     private val testScope = TestScope(UnconfinedTestDispatcher())
 
     private lateinit var subject: OfflineFirstNewsRepository
+
+    private lateinit var niaPreferencesDataSource: NiaPreferencesDataSource
 
     private lateinit var newsResourceDao: TestNewsResourceDao
 
@@ -68,17 +72,19 @@ class OfflineFirstNewsRepositoryTest {
 
     @Before
     fun setup() {
+        niaPreferencesDataSource = NiaPreferencesDataSource(
+            tmpFolder.testUserPreferencesDataStore(testScope),
+        )
         newsResourceDao = TestNewsResourceDao()
         topicDao = TestTopicDao()
         network = TestNiaNetworkDataSource()
         notifier = TestNotifier()
         synchronizer = TestSynchronizer(
-            NiaPreferencesDataSource(
-                tmpFolder.testUserPreferencesDataStore(testScope),
-            ),
+            niaPreferencesDataSource,
         )
 
         subject = OfflineFirstNewsRepository(
+            niaPreferencesDataSource = niaPreferencesDataSource,
             newsResourceDao = newsResourceDao,
             topicDao = topicDao,
             network = network,
@@ -130,6 +136,8 @@ class OfflineFirstNewsRepositoryTest {
     @Test
     fun offlineFirstNewsRepository_sync_pulls_from_network() =
         testScope.runTest {
+            // User has not onboarded
+            niaPreferencesDataSource.setShouldHideOnboarding(false)
             subject.syncWith(synchronizer)
 
             val newsResourcesFromNetwork = network.getNewsResources()
@@ -151,16 +159,16 @@ class OfflineFirstNewsRepositoryTest {
                 actual = synchronizer.getChangeListVersions().newsResourceVersion,
             )
 
-            // Notifier should have been called with new news resources
-            assertEquals(
-                expected = newsResourcesFromDb.map(NewsResource::id).sorted(),
-                actual = notifier.addedNewsResources.first().map(NewsResource::id).sorted(),
-            )
+            // Notifier should not have been called
+            assertTrue(notifier.addedNewsResources.isEmpty())
         }
 
     @Test
     fun offlineFirstNewsRepository_sync_deletes_items_marked_deleted_on_network() =
         testScope.runTest {
+            // User has not onboarded
+            niaPreferencesDataSource.setShouldHideOnboarding(false)
+
             val newsResourcesFromNetwork = network.getNewsResources()
                 .map(NetworkNewsResource::asEntity)
                 .map(NewsResourceEntity::asExternalModel)
@@ -198,17 +206,16 @@ class OfflineFirstNewsRepositoryTest {
                 actual = synchronizer.getChangeListVersions().newsResourceVersion,
             )
 
-            // Notifier should have been called with news resources from network that are not
-            // deleted
-            assertEquals(
-                expected = (newsResourcesFromNetwork.map(NewsResource::id) - deletedItems).sorted(),
-                actual = notifier.addedNewsResources.first().map(NewsResource::id).sorted(),
-            )
+            // Notifier should not have been called
+            assertTrue(notifier.addedNewsResources.isEmpty())
         }
 
     @Test
     fun offlineFirstNewsRepository_incremental_sync_pulls_from_network() =
         testScope.runTest {
+            // User has not onboarded
+            niaPreferencesDataSource.setShouldHideOnboarding(false)
+
             // Set news version to 7
             synchronizer.updateChangeListVersions {
                 copy(newsResourceVersion = 7)
@@ -244,11 +251,8 @@ class OfflineFirstNewsRepositoryTest {
                 actual = synchronizer.getChangeListVersions().newsResourceVersion,
             )
 
-            // Notifier should have been called with only added news resources from network
-            assertEquals(
-                expected = newsResourcesFromNetwork.map(NewsResource::id).sorted(),
-                actual = notifier.addedNewsResources.first().map(NewsResource::id).sorted(),
-            )
+            // Notifier should not have been called
+            assertTrue(notifier.addedNewsResources.isEmpty())
         }
 
     @Test
@@ -282,5 +286,69 @@ class OfflineFirstNewsRepositoryTest {
                 actual = newsResourceDao.topicCrossReferences
                     .sortedBy(NewsResourceTopicCrossRef::toString),
             )
+        }
+
+    @Test
+    fun offlineFirstNewsRepository_sends_notifications_for_newly_synced_news_that_is_followed() =
+        testScope.runTest {
+            // User has onboarded
+            niaPreferencesDataSource.setShouldHideOnboarding(true)
+
+            val networkNewsResources = network.getNewsResources()
+
+            // Follow roughly half the topics
+            val followedTopicIds = networkNewsResources
+                .flatMap(NetworkNewsResource::topicEntityShells)
+                .mapNotNull { topic ->
+                    when (topic.id.chars().sum() % 2) {
+                        0 -> topic.id
+                        else -> null
+                    }
+                }
+                .toSet()
+
+            // Set followed topics
+            niaPreferencesDataSource.setFollowedTopicIds(followedTopicIds)
+
+            subject.syncWith(synchronizer)
+
+            // Notifier should have been called with only news resources that have topics
+            // that the user follows
+            assertEquals(
+                expected = networkNewsResources
+                    .filter { (it.topics intersect followedTopicIds).isNotEmpty() }
+                    .map(NetworkNewsResource::id)
+                    .sorted(),
+                actual = notifier.addedNewsResources.first().map(NewsResource::id).sorted(),
+            )
+        }
+
+    @Test
+    fun offlineFirstNewsRepository_does_not_send_notifications_for_existing_news_resources() =
+        testScope.runTest {
+            // User has onboarded
+            niaPreferencesDataSource.setShouldHideOnboarding(true)
+
+            val networkNewsResources = network.getNewsResources()
+                .map(NetworkNewsResource::asEntity)
+
+            val newsResources = networkNewsResources
+                .map(NewsResourceEntity::asExternalModel)
+
+            // Prepopulate dao with news resources
+            newsResourceDao.upsertNewsResources(networkNewsResources)
+
+            val followedTopicIds = newsResources
+                .flatMap(NewsResource::topics)
+                .map(Topic::id)
+                .toSet()
+
+            // Follow all topics
+            niaPreferencesDataSource.setFollowedTopicIds(followedTopicIds)
+
+            subject.syncWith(synchronizer)
+
+            // Notifier should not have been called bc all news resources existed previously
+            assertTrue(notifier.addedNewsResources.isEmpty())
         }
 }

--- a/core/database/src/main/java/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceDao.kt
+++ b/core/database/src/main/java/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceDao.kt
@@ -21,7 +21,6 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
-import androidx.room.Update
 import androidx.room.Upsert
 import com.google.samples.apps.nowinandroid.core.database.model.NewsResourceEntity
 import com.google.samples.apps.nowinandroid.core.database.model.NewsResourceTopicCrossRef
@@ -71,12 +70,6 @@ interface NewsResourceDao {
      */
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertOrIgnoreNewsResources(entities: List<NewsResourceEntity>): List<Long>
-
-    /**
-     * Updates [entities] in the db that match the primary key, and no-ops if they don't
-     */
-    @Update
-    suspend fun updateNewsResources(entities: List<NewsResourceEntity>)
 
     /**
      * Inserts or updates [newsResourceEntities] in the db under the specified primary keys

--- a/sync/work/src/demo/java/com/google/samples/apps/nowinandroid/sync/di/SyncModule.kt
+++ b/sync/work/src/demo/java/com/google/samples/apps/nowinandroid/sync/di/SyncModule.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid.sync.di
+
+import com.google.samples.apps.nowinandroid.core.data.util.SyncManager
+import com.google.samples.apps.nowinandroid.sync.status.StubSyncSubscriber
+import com.google.samples.apps.nowinandroid.sync.status.SyncSubscriber
+import com.google.samples.apps.nowinandroid.sync.status.WorkManagerSyncManager
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface SyncModule {
+    @Binds
+    fun bindsSyncStatusMonitor(
+        syncStatusMonitor: WorkManagerSyncManager,
+    ): SyncManager
+
+    @Binds
+    fun bindsSyncSubscriber(
+        syncSubscriber: StubSyncSubscriber,
+    ): SyncSubscriber
+}

--- a/sync/work/src/main/java/com/google/samples/apps/nowinandroid/sync/initializers/SyncWorkHelpers.kt
+++ b/sync/work/src/main/java/com/google/samples/apps/nowinandroid/sync/initializers/SyncWorkHelpers.kt
@@ -27,6 +27,7 @@ import androidx.work.ForegroundInfo
 import androidx.work.NetworkType
 import com.google.samples.apps.nowinandroid.sync.R
 
+const val SYNC_TOPIC = "sync"
 private const val SyncNotificationId = 0
 private const val SyncNotificationChannelID = "SyncNotificationChannel"
 

--- a/sync/work/src/main/java/com/google/samples/apps/nowinandroid/sync/status/StubSyncSubscriber.kt
+++ b/sync/work/src/main/java/com/google/samples/apps/nowinandroid/sync/status/StubSyncSubscriber.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,18 @@
  * limitations under the License.
  */
 
-package com.google.samples.apps.nowinandroid.sync.di
+package com.google.samples.apps.nowinandroid.sync.status
 
-import com.google.samples.apps.nowinandroid.core.data.util.SyncManager
-import com.google.samples.apps.nowinandroid.sync.status.WorkManagerSyncManager
-import dagger.Binds
-import dagger.Module
-import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
+import android.util.Log
+import javax.inject.Inject
 
-@Module
-@InstallIn(SingletonComponent::class)
-interface SyncModule {
-    @Binds
-    fun bindsSyncStatusMonitor(
-        syncStatusMonitor: WorkManagerSyncManager,
-    ): SyncManager
+private const val TAG = "StubSyncSubscriber"
+
+/**
+ * Stub implementation of [SyncSubscriber]
+ */
+class StubSyncSubscriber @Inject constructor() : SyncSubscriber {
+    override suspend fun subscribe() {
+        Log.d(TAG, "Subscribing to sync")
+    }
 }

--- a/sync/work/src/main/java/com/google/samples/apps/nowinandroid/sync/status/SyncSubscriber.kt
+++ b/sync/work/src/main/java/com/google/samples/apps/nowinandroid/sync/status/SyncSubscriber.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid.sync.status
+
+/**
+ * Subscribes to backend requested synchronization
+ */
+interface SyncSubscriber {
+    suspend fun subscribe()
+}

--- a/sync/work/src/main/java/com/google/samples/apps/nowinandroid/sync/workers/SyncWorker.kt
+++ b/sync/work/src/main/java/com/google/samples/apps/nowinandroid/sync/workers/SyncWorker.kt
@@ -34,6 +34,7 @@ import com.google.samples.apps.nowinandroid.core.network.Dispatcher
 import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.IO
 import com.google.samples.apps.nowinandroid.sync.initializers.SyncConstraints
 import com.google.samples.apps.nowinandroid.sync.initializers.syncForegroundInfo
+import com.google.samples.apps.nowinandroid.sync.status.SyncSubscriber
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineDispatcher
@@ -54,6 +55,7 @@ class SyncWorker @AssistedInject constructor(
     private val newsRepository: NewsRepository,
     @Dispatcher(IO) private val ioDispatcher: CoroutineDispatcher,
     private val analyticsHelper: AnalyticsHelper,
+    private val syncSubscriber: SyncSubscriber,
 ) : CoroutineWorker(appContext, workerParams), Synchronizer {
 
     override suspend fun getForegroundInfo(): ForegroundInfo =
@@ -62,6 +64,8 @@ class SyncWorker @AssistedInject constructor(
     override suspend fun doWork(): Result = withContext(ioDispatcher) {
         traceAsync("Sync", 0) {
             analyticsHelper.logSyncStarted()
+
+            syncSubscriber.subscribe()
 
             // First sync the repositories in parallel
             val syncedSuccessfully = awaitAll(

--- a/sync/work/src/prod/java/com/google/samples/apps/nowinandroid/sync/di/SyncModule.kt
+++ b/sync/work/src/prod/java/com/google/samples/apps/nowinandroid/sync/di/SyncModule.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid.sync.di
+
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.ktx.messaging
+import com.google.samples.apps.nowinandroid.core.data.util.SyncManager
+import com.google.samples.apps.nowinandroid.sync.status.FirebaseSyncSubscriber
+import com.google.samples.apps.nowinandroid.sync.status.SyncSubscriber
+import com.google.samples.apps.nowinandroid.sync.status.WorkManagerSyncManager
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface SyncModule {
+    @Binds
+    fun bindsSyncStatusMonitor(
+        syncStatusMonitor: WorkManagerSyncManager,
+    ): SyncManager
+
+    @Binds
+    fun bindsSyncSubscriber(
+        syncSubscriber: FirebaseSyncSubscriber,
+    ): SyncSubscriber
+
+    companion object {
+        @Provides
+        @Singleton
+        fun provideFirebaseMessaging(): FirebaseMessaging = Firebase.messaging
+    }
+}

--- a/sync/work/src/prod/java/com/google/samples/apps/nowinandroid/sync/status/FirebaseSyncSubscriber.kt
+++ b/sync/work/src/prod/java/com/google/samples/apps/nowinandroid/sync/status/FirebaseSyncSubscriber.kt
@@ -14,24 +14,22 @@
  * limitations under the License.
  */
 
-package com.google.samples.apps.nowinandroid.sync.services
+package com.google.samples.apps.nowinandroid.sync.status
 
-import com.google.firebase.messaging.FirebaseMessagingService
-import com.google.firebase.messaging.RemoteMessage
-import com.google.samples.apps.nowinandroid.core.data.util.SyncManager
+import com.google.firebase.messaging.FirebaseMessaging
 import com.google.samples.apps.nowinandroid.sync.initializers.SYNC_TOPIC
-import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
-@AndroidEntryPoint
-class SyncNotificationsService : FirebaseMessagingService() {
-
-    @Inject
-    lateinit var syncManager: SyncManager
-
-    override fun onMessageReceived(message: RemoteMessage) {
-        if (SYNC_TOPIC == message.from) {
-            syncManager.requestSync()
-        }
+/**
+ * Implementation of [SyncSubscriber] that subscribes to the FCM [SYNC_TOPIC]
+ */
+class FirebaseSyncSubscriber @Inject constructor(
+    private val firebaseMessaging: FirebaseMessaging,
+) : SyncSubscriber {
+    override suspend fun subscribe() {
+        firebaseMessaging
+            .subscribeToTopic(SYNC_TOPIC)
+            .await()
     }
 }


### PR DESCRIPTION
This PR:

Adds a `SyncSubscriber`. An interface for subscribing to backend triggered sync. When data changes on the backend, it pings the device to fetch more data and may display a notification to the user if the user's interest aligns.

The app uses FCM for this, as well as an opportunistic sync on startup.

It also tightens up the business logic for notifications. Notifications will not be shown unless the user has completed onboarding. This prevents notification spam on first install.