### PR TITLE
Update `BookmarksGrid` horizontal spacing to fix #732

### DIFF
--- a/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreen.kt
+++ b/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreen.kt
@@ -181,7 +181,7 @@ private fun BookmarksGrid(
     LazyVerticalGrid(
         columns = Adaptive(300.dp),
         contentPadding = PaddingValues(16.dp),
-        horizontalArrangement = Arrangement.spacedBy(32.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalArrangement = Arrangement.spacedBy(24.dp),
         state = scrollableState,
         modifier = modifier


### PR DESCRIPTION
Bookmarks screen is the only one to use a `32.dp` horizontal spacing:

https://github.com/android/nowinandroid/blob/d20910595522867067e7a7d1c542e95fc5f5155d/feature/bookmarks/src/main/java/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreen.kt#L181-L185

Other screens are using a `16.dp`

https://github.com/android/nowinandroid/blob/d20910595522867067e7a7d1c542e95fc5f5155d/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt#L149-L153

https://github.com/android/nowinandroid/blob/d20910595522867067e7a7d1c542e95fc5f5155d/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt#L293-L297

