### PR TITLE
Tweak the SearchScreen with empty search results

### DIFF
--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/DefaultSearchContentsRepository.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/DefaultSearchContentsRepository.kt
@@ -75,12 +75,11 @@ class DefaultSearchContentsRepository @Inject constructor(
         }
     }
 
-    override fun getSearchContentsCount(): Flow<Int> {
-        return combine(
+    override fun getSearchContentsCount(): Flow<Int> =
+        combine(
             newsResourceFtsDao.getCount(),
             topicFtsDao.getCount(),
         ) { newsResourceCount, topicsCount ->
             newsResourceCount + topicsCount
         }
-    }
 }

--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/DefaultSearchContentsRepository.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/DefaultSearchContentsRepository.kt
@@ -74,4 +74,13 @@ class DefaultSearchContentsRepository @Inject constructor(
             )
         }
     }
+
+    override fun getSearchContentsCount(): Flow<Int> {
+        return combine(
+            newsResourceFtsDao.getCount(),
+            topicFtsDao.getCount(),
+        ) { newsResourceCount, topicsCount ->
+            newsResourceCount + topicsCount
+        }
+    }
 }

--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/DefaultSearchContentsRepository.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/DefaultSearchContentsRepository.kt
@@ -61,7 +61,7 @@ class DefaultSearchContentsRepository @Inject constructor(
             .mapLatest { it.toSet() }
             .distinctUntilChanged()
             .flatMapLatest {
-                newsResourceDao.getNewsResources(filterNewsIds = it)
+                newsResourceDao.getNewsResources(useFilterNewsIds = true, filterNewsIds = it)
             }
         val topicsFlow = topicIds
             .mapLatest { it.toSet() }

--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/SearchContentsRepository.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/SearchContentsRepository.kt
@@ -33,4 +33,6 @@ interface SearchContentsRepository {
      * Query the contents matched with the [searchQuery] and returns it as a [Flow] of [SearchResult]
      */
     fun searchContents(searchQuery: String): Flow<SearchResult>
+
+    fun getSearchContentsCount(): Flow<Int>
 }

--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/fake/FakeSearchContentsRepository.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/fake/FakeSearchContentsRepository.kt
@@ -29,4 +29,5 @@ class FakeSearchContentsRepository @Inject constructor() : SearchContentsReposit
 
     override suspend fun populateFtsData() { /* no-op */ }
     override fun searchContents(searchQuery: String): Flow<SearchResult> = flowOf()
+    override fun getSearchContentsCount(): Flow<Int> = flowOf(1)
 }

--- a/core/database/src/main/java/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceFtsDao.kt
+++ b/core/database/src/main/java/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceFtsDao.kt
@@ -35,5 +35,5 @@ interface NewsResourceFtsDao {
     fun searchAllNewsResources(query: String): Flow<List<String>>
 
     @Query("SELECT count(*) FROM newsResourcesFts")
-    suspend fun getCount(): Int
+    fun getCount(): Flow<Int>
 }

--- a/core/domain/src/main/java/com/google/samples/apps/nowinandroid/core/domain/GetSearchContentsCountUseCase.kt
+++ b/core/domain/src/main/java/com/google/samples/apps/nowinandroid/core/domain/GetSearchContentsCountUseCase.kt
@@ -14,26 +14,18 @@
  * limitations under the License.
  */
 
-package com.google.samples.apps.nowinandroid.core.database.dao
+package com.google.samples.apps.nowinandroid.core.domain
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
-import com.google.samples.apps.nowinandroid.core.database.model.TopicFtsEntity
+import com.google.samples.apps.nowinandroid.core.data.repository.SearchContentsRepository
 import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
 
 /**
- * DAO for [TopicFtsEntity] access.
+ * A use case which returns total count of *Fts tables
  */
-@Dao
-interface TopicFtsDao {
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertAll(topics: List<TopicFtsEntity>)
-
-    @Query("SELECT topicId FROM topicsFts WHERE topicsFts MATCH :query")
-    fun searchAllTopics(query: String): Flow<List<String>>
-
-    @Query("SELECT count(*) FROM topicsFts")
-    fun getCount(): Flow<Int>
+class GetSearchContentsCountUseCase @Inject constructor(
+    private val searchContentsRepository: SearchContentsRepository,
+) {
+    operator fun invoke(): Flow<Int> =
+        searchContentsRepository.getSearchContentsCount()
 }

--- a/core/testing/src/main/java/com/google/samples/apps/nowinandroid/core/testing/repository/TestSearchContentsRepository.kt
+++ b/core/testing/src/main/java/com/google/samples/apps/nowinandroid/core/testing/repository/TestSearchContentsRepository.kt
@@ -21,6 +21,7 @@ import com.google.samples.apps.nowinandroid.core.data.repository.SearchContentsR
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
 import com.google.samples.apps.nowinandroid.core.model.data.Topic
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 
 class TestSearchContentsRepository : SearchContentsRepository {
@@ -44,8 +45,9 @@ class TestSearchContentsRepository : SearchContentsRepository {
         ),
     )
 
-    override fun getSearchContentsCount(): Flow<Int> =
-        flowOf(cachedTopics.size + cachedNewsResources.size)
+    override fun getSearchContentsCount(): Flow<Int> = flow {
+        emit(cachedTopics.size + cachedNewsResources.size)
+    }
 
     /**
      * Test only method to add the topics to the stored list in memory

--- a/core/testing/src/main/java/com/google/samples/apps/nowinandroid/core/testing/repository/TestSearchContentsRepository.kt
+++ b/core/testing/src/main/java/com/google/samples/apps/nowinandroid/core/testing/repository/TestSearchContentsRepository.kt
@@ -21,6 +21,7 @@ import com.google.samples.apps.nowinandroid.core.data.repository.SearchContentsR
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
 import com.google.samples.apps.nowinandroid.core.model.data.Topic
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 
 class TestSearchContentsRepository : SearchContentsRepository {
@@ -43,6 +44,10 @@ class TestSearchContentsRepository : SearchContentsRepository {
             },
         ),
     )
+
+    override fun getSearchContentsCount(): Flow<Int> = flow {
+        emit(cachedTopics.size + cachedNewsResources.size)
+    }
 
     /**
      * Test only method to add the topics to the stored list in memory

--- a/core/testing/src/main/java/com/google/samples/apps/nowinandroid/core/testing/repository/TestSearchContentsRepository.kt
+++ b/core/testing/src/main/java/com/google/samples/apps/nowinandroid/core/testing/repository/TestSearchContentsRepository.kt
@@ -21,7 +21,6 @@ import com.google.samples.apps.nowinandroid.core.data.repository.SearchContentsR
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
 import com.google.samples.apps.nowinandroid.core.model.data.Topic
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 
 class TestSearchContentsRepository : SearchContentsRepository {
@@ -45,9 +44,8 @@ class TestSearchContentsRepository : SearchContentsRepository {
         ),
     )
 
-    override fun getSearchContentsCount(): Flow<Int> = flow {
-        emit(cachedTopics.size + cachedNewsResources.size)
-    }
+    override fun getSearchContentsCount(): Flow<Int> =
+        flowOf(cachedTopics.size + cachedNewsResources.size)
 
     /**
      * Test only method to add the topics to the stored list in memory

--- a/feature/search/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreenTest.kt
+++ b/feature/search/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreenTest.kt
@@ -103,6 +103,29 @@ class SearchScreenTest {
     }
 
     @Test
+    fun emptySearchResult_nonEmptyRecentSearches_emptySearchScreenAndRecentSearchesAreDisplayed() {
+        val recentSearches = listOf("kotlin")
+        composeTestRule.setContent {
+            SearchScreen(
+                searchResultUiState = SearchResultUiState.Success(),
+                recentSearchesUiState = RecentSearchQueriesUiState.Success(
+                    recentQueries = recentSearches.map(::RecentSearchQuery),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(tryAnotherSearchString)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription(clearRecentSearchesContentDesc)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("kotlin")
+            .assertIsDisplayed()
+    }
+
+    @Test
     fun searchResultWithTopics_allTopicsAreVisible_followButtonsVisibleForTheNumOfFollowedTopics() {
         composeTestRule.setContent {
             SearchScreen(

--- a/feature/search/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreenTest.kt
+++ b/feature/search/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreenTest.kt
@@ -52,6 +52,7 @@ class SearchScreenTest {
     private lateinit var topicsString: String
     private lateinit var updatesString: String
     private lateinit var tryAnotherSearchString: String
+    private lateinit var searchNotReadyString: String
 
     private val userData: UserData = UserData(
         bookmarkedNewsResources = setOf("1", "3"),
@@ -75,6 +76,7 @@ class SearchScreenTest {
             updatesString = getString(R.string.updates)
             tryAnotherSearchString = getString(R.string.try_another_search) +
                 " " + getString(R.string.interests) + " " + getString(R.string.to_browse_topics)
+            searchNotReadyString = getString(R.string.search_not_ready)
         }
     }
 
@@ -197,6 +199,19 @@ class SearchScreenTest {
             .assertIsDisplayed()
         composeTestRule
             .onNodeWithText("testing")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun searchNotReady_verifySearchNotReadyMessageIsVisible() {
+        composeTestRule.setContent {
+            SearchScreen(
+                searchResultUiState = SearchResultUiState.SearchNotReady,
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(searchNotReadyString)
             .assertIsDisplayed()
     }
 }

--- a/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchResultUiState.kt
+++ b/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchResultUiState.kt
@@ -37,4 +37,10 @@ sealed interface SearchResultUiState {
     ) : SearchResultUiState {
         fun isEmpty(): Boolean = topics.isEmpty() && newsResources.isEmpty()
     }
+
+    /**
+     * A state where the search contents are not ready. This happens when the *Fts tables are not
+     * populated yet.
+     */
+    object SearchNotReady : SearchResultUiState
 }

--- a/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
@@ -150,6 +150,7 @@ internal fun SearchScreen(
             SearchResultUiState.LoadFailed,
             -> Unit
 
+            SearchResultUiState.SearchNotReady -> SearchNotReadyBody()
             SearchResultUiState.EmptyQuery,
             -> {
                 if (recentSearchesUiState is RecentSearchQueriesUiState.Success) {
@@ -257,6 +258,21 @@ fun EmptySearchResultBody(
                     onInterestsClick()
                 }
         }
+    }
+}
+
+@Composable
+private fun SearchNotReadyBody() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.padding(horizontal = 48.dp),
+    ) {
+        Text(
+            text = stringResource(id = searchR.string.search_not_ready),
+            fontSize = 18.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 24.dp),
+        )
     }
 }
 
@@ -523,6 +539,14 @@ private fun RecentSearchesBodyPreview() {
             onRecentSearchClicked = {},
             recentSearchQueries = listOf("kotlin", "jetpack compose", "testing"),
         )
+    }
+}
+
+@Preview
+@Composable
+private fun SearchNotReadyBodyPreview() {
+    NiaTheme {
+        SearchNotReadyBody()
     }
 }
 

--- a/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
@@ -63,10 +63,12 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -147,6 +149,7 @@ internal fun SearchScreen(
             SearchResultUiState.Loading,
             SearchResultUiState.LoadFailed,
             -> Unit
+
             SearchResultUiState.EmptyQuery,
             -> {
                 if (recentSearchesUiState is RecentSearchQueriesUiState.Success) {
@@ -167,6 +170,16 @@ internal fun SearchScreen(
                         onInterestsClick = onInterestsClick,
                         searchQuery = searchQuery,
                     )
+                    if (recentSearchesUiState is RecentSearchQueriesUiState.Success) {
+                        RecentSearchesBody(
+                            onClearRecentSearches = onClearRecentSearches,
+                            onRecentSearchClicked = {
+                                onSearchQueryChanged(it)
+                                onSearchTriggered(it)
+                            },
+                            recentSearchQueries = recentSearchesUiState.recentQueries.map { it.query },
+                        )
+                    }
                 } else {
                     SearchResultBody(
                         topics = searchResultUiState.topics,
@@ -189,7 +202,10 @@ fun EmptySearchResultBody(
     onInterestsClick: () -> Unit,
     searchQuery: String,
 ) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.padding(horizontal = 48.dp),
+    ) {
         val message = stringResource(id = searchR.string.search_result_not_found, searchQuery)
         val start = message.indexOf(searchQuery)
         Text(
@@ -203,26 +219,34 @@ fun EmptySearchResultBody(
                     ),
                 ),
             ),
-            modifier = Modifier.padding(horizontal = 36.dp, vertical = 24.dp),
+            fontSize = 18.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 24.dp),
         )
         val interests = stringResource(id = searchR.string.interests)
         val tryAnotherSearchString = buildAnnotatedString {
-            append(stringResource(id = searchR.string.try_another_search))
-            append(" ")
-            withStyle(
-                style = SpanStyle(
-                    textDecoration = TextDecoration.Underline,
-                    fontWeight = FontWeight.Bold,
-                ),
-            ) {
-                pushStringAnnotation(tag = interests, annotation = interests)
-                append(interests)
+            withStyle(style = SpanStyle(fontSize = 18.sp)) {
+                append(stringResource(id = searchR.string.try_another_search))
+                append(" ")
+                withStyle(
+                    style = SpanStyle(
+                        textDecoration = TextDecoration.Underline,
+                        fontWeight = FontWeight.Bold,
+                    ),
+                ) {
+                    pushStringAnnotation(tag = interests, annotation = interests)
+                    append(interests)
+                }
+                append(" ")
+                append(stringResource(id = searchR.string.to_browse_topics))
             }
-            append(" ")
-            append(stringResource(id = searchR.string.to_browse_topics))
         }
         ClickableText(
             text = tryAnotherSearchString,
+            style = TextStyle(
+                textAlign = TextAlign.Center,
+                lineHeight = 24.sp,
+            ),
             modifier = Modifier
                 .padding(start = 36.dp, end = 36.dp, bottom = 24.dp)
                 .clickable {},
@@ -454,7 +478,8 @@ private fun SearchTextField(
                 } else {
                     false
                 }
-            }.testTag("searchTextField"),
+            }
+            .testTag("searchTextField"),
         shape = RoundedCornerShape(32.dp),
         value = searchQuery,
         keyboardOptions = KeyboardOptions(

--- a/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
@@ -65,7 +65,6 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
@@ -74,7 +73,6 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.samples.apps.nowinandroid.core.designsystem.icon.NiaIcons
@@ -220,33 +218,32 @@ fun EmptySearchResultBody(
                     ),
                 ),
             ),
-            fontSize = 18.sp,
+            style = MaterialTheme.typography.bodyLarge,
             textAlign = TextAlign.Center,
             modifier = Modifier.padding(vertical = 24.dp),
         )
         val interests = stringResource(id = searchR.string.interests)
         val tryAnotherSearchString = buildAnnotatedString {
-            withStyle(style = SpanStyle(fontSize = 18.sp)) {
-                append(stringResource(id = searchR.string.try_another_search))
-                append(" ")
-                withStyle(
-                    style = SpanStyle(
-                        textDecoration = TextDecoration.Underline,
-                        fontWeight = FontWeight.Bold,
-                    ),
-                ) {
-                    pushStringAnnotation(tag = interests, annotation = interests)
-                    append(interests)
-                }
-                append(" ")
-                append(stringResource(id = searchR.string.to_browse_topics))
+            append(stringResource(id = searchR.string.try_another_search))
+            append(" ")
+            withStyle(
+                style = SpanStyle(
+                    textDecoration = TextDecoration.Underline,
+                    fontWeight = FontWeight.Bold,
+                ),
+            ) {
+                pushStringAnnotation(tag = interests, annotation = interests)
+                append(interests)
             }
+            append(" ")
+            append(stringResource(id = searchR.string.to_browse_topics))
         }
         ClickableText(
             text = tryAnotherSearchString,
-            style = TextStyle(
-                textAlign = TextAlign.Center,
-                lineHeight = 24.sp,
+            style = MaterialTheme.typography.bodyLarge.merge(
+                TextStyle(
+                    textAlign = TextAlign.Center,
+                ),
             ),
             modifier = Modifier
                 .padding(start = 36.dp, end = 36.dp, bottom = 24.dp)
@@ -269,7 +266,7 @@ private fun SearchNotReadyBody() {
     ) {
         Text(
             text = stringResource(id = searchR.string.search_not_ready),
-            fontSize = 18.sp,
+            style = MaterialTheme.typography.bodyLarge,
             textAlign = TextAlign.Center,
             modifier = Modifier.padding(vertical = 24.dp),
         )
@@ -382,8 +379,7 @@ private fun RecentSearchesBody(
             items(recentSearchQueries) { recentSearch ->
                 Text(
                     text = recentSearch,
-                    fontSize = 28.sp,
-                    fontFamily = FontFamily.SansSerif,
+                    style = MaterialTheme.typography.headlineSmall,
                     modifier = Modifier
                         .padding(vertical = 16.dp)
                         .clickable {

--- a/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
@@ -364,22 +364,15 @@ private fun RecentSearchesBody(
         }
         LazyColumn(modifier = Modifier.padding(horizontal = 16.dp)) {
             items(recentSearchQueries) { recentSearch ->
-                ClickableText(
-                    text = buildAnnotatedString {
-                        withStyle(
-                            style = SpanStyle(
-                                fontSize = 28.sp,
-                                fontFamily = FontFamily.SansSerif,
-                            ),
-                        ) {
-                            append(recentSearch)
-                        }
-                    },
-                    onClick = {
-                        onRecentSearchClicked(recentSearch)
-                    },
+                Text(
+                    text = recentSearch,
+                    fontSize = 28.sp,
+                    fontFamily = FontFamily.SansSerif,
                     modifier = Modifier
                         .padding(vertical = 16.dp)
+                        .clickable {
+                            onRecentSearchClicked(recentSearch)
+                        }
                         .fillMaxWidth(),
                 )
             }

--- a/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModel.kt
@@ -115,8 +115,8 @@ class SearchViewModel @Inject constructor(
 }
 
 /** Minimum length where search query is considered as [SearchResultUiState.EmptyQuery] */
-const val SEARCH_QUERY_MIN_LENGTH = 2
+private const val SEARCH_QUERY_MIN_LENGTH = 2
 
 /** Minimum number of the fts table's entity count where it's considered as search is not ready */
-const val SEARCH_MIN_FTS_ENTITY_COUNT = 1
-const val SEARCH_QUERY = "searchQuery"
+private const val SEARCH_MIN_FTS_ENTITY_COUNT = 1
+private const val SEARCH_QUERY = "searchQuery"

--- a/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.samples.apps.nowinandroid.core.data.repository.RecentSearchRepository
 import com.google.samples.apps.nowinandroid.core.domain.GetRecentSearchQueriesUseCase
+import com.google.samples.apps.nowinandroid.core.domain.GetSearchContentsCountUseCase
 import com.google.samples.apps.nowinandroid.core.domain.GetSearchContentsUseCase
 import com.google.samples.apps.nowinandroid.core.result.Result
 import com.google.samples.apps.nowinandroid.core.result.asResult
@@ -36,8 +37,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
-    // TODO: Add GetSearchContentsCountUseCase to check if the fts tables are populated
     getSearchContentsUseCase: GetSearchContentsUseCase,
+    getSearchContentsCountUseCase: GetSearchContentsCountUseCase,
     recentSearchQueriesUseCase: GetRecentSearchQueriesUseCase,
     private val recentSearchRepository: RecentSearchRepository,
     private val savedStateHandle: SavedStateHandle,
@@ -46,25 +47,31 @@ class SearchViewModel @Inject constructor(
     val searchQuery = savedStateHandle.getStateFlow(SEARCH_QUERY, "")
 
     val searchResultUiState: StateFlow<SearchResultUiState> =
-        searchQuery.flatMapLatest { query ->
-            if (query.length < SEARCH_QUERY_MIN_LENGTH) {
-                flowOf(SearchResultUiState.EmptyQuery)
+        getSearchContentsCountUseCase().flatMapLatest { totalCount ->
+            if (totalCount < SEARCH_MIN_FTS_ENTITY_COUNT) {
+                flowOf(SearchResultUiState.SearchNotReady)
             } else {
-                getSearchContentsUseCase(query).asResult().map {
-                    when (it) {
-                        is Result.Success -> {
-                            SearchResultUiState.Success(
-                                topics = it.data.topics,
-                                newsResources = it.data.newsResources,
-                            )
-                        }
+                searchQuery.flatMapLatest { query ->
+                    if (query.length < SEARCH_QUERY_MIN_LENGTH) {
+                        flowOf(SearchResultUiState.EmptyQuery)
+                    } else {
+                        getSearchContentsUseCase(query).asResult().map {
+                            when (it) {
+                                is Result.Success -> {
+                                    SearchResultUiState.Success(
+                                        topics = it.data.topics,
+                                        newsResources = it.data.newsResources,
+                                    )
+                                }
 
-                        is Result.Loading -> {
-                            SearchResultUiState.Loading
-                        }
+                                is Result.Loading -> {
+                                    SearchResultUiState.Loading
+                                }
 
-                        is Result.Error -> {
-                            SearchResultUiState.LoadFailed
+                                is Result.Error -> {
+                                    SearchResultUiState.LoadFailed
+                                }
+                            }
                         }
                     }
                 }
@@ -109,4 +116,7 @@ class SearchViewModel @Inject constructor(
 
 /** Minimum length where search query is considered as [SearchResultUiState.EmptyQuery] */
 const val SEARCH_QUERY_MIN_LENGTH = 2
+
+/** Minimum number of the fts table's entity count where it's considered as search is not ready */
+const val SEARCH_MIN_FTS_ENTITY_COUNT = 1
 const val SEARCH_QUERY = "searchQuery"

--- a/feature/search/src/main/res/values/strings.xml
+++ b/feature/search/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="search">Search</string>
     <string name="clear_search_text_content_desc">Clear search text</string>
     <string name="search_result_not_found">Sorry, there is no content found for your search \"%1$s\"</string>
+    <string name="search_not_ready">Sorry, we are still processing the search index. Please come back later</string>
     <string name="try_another_search">Try another search or explorer </string>
     <string name="interests">Interests</string>
     <string name="to_browse_topics"> to browse topics</string>

--- a/feature/search/src/test/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModelTest.kt
+++ b/feature/search/src/test/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModelTest.kt
@@ -18,6 +18,7 @@ package com.google.samples.apps.nowinandroid.feature.search
 
 import androidx.lifecycle.SavedStateHandle
 import com.google.samples.apps.nowinandroid.core.domain.GetRecentSearchQueriesUseCase
+import com.google.samples.apps.nowinandroid.core.domain.GetSearchContentsCountUseCase
 import com.google.samples.apps.nowinandroid.core.domain.GetSearchContentsUseCase
 import com.google.samples.apps.nowinandroid.core.testing.data.newsResourcesTestData
 import com.google.samples.apps.nowinandroid.core.testing.data.topicsTestData
@@ -55,12 +56,14 @@ class SearchViewModelTest {
     )
     private val recentSearchRepository = TestRecentSearchRepository()
     private val getRecentQueryUseCase = GetRecentSearchQueriesUseCase(recentSearchRepository)
+    private val getSearchContentsCountUseCase = GetSearchContentsCountUseCase(searchContentsRepository)
     private lateinit var viewModel: SearchViewModel
 
     @Before
     fun setup() {
         viewModel = SearchViewModel(
             getSearchContentsUseCase = getSearchContentsUseCase,
+            getSearchContentsCountUseCase = getSearchContentsCountUseCase,
             recentSearchQueriesUseCase = getRecentQueryUseCase,
             savedStateHandle = SavedStateHandle(),
             recentSearchRepository = recentSearchRepository,

--- a/feature/search/src/test/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModelTest.kt
+++ b/feature/search/src/test/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModelTest.kt
@@ -29,6 +29,7 @@ import com.google.samples.apps.nowinandroid.core.testing.util.MainDispatcherRule
 import com.google.samples.apps.nowinandroid.feature.search.RecentSearchQueriesUiState.Success
 import com.google.samples.apps.nowinandroid.feature.search.SearchResultUiState.EmptyQuery
 import com.google.samples.apps.nowinandroid.feature.search.SearchResultUiState.Loading
+import com.google.samples.apps.nowinandroid.feature.search.SearchResultUiState.SearchNotReady
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -77,9 +78,12 @@ class SearchViewModelTest {
 
     @Test
     fun stateIsEmptyQuery_withEmptySearchQuery() = runTest {
+        searchContentsRepository.addNewsResources(newsResourcesTestData)
+        searchContentsRepository.addTopics(topicsTestData)
         val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.searchResultUiState.collect() }
 
         viewModel.onSearchQueryChanged("")
+
         assertEquals(EmptyQuery, viewModel.searchResultUiState.value)
 
         collectJob.cancel()
@@ -107,6 +111,17 @@ class SearchViewModelTest {
 
         val result = viewModel.recentSearchQueriesUiState.value
         assertIs<Success>(result)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun searchNotReady_withNoFtsTableEntity() = runTest {
+        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.searchResultUiState.collect() }
+
+        viewModel.onSearchQueryChanged("")
+
+        assertEquals(SearchNotReady, viewModel.searchResultUiState.value)
 
         collectJob.cancel()
     }


### PR DESCRIPTION
Tweak the SearchScreen with empty search results.

- Display the recent searches
- Tweak the styles to match the UI mock
- Use Text for each row in recent searches so that ripple effect is applied when it's clicked
- Add missing useFilterNewsIds argument to search for the NewsResources.

Also add SearchNotReadyBody that is displayed before the *Fts tables are populated which is triggered by WorkManager

Screenshot:

Search result is empty:
<img src="https://user-images.githubusercontent.com/796361/233558594-4a73fea1-06fb-4af7-9ba3-e5d08a976d3c.png" width="400px" />


Search is not ready (*Fts tables hasn't been populated)
<img src="https://user-images.githubusercontent.com/796361/233904721-eef9e7f4-1150-426f-b730-899e96ace43c.png" width="400px" />


