### PR TITLE
Create and use CI specific group of GMD devices

### DIFF
--- a/.github/workflows/AndroidCIWithGmd.yaml
+++ b/.github/workflows/AndroidCIWithGmd.yaml
@@ -10,9 +10,6 @@ jobs:
 
   android-ci:
     runs-on: macos-12
-    strategy:
-      matrix:
-        device-config: [ "pixel4api30aospatd", "pixelcapi30aospatd" ]
 
     steps:
       - uses: actions/checkout@v3
@@ -30,7 +27,7 @@ jobs:
 
       - name: Run instrumented tests with GMD
         run: ./gradlew cleanManagedDevices --unused-only &&
-          ./gradlew ${{ matrix.device-config }}DemoDebugAndroidTest -Dorg.gradle.workers.max=1
+          ./gradlew ciDemoDebugAndroidTest -Dorg.gradle.workers.max=1
           -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true
 
       - name: Upload test reports

--- a/.github/workflows/AndroidCIWithGmd.yaml
+++ b/.github/workflows/AndroidCIWithGmd.yaml
@@ -24,6 +24,9 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 
+      - name: Build AndroidTest apps
+        run: ./gradlew packageDemoDebug packageDemoDebugAndroidTest
+
       - name: Run instrumented tests with GMD
         run: ./gradlew cleanManagedDevices --unused-only &&
           ./gradlew ${{ matrix.device-config }}DemoDebugAndroidTest -Dorg.gradle.workers.max=1

--- a/.github/workflows/AndroidCIWithGmd.yaml
+++ b/.github/workflows/AndroidCIWithGmd.yaml
@@ -15,11 +15,12 @@ jobs:
         device-config: [ "pixel4api30aospatd", "pixelcapi30aospatd" ]
 
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 17
-      - uses: actions/checkout@v3
+      - uses: gradle/gradle-build-action@v2
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/GradleManagedDevices.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/GradleManagedDevices.kt
@@ -18,7 +18,7 @@ package com.google.samples.apps.nowinandroid
 
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.dsl.ManagedVirtualDevice
-import org.gradle.api.Project
+import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.invoke
 
 /**
@@ -27,20 +27,28 @@ import org.gradle.kotlin.dsl.invoke
 internal fun configureGradleManagedDevices(
     commonExtension: CommonExtension<*, *, *, *>,
 ) {
-    val deviceConfigs = listOf(
-        DeviceConfig("Pixel 4", 30, "aosp-atd"),
-        DeviceConfig("Pixel 6", 31, "aosp"),
-        DeviceConfig("Pixel C", 30, "aosp-atd"),
-    )
+    val pixel4 = DeviceConfig("Pixel 4", 30, "aosp-atd")
+    val pixel6 = DeviceConfig("Pixel 6", 31, "aosp")
+    val pixelC = DeviceConfig("Pixel C", 30, "aosp-atd")
+
+    val allDevices = listOf(pixel4, pixel6, pixelC)
+    val ciDevices = listOf(pixel4, pixelC)
 
     commonExtension.testOptions {
         managedDevices {
             devices {
-                deviceConfigs.forEach { deviceConfig ->
+                allDevices.forEach { deviceConfig ->
                     maybeCreate(deviceConfig.taskName, ManagedVirtualDevice::class.java).apply {
                         device = deviceConfig.device
                         apiLevel = deviceConfig.apiLevel
                         systemImageSource = deviceConfig.systemImageSource
+                    }
+                }
+            }
+            groups {
+                maybeCreate("ci").apply {
+                    ciDevices.forEach { deviceConfig ->
+                        targetDevices.add(devices[deviceConfig.taskName])
                     }
                 }
             }


### PR DESCRIPTION
This should reduce the total CI time of `AndroidCIWithGmd` workflow.
Using the matrix strategy at the GitHub Actions level forces us to run the tests sequentially and download/rebuild everything from scratch at each iteration.

The first two commits are cherry-picked from:
- #694
- #695