### PR TITLE
Add analytics for search queries

### DIFF
--- a/core/analytics/src/main/java/com/google/samples/apps/nowinandroid/core/analytics/AnalyticsEvent.kt
+++ b/core/analytics/src/main/java/com/google/samples/apps/nowinandroid/core/analytics/AnalyticsEvent.kt
@@ -34,6 +34,7 @@ data class AnalyticsEvent(
     class Types {
         companion object {
             const val SCREEN_VIEW = "screen_view" // (extras: SCREEN_NAME)
+            const val VIEW_SEARCH_RESULTS = "view_search_results" // (extras: SEARCH_TERM)
         }
     }
 
@@ -53,6 +54,7 @@ data class AnalyticsEvent(
     class ParamKeys {
         companion object {
             const val SCREEN_NAME = "screen_name"
+            const val SEARCH_TERM = "search_term"
         }
     }
 }

--- a/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModel.kt
@@ -19,6 +19,9 @@ package com.google.samples.apps.nowinandroid.feature.search
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsEvent
+import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsEvent.Param
+import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsHelper
 import com.google.samples.apps.nowinandroid.core.data.repository.RecentSearchRepository
 import com.google.samples.apps.nowinandroid.core.domain.GetRecentSearchQueriesUseCase
 import com.google.samples.apps.nowinandroid.core.domain.GetSearchContentsCountUseCase
@@ -42,6 +45,7 @@ class SearchViewModel @Inject constructor(
     recentSearchQueriesUseCase: GetRecentSearchQueriesUseCase,
     private val recentSearchRepository: RecentSearchRepository,
     private val savedStateHandle: SavedStateHandle,
+    private val analyticsHelper: AnalyticsHelper,
 ) : ViewModel() {
 
     val searchQuery = savedStateHandle.getStateFlow(SEARCH_QUERY, "")
@@ -105,6 +109,13 @@ class SearchViewModel @Inject constructor(
         viewModelScope.launch {
             recentSearchRepository.insertOrReplaceRecentSearch(query)
         }
+        analyticsHelper.logEvent(
+            AnalyticsEvent(
+                type = SEARCH_QUERY,
+                extras = listOf(Param(SEARCH_QUERY, query)
+                )
+            )
+        )
     }
 
     fun clearRecentSearches() {

--- a/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModel.kt
@@ -112,9 +112,10 @@ class SearchViewModel @Inject constructor(
         analyticsHelper.logEvent(
             AnalyticsEvent(
                 type = SEARCH_QUERY,
-                extras = listOf(Param(SEARCH_QUERY, query)
-                )
-            )
+                extras = listOf(
+                    Param(SEARCH_QUERY, query),
+                ),
+            ),
         )
     }
 

--- a/feature/search/src/test/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModelTest.kt
+++ b/feature/search/src/test/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModelTest.kt
@@ -17,6 +17,8 @@
 package com.google.samples.apps.nowinandroid.feature.search
 
 import androidx.lifecycle.SavedStateHandle
+import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsHelper
+import com.google.samples.apps.nowinandroid.core.analytics.NoOpAnalyticsHelper
 import com.google.samples.apps.nowinandroid.core.domain.GetRecentSearchQueriesUseCase
 import com.google.samples.apps.nowinandroid.core.domain.GetSearchContentsCountUseCase
 import com.google.samples.apps.nowinandroid.core.domain.GetSearchContentsUseCase
@@ -68,6 +70,7 @@ class SearchViewModelTest {
             recentSearchQueriesUseCase = getRecentQueryUseCase,
             savedStateHandle = SavedStateHandle(),
             recentSearchRepository = recentSearchRepository,
+            analyticsHelper = NoOpAnalyticsHelper(),
         )
     }
 

--- a/feature/search/src/test/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModelTest.kt
+++ b/feature/search/src/test/java/com/google/samples/apps/nowinandroid/feature/search/SearchViewModelTest.kt
@@ -17,7 +17,6 @@
 package com.google.samples.apps.nowinandroid.feature.search
 
 import androidx.lifecycle.SavedStateHandle
-import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsHelper
 import com.google.samples.apps.nowinandroid.core.analytics.NoOpAnalyticsHelper
 import com.google.samples.apps.nowinandroid.core.domain.GetRecentSearchQueriesUseCase
 import com.google.samples.apps.nowinandroid.core.domain.GetSearchContentsCountUseCase


### PR DESCRIPTION
This sends an analytics event for each user-initiated search query. This implementation will only capture those searches where the user actively taps on the search button. 

Other ideas/thoughts...

Most of the searches will happen in real time as the user enters their search keywords. I wonder if it'd be better to capture each one of these searches instead. To avoid capturing every intermediate search (every letter being entered) perhaps we could capture the event where search results are being displayed AND the user taps on the search area (the search box losing focus).  

@thagikura Any thoughts here? 