### PR TITLE
Fix instrumented test reports archives

### DIFF
--- a/.github/workflows/AndroidCIWithGmd.yaml
+++ b/.github/workflows/AndroidCIWithGmd.yaml
@@ -34,5 +34,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-reports
-          path: |
-            '**/*/build/reports/androidTests/'
+          path: '**/build/reports/androidTests'

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -97,4 +97,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-reports-${{ matrix.api-level }}
-          path: '*/build/reports/androidTests'
+          path: '**/build/reports/androidTests'


### PR DESCRIPTION
- Fixes missing tests reports from `AndroidCIWithGmd.yaml`
  ```
  Warning: No files were found with the provided path: '**/*/build/reports/androidTests/'. No artifacts will be uploaded.
  ```
- Fixes missing tests reports from `Build.yaml`, where only top-level tests from `:app` were reported.