### PR TITLE
Grant `permission.POST_NOTIFICATIONS` in Macrobenchmark tests

### DIFF
--- a/benchmarks/src/main/java/com/google/samples/apps/nowinandroid/GeneralActions.kt
+++ b/benchmarks/src/main/java/com/google/samples/apps/nowinandroid/GeneralActions.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid
+
+import android.Manifest.permission
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.TIRAMISU
+import androidx.benchmark.macro.MacrobenchmarkScope
+
+/**
+ * Because the app under test is different from the one running the instrumentation test,
+ * the permission has to be granted manually by either:
+ *
+ * - tapping the Allow button
+ *    ```kotlin
+ *    val obj = By.text("Allow")
+ *    val dialog = device.wait(Until.findObject(obj), TIMEOUT)
+ *    dialog?.let {
+ *        it.click()
+ *        device.wait(Until.gone(obj), 5_000)
+ *    }
+ *    ```
+ * - or (preferred) executing the grant command on the target package.
+ */
+fun MacrobenchmarkScope.allowNotifications() {
+    if (SDK_INT >= TIRAMISU) {
+        val command = "pm grant $packageName ${permission.POST_NOTIFICATIONS}"
+        device.executeShellCommand(command)
+    }
+}

--- a/benchmarks/src/main/java/com/google/samples/apps/nowinandroid/foryou/ScrollForYouFeedBenchmark.kt
+++ b/benchmarks/src/main/java/com/google/samples/apps/nowinandroid/foryou/ScrollForYouFeedBenchmark.kt
@@ -22,6 +22,7 @@ import androidx.benchmark.macro.StartupMode
 import androidx.benchmark.macro.junit4.MacrobenchmarkRule
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import com.google.samples.apps.nowinandroid.PACKAGE_NAME
+import com.google.samples.apps.nowinandroid.allowNotifications
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -47,6 +48,7 @@ class ScrollForYouFeedBenchmark {
             // Start the app
             pressHome()
             startActivityAndWait()
+            allowNotifications()
         },
     ) {
         forYouWaitForContent()

--- a/benchmarks/src/main/java/com/google/samples/apps/nowinandroid/interests/TopicsScreenRecompositionBenchmark.kt
+++ b/benchmarks/src/main/java/com/google/samples/apps/nowinandroid/interests/TopicsScreenRecompositionBenchmark.kt
@@ -23,6 +23,7 @@ import androidx.benchmark.macro.junit4.MacrobenchmarkRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.uiautomator.By
 import com.google.samples.apps.nowinandroid.PACKAGE_NAME
+import com.google.samples.apps.nowinandroid.allowNotifications
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -47,7 +48,7 @@ class TopicsScreenRecompositionBenchmark {
                 // Start the app
                 pressHome()
                 startActivityAndWait()
-
+                allowNotifications()
                 // Navigate to interests screen
                 device.findObject(By.text("Interests")).click()
                 device.waitForIdle()


### PR DESCRIPTION
Description of the problem:
Benchmarks failing because this dialog is in the middle.

![aa](https://github.com/android/nowinandroid/assets/8226593/c568ebb1-840f-4e30-8c65-68054cc4e1f8)

Expected solution:

```
@get:Rule
val grantPermissionRule = GrantPermissionRule.grant(Manifest.permission.POST_NOTIFICATIONS)

@get:Rule
val benchmarkRule = MacrobenchmarkRule()
```

This [issue](https://issuetracker.google.com/283745750) is tracking the alternatives.
Actual solution: manually dismissing the Alert Dialog or executing the command programatically.