### PR TITLE
Mark all news resources read on first sync

### DIFF
--- a/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
+++ b/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
@@ -289,6 +289,33 @@ class OfflineFirstNewsRepositoryTest {
         }
 
     @Test
+    fun offlineFirstNewsRepository_sync_marks_as_read_on_first_run() =
+        testScope.runTest {
+            subject.syncWith(synchronizer)
+
+            assertEquals(
+                network.getNewsResources().map { it.id }.toSet(),
+                niaPreferencesDataSource.userData.first().viewedNewsResources,
+            )
+        }
+
+    @Test
+    fun offlineFirstNewsRepository_sync_does_not_mark_as_read_on_subsequent_run() =
+        testScope.runTest {
+            // Pretend that we already have up to change list 7
+            synchronizer.updateChangeListVersions {
+                copy(newsResourceVersion = 7)
+            }
+
+            subject.syncWith(synchronizer)
+
+            assertEquals(
+                emptySet(),
+                niaPreferencesDataSource.userData.first().viewedNewsResources,
+            )
+        }
+
+    @Test
     fun offlineFirstNewsRepository_sends_notifications_for_newly_synced_news_that_is_followed() =
         testScope.runTest {
             // User has onboarded

--- a/core/datastore/src/main/java/com/google/samples/apps/nowinandroid/core/datastore/NiaPreferencesDataSource.kt
+++ b/core/datastore/src/main/java/com/google/samples/apps/nowinandroid/core/datastore/NiaPreferencesDataSource.kt
@@ -139,12 +139,18 @@ class NiaPreferencesDataSource @Inject constructor(
     }
 
     suspend fun setNewsResourceViewed(newsResourceId: String, viewed: Boolean) {
+        setNewsResourcesViewed(listOf(newsResourceId), viewed)
+    }
+
+    suspend fun setNewsResourcesViewed(newsResourceIds: List<String>, viewed: Boolean) {
         userPreferences.updateData {
             it.copy {
-                if (viewed) {
-                    viewedNewsResourceIds.put(newsResourceId, true)
-                } else {
-                    viewedNewsResourceIds.remove(newsResourceId)
+                newsResourceIds.forEach {
+                    if (viewed) {
+                        viewedNewsResourceIds.put(it, true)
+                    } else {
+                        viewedNewsResourceIds.remove(it)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Otherwise, there will be unread articles until the user clicks through every article that has ever been published.

Closes #718 