### PR TITLE
Adjust JDK setup to remove toolchain

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -22,16 +22,15 @@ plugins {
 
 group = "com.google.samples.apps.nowinandroid.buildlogic"
 
+// Configure the build-logic plugins to target JDK 17
+// This matches the JDK used to build the project, and is not related to what is running on device.
 java {
-    // Up to Java 11 APIs are available through desugaring
-    // https://developer.android.com/studio/write/java11-minimal-support-table
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
-
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 }
 
@@ -92,6 +91,10 @@ gradlePlugin {
         register("androidFlavors") {
             id = "nowinandroid.android.application.flavors"
             implementationClass = "AndroidApplicationFlavorsConventionPlugin"
+        }
+        register("jvmLibrary") {
+            id = "nowinandroid.jvm.library"
+            implementationClass = "JvmLibraryConventionPlugin"
         }
     }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -18,7 +18,6 @@ import com.android.build.api.dsl.ApplicationExtension
 import com.google.samples.apps.nowinandroid.configureGradleManagedDevices
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.google.samples.apps.nowinandroid.configureKotlinAndroid
-import com.google.samples.apps.nowinandroid.configureKotlinAndroidToolchain
 import com.google.samples.apps.nowinandroid.configurePrintApksTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -32,7 +31,6 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 apply("org.jetbrains.kotlin.android")
             }
 
-            configureKotlinAndroidToolchain()
             extensions.configure<ApplicationExtension> {
                 configureKotlinAndroid(this)
                 defaultConfig.targetSdk = 33

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -19,7 +19,6 @@ import com.android.build.gradle.LibraryExtension
 import com.google.samples.apps.nowinandroid.configureFlavors
 import com.google.samples.apps.nowinandroid.configureGradleManagedDevices
 import com.google.samples.apps.nowinandroid.configureKotlinAndroid
-import com.google.samples.apps.nowinandroid.configureKotlinAndroidToolchain
 import com.google.samples.apps.nowinandroid.configurePrintApksTask
 import com.google.samples.apps.nowinandroid.disableUnnecessaryAndroidTests
 import org.gradle.api.Plugin
@@ -38,7 +37,6 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 apply("org.jetbrains.kotlin.android")
             }
 
-            configureKotlinAndroidToolchain()
             extensions.configure<LibraryExtension> {
                 configureKotlinAndroid(this)
                 defaultConfig.targetSdk = 33

--- a/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+import com.google.samples.apps.nowinandroid.configureKotlinJvm
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class JvmLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("org.jetbrains.kotlin.jvm")
+            }
+            configureKotlinJvm()
+        }
+    }
+}

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -15,11 +15,7 @@
  */
 
 plugins {
-    id("kotlin")
-}
-
-kotlin {
-    jvmToolchain(11)
+    id("nowinandroid.jvm.library")
 }
 
 dependencies {


### PR DESCRIPTION
Hopefully one of the last of the JDK related PRs 🤞 

After this PR, all of the following should be true:

1. The app code (Android modules and JVM module) all target JDK 11 to match https://developer.android.com/studio/write/java11-minimal-support-table. This is configured in `KotlinAndroid.kt`, via convention plugins based on the type of module.
1. The project is built entirely using JDK 17, which matches the version embedded in Android Studio Flamingo, and is what is used on CI (GitHub Actions and internal). This removes all uses of `jvmToolchain` for `11`, which did help solve item 1, at the cost of needing two separate JDK versions available to build the project. This PR fixes #727.
1. The convention plugins in `build-logic` are configured to target JDK 17, which matches the JDK being used to build the project. This doesn't have anything to do with the code actually shipping to the device (item 1).