### PR TITLE
Save the showSettingsDialog flag in instance state

### DIFF
--- a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -15,7 +15,6 @@
  */
 
 package com.google.samples.apps.nowinandroid.ui
-
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
@@ -41,7 +40,10 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
@@ -94,6 +96,9 @@ fun NiaApp(
 ) {
     val shouldShowGradientBackground =
         appState.currentTopLevelDestination == TopLevelDestination.FOR_YOU
+    var showSettingsDialog by rememberSaveable {
+        mutableStateOf(false)
+    }
 
     NiaBackground {
         NiaGradientBackground(
@@ -118,9 +123,9 @@ fun NiaApp(
                 }
             }
 
-            if (appState.shouldShowSettingsDialog) {
+            if (showSettingsDialog) {
                 SettingsDialog(
-                    onDismiss = { appState.setShowSettingsDialog(false) },
+                    onDismiss = { showSettingsDialog = false },
                 )
             }
 
@@ -184,7 +189,7 @@ fun NiaApp(
                                 colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
                                     containerColor = Color.Transparent,
                                 ),
-                                onActionClick = { appState.setShowSettingsDialog(true) },
+                                onActionClick = { showSettingsDialog = true },
                                 onNavigationClick = { appState.navigateToSearch() },
                             )
                         }

--- a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
@@ -20,11 +20,8 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -100,9 +97,6 @@ class NiaAppState(
             else -> null
         }
 
-    var shouldShowSettingsDialog by mutableStateOf(false)
-        private set
-
     val shouldShowBottomBar: Boolean
         get() = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
 
@@ -168,10 +162,6 @@ class NiaAppState(
                 INTERESTS -> navController.navigateToInterestsGraph(topLevelNavOptions)
             }
         }
-    }
-
-    fun setShowSettingsDialog(shouldShow: Boolean) {
-        shouldShowSettingsDialog = shouldShow
     }
 
     fun navigateToSearch() {


### PR DESCRIPTION
This prevents the settings dialog from being dismissed when the device is rotated.

Since the flag is not used outside of NiaApp, it's moved there and stored with `rememberSaveable`.