### PR TITLE
Initialize sync manually

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,7 +87,6 @@ androidx-metrics = { group = "androidx.metrics", name = "metrics-performance", v
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxNavigation" }
 androidx-navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "androidxNavigation" }
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "androidxProfileinstaller" }
-androidx-startup = { group = "androidx.startup", name = "startup-runtime", version.ref = "androidxStartup" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspresso" }
 androidx-test-ext = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidxTestExt" }

--- a/sync/work/build.gradle.kts
+++ b/sync/work/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation(project(":core:datastore"))
     implementation(project(":core:model"))
     implementation(libs.androidx.lifecycle.livedata.ktx)
-    implementation(libs.androidx.startup)
     implementation(libs.androidx.tracing.ktx)
     implementation(libs.androidx.work.ktx)
     implementation(libs.firebase.cloud.messaging)

--- a/sync/work/src/demo/AndroidManifest.xml
+++ b/sync/work/src/demo/AndroidManifest.xml
@@ -18,17 +18,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application>
-        <provider
-            android:name="androidx.startup.InitializationProvider"
-            android:authorities="${applicationId}.androidx-startup"
-            android:exported="false"
-            tools:node="merge">
-            <!--  TODO: b/2173216 Disable auto sync startup till it works well with instrumented tests   -->
-            <meta-data
-                android:name="com.google.samples.apps.nowinandroid.sync.initializers.SyncInitializer"
-                android:value="androidx.startup"
-                tools:node="remove" />
-        </provider>
         <service
             android:name=".services.SyncNotificationsService"
             android:exported="false"

--- a/sync/work/src/main/AndroidManifest.xml
+++ b/sync/work/src/main/AndroidManifest.xml
@@ -18,17 +18,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application>
-        <provider
-            android:name="androidx.startup.InitializationProvider"
-            android:authorities="${applicationId}.androidx-startup"
-            android:exported="false"
-            tools:node="merge">
-            <!--  TODO: b/2173216 Disable auto sync startup till it works well with instrumented tests   -->
-            <meta-data
-                android:name="com.google.samples.apps.nowinandroid.sync.initializers.SyncInitializer"
-                android:value="androidx.startup"
-                tools:node="remove" />
-        </provider>
         <service
             android:name=".services.SyncNotificationsService"
             android:exported="false">

--- a/sync/work/src/main/java/com/google/samples/apps/nowinandroid/sync/initializers/SyncInitializer.kt
+++ b/sync/work/src/main/java/com/google/samples/apps/nowinandroid/sync/initializers/SyncInitializer.kt
@@ -17,31 +17,14 @@
 package com.google.samples.apps.nowinandroid.sync.initializers
 
 import android.content.Context
-import androidx.startup.AppInitializer
-import androidx.startup.Initializer
 import androidx.work.ExistingWorkPolicy
 import androidx.work.WorkManager
-import androidx.work.WorkManagerInitializer
 import com.google.samples.apps.nowinandroid.sync.workers.SyncWorker
 
 object Sync {
-    // This method is a workaround to manually initialize the sync process instead of relying on
-    // automatic initialization with Androidx Startup. It is called from the app module's
-    // Application.onCreate() and should be only done once.
+    // This method is initializes sync, the process that keeps the app's data current.
+    // It is called from the app module's Application.onCreate() and should be only done once.
     fun initialize(context: Context) {
-        AppInitializer.getInstance(context)
-            .initializeComponent(SyncInitializer::class.java)
-    }
-}
-
-// This name should not be changed otherwise the app may have concurrent sync requests running
-internal const val SyncWorkName = "SyncWorkName"
-
-/**
- * Registers work to sync the data layer periodically on app startup.
- */
-class SyncInitializer : Initializer<Sync> {
-    override fun create(context: Context): Sync {
         WorkManager.getInstance(context).apply {
             // Run sync on app startup and ensure only one sync worker runs at any time
             enqueueUniqueWork(
@@ -50,10 +33,8 @@ class SyncInitializer : Initializer<Sync> {
                 SyncWorker.startUpSyncWork(),
             )
         }
-
-        return Sync
     }
-
-    override fun dependencies(): List<Class<out Initializer<*>>> =
-        listOf(WorkManagerInitializer::class.java)
 }
+
+// This name should not be changed otherwise the app may have concurrent sync requests running
+internal const val SyncWorkName = "SyncWorkName"


### PR DESCRIPTION
This PR removes the use of Androidx startup for sync.

Since NiA does not expose content providers for other apps to consume, using androidx startup (using  ContentProviders by proxy) to bootstrap the sync process is unnecessary.

Sync is now explicitly started in the `onCreate` of the `Application`, rather than automatically initialized by Androidx startup.

