### PR TITLE
Fix issue #611 : shouldShowSettingsDialog state save in activity recreation

### DIFF
--- a/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NiaAppStateTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NiaAppStateTest.kt
@@ -20,7 +20,10 @@ import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSiz
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.DpSize
@@ -78,6 +81,7 @@ class NiaAppStateTest {
                     windowSizeClass = getCompactWindowClass(),
                     networkMonitor = networkMonitor,
                     userNewsResourceRepository = userNewsResourceRepository,
+                    initialShouldShowSettingsDialog = mutableStateOf(false),
                 )
             }
 
@@ -100,6 +104,7 @@ class NiaAppStateTest {
                 windowSizeClass = getCompactWindowClass(),
                 networkMonitor = networkMonitor,
                 userNewsResourceRepository = userNewsResourceRepository,
+                initialShouldShowSettingsDialog = rememberTestShouldShowSettingsDialog(),
             )
         }
 
@@ -118,6 +123,7 @@ class NiaAppStateTest {
                 windowSizeClass = getCompactWindowClass(),
                 networkMonitor = networkMonitor,
                 userNewsResourceRepository = userNewsResourceRepository,
+                initialShouldShowSettingsDialog = rememberTestShouldShowSettingsDialog(),
             )
         }
 
@@ -134,6 +140,7 @@ class NiaAppStateTest {
                 windowSizeClass = WindowSizeClass.calculateFromSize(DpSize(800.dp, 800.dp)),
                 networkMonitor = networkMonitor,
                 userNewsResourceRepository = userNewsResourceRepository,
+                initialShouldShowSettingsDialog = rememberTestShouldShowSettingsDialog(),
             )
         }
 
@@ -150,6 +157,7 @@ class NiaAppStateTest {
                 windowSizeClass = WindowSizeClass.calculateFromSize(DpSize(900.dp, 1200.dp)),
                 networkMonitor = networkMonitor,
                 userNewsResourceRepository = userNewsResourceRepository,
+                initialShouldShowSettingsDialog = rememberTestShouldShowSettingsDialog(),
             )
         }
 
@@ -166,6 +174,7 @@ class NiaAppStateTest {
                 windowSizeClass = WindowSizeClass.calculateFromSize(DpSize(900.dp, 1200.dp)),
                 networkMonitor = networkMonitor,
                 userNewsResourceRepository = userNewsResourceRepository,
+                initialShouldShowSettingsDialog = rememberTestShouldShowSettingsDialog(),
             )
         }
 
@@ -194,4 +203,9 @@ private fun rememberTestNavController(): TestNavHostController {
         }
     }
     return navController
+}
+
+@Composable
+private fun rememberTestShouldShowSettingsDialog(): MutableState<Boolean> {
+    return rememberSaveable { mutableStateOf(false) }
 }

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -236,7 +236,7 @@ private fun NiaNavRail(
                 },
                 label = { Text(stringResource(destination.iconTextId)) },
 
-                )
+            )
         }
     }
 }

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -41,7 +41,9 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
@@ -90,6 +92,7 @@ fun NiaApp(
         networkMonitor = networkMonitor,
         windowSizeClass = windowSizeClass,
         userNewsResourceRepository = userNewsResourceRepository,
+        initialShouldShowSettingsDialog = rememberSaveable { mutableStateOf(false) },
     ),
 ) {
     val shouldShowGradientBackground =
@@ -233,7 +236,7 @@ private fun NiaNavRail(
                 },
                 label = { Text(stringResource(destination.iconTextId)) },
 
-            )
+                )
         }
     }
 }

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
@@ -19,9 +19,9 @@ package com.google.samples.apps.nowinandroid.ui
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -61,6 +61,7 @@ fun rememberNiaAppState(
     userNewsResourceRepository: UserNewsResourceRepository,
     coroutineScope: CoroutineScope = rememberCoroutineScope(),
     navController: NavHostController = rememberNavController(),
+    initialShouldShowSettingsDialog: MutableState<Boolean>,
 ): NiaAppState {
     NavigationTrackingSideEffect(navController)
     return remember(
@@ -76,6 +77,7 @@ fun rememberNiaAppState(
             windowSizeClass,
             networkMonitor,
             userNewsResourceRepository,
+            initialShouldShowSettingsDialog,
         )
     }
 }
@@ -87,6 +89,7 @@ class NiaAppState(
     val windowSizeClass: WindowSizeClass,
     networkMonitor: NetworkMonitor,
     userNewsResourceRepository: UserNewsResourceRepository,
+    initialShouldShowSettingsDialog: MutableState<Boolean>,
 ) {
     val currentDestination: NavDestination?
         @Composable get() = navController
@@ -100,7 +103,7 @@ class NiaAppState(
             else -> null
         }
 
-    var shouldShowSettingsDialog by mutableStateOf(false)
+    var shouldShowSettingsDialog by initialShouldShowSettingsDialog
         private set
 
     val shouldShowBottomBar: Boolean


### PR DESCRIPTION
Fixes #611

**Issue name**: [Bug]: shouldShowSettingsDialog is not persisted through activity recreation

- use rememberSaveable

> While remember helps you retain state across recompositions, the state is not retained across configuration changes. For this, you must use rememberSaveable. rememberSaveable automatically saves any value that can be saved in a Bundle. For other values, you can pass in a custom saver object.


reference: https://developer.android.com/jetpack/compose/state

https://user-images.githubusercontent.com/93872496/235056844-dba80f0a-d9db-4cc9-95aa-bd8b77585cf1.mp4

