### PR TITLE
Fix incomplete build reports

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -48,15 +48,22 @@ jobs:
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v3
         with:
-          name: build-outputs
-          path: app/build/outputs
+          name: APKs
+          path: '**/build/outputs/apk/**/*.apk'
 
-      - name: Upload build reports
+      - name: Upload lint reports (HTML)
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: build-reports
-          path: app/build/reports
+          name: lint-reports
+          path: '**/build/reports/lint-results-*.html'
+
+      - name: Upload test results (XML)
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: '**/build/test-results/test*UnitTest/**.xml'
 
   androidTest:
     needs: build


### PR DESCRIPTION
- Add all generated lint reports (only app was archived)
- Add all unit tests reports (none were archived)
- Add all APKs (missing app-nia-catalog) and remove unnecessary files (logs, sdkDependencies, proguard's config/mapping/seeds etc. which are also quite large compared to APKs)