### PR TITLE
Simplify handling of nullability in `ConnectivityManagerNetworkMonitor`

### DIFF
--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
@@ -30,7 +30,6 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.conflate
-import Kotlinx.coroutines.flow.flowOf
 import javax.inject.Inject
 
 class ConnectivityManagerNetworkMonitor @Inject constructor(

--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
@@ -48,7 +48,7 @@ class ConnectivityManagerNetworkMonitor @Inject constructor(
          */
         fun update() {
             channel.trySend(connectivityManager.isCurrentlyConnected())
-       }
+        }
 
         /**
          * The callback's methods are invoked on changes to *any* network, not just the active

--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
@@ -37,11 +37,11 @@ class ConnectivityManagerNetworkMonitor @Inject constructor(
 ) : NetworkMonitor {
     override val isOnline: Flow<Boolean> = callbackFlow {
         val connectivityManager = context.getSystemService<ConnectivityManager>()
-        ?: run {
-            channel.trySend(false)
-            channel.close()
-            return@callbackFlow
-        }
+            ?: run {
+                channel.trySend(false)
+                channel.close()
+                return@callbackFlow
+            }
 
         /**
          * The callback's methods are invoked on changes to *any* network, not just the active

--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
@@ -30,61 +30,61 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.conflate
+import Kotlinx.coroutines.flow.flowOf
 import javax.inject.Inject
 
 class ConnectivityManagerNetworkMonitor @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : NetworkMonitor {
-    override val isOnline: Flow<Boolean> = callbackFlow {
+    override val isOnline: Flow<Boolean> {
         val connectivityManager = context.getSystemService<ConnectivityManager>()
+            ?: return flowOf(false)
 
-        /**
-         * The callback's methods are invoked on changes to *any* network, not just the active
-         * network. So to check for network connectivity, one must query the active network of the
-         * ConnectivityManager.
-         */
-        val callback = object : NetworkCallback() {
-            override fun onAvailable(network: Network) {
-                channel.trySend(connectivityManager.isCurrentlyConnected())
+        return callbackFlow {
+
+            /**
+             * The callback's methods are invoked on changes to *any* network, not just the active
+             * network. So to check for network connectivity, one must query the active network of the
+             * ConnectivityManager.
+             */
+            val callback = object : NetworkCallback() {
+                override fun onAvailable(network: Network) {
+                    channel.trySend(connectivityManager.isCurrentlyConnected())
+                }
+
+                override fun onLost(network: Network) {
+                    channel.trySend(connectivityManager.isCurrentlyConnected())
+                }
+
+                override fun onCapabilitiesChanged(
+                    network: Network,
+                    networkCapabilities: NetworkCapabilities,
+                ) {
+                    channel.trySend(connectivityManager.isCurrentlyConnected())
+                }
             }
 
-            override fun onLost(network: Network) {
-                channel.trySend(connectivityManager.isCurrentlyConnected())
-            }
+            connectivityManager.registerNetworkCallback(
+                Builder()
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .build(),
+                callback,
+            )
 
-            override fun onCapabilitiesChanged(
-                network: Network,
-                networkCapabilities: NetworkCapabilities,
-            ) {
-                channel.trySend(connectivityManager.isCurrentlyConnected())
+            channel.trySend(connectivityManager.isCurrentlyConnected())
+
+            awaitClose {
+                connectivityManager.unregisterNetworkCallback(callback)
             }
         }
-
-        connectivityManager?.registerNetworkCallback(
-            Builder()
-                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                .build(),
-            callback,
-        )
-
-        channel.trySend(connectivityManager.isCurrentlyConnected())
-
-        awaitClose {
-            connectivityManager?.unregisterNetworkCallback(callback)
-        }
-    }
-        .conflate()
+            .conflate()
 
     @Suppress("DEPRECATION")
-    private fun ConnectivityManager?.isCurrentlyConnected() = when (this) {
-        null -> false
-        else -> when {
-            VERSION.SDK_INT >= VERSION_CODES.M ->
-                activeNetwork
-                    ?.let(::getNetworkCapabilities)
-                    ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                    ?: false
-            else -> activeNetworkInfo?.isConnected ?: false
-        }
-    }
+    private fun ConnectivityManager.isCurrentlyConnected() = when {
+        VERSION.SDK_INT >= VERSION_CODES.M ->
+            activeNetwork
+                ?.let(::getNetworkCapabilities)
+                ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        else -> activeNetworkInfo?.isConnected
+    } ?: false
 }


### PR DESCRIPTION
Detect nullability of `ConnectivityManager` as soon as possible to avoid handling unnecessary states.