### PR TITLE
Update benchmarks module minSdk to 28

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -25,7 +25,7 @@ android {
     namespace = "com.google.samples.apps.nowinandroid.benchmarks"
 
     defaultConfig {
-        minSdk = 23
+        minSdk = 28
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField("String", "APP_BUILD_TYPE_SUFFIX", "\"\"")


### PR DESCRIPTION
Call requires API level 24:
- `CompilationMode` sealed class

Calls requires API level 28:
- `BaselineProfileRule()`
- `baselineProfileRule.collectBaselineProfile(PACKAGE_NAME)`