### PR TITLE
Add type-safe access to Gradle Catalog versions and libraries in `build-logic`

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidApplicationFirebaseConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationFirebaseConventionPlugin.kt
@@ -16,12 +16,11 @@
 
 import com.android.build.api.dsl.ApplicationExtension
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
+import com.google.samples.apps.nowinandroid.nia
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
 
 class AndroidApplicationFirebaseConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -32,13 +31,12 @@ class AndroidApplicationFirebaseConventionPlugin : Plugin<Project> {
                 apply("com.google.firebase.crashlytics")
             }
 
-            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+            val libs = nia().libraries
             dependencies {
-                val bom = libs.findLibrary("firebase-bom").get()
-                add("implementation", platform(bom))
-                "implementation"(libs.findLibrary("firebase.analytics").get())
-                "implementation"(libs.findLibrary("firebase.performance").get())
-                "implementation"(libs.findLibrary("firebase.crashlytics").get())
+                add("implementation", platform(libs.`firebase-bom`))
+                add("implementation", libs.`firebase-analytics`)
+                add("implementation", libs.`firebase-performance`)
+                add("implementation", libs.`firebase-crashlytics`)
             }
 
             extensions.configure<ApplicationExtension> {

--- a/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
@@ -14,15 +14,13 @@
  *   limitations under the License.
  */
 
-import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.gradle.LibraryExtension
 import com.google.samples.apps.nowinandroid.configureGradleManagedDevices
+import com.google.samples.apps.nowinandroid.nia
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.kotlin
 
 class AndroidFeatureConventionPlugin : Plugin<Project> {
@@ -40,7 +38,7 @@ class AndroidFeatureConventionPlugin : Plugin<Project> {
                 configureGradleManagedDevices(this)
             }
 
-            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+            val libs = nia().libraries
 
             dependencies {
                 add("implementation", project(":core:model"))
@@ -56,14 +54,14 @@ class AndroidFeatureConventionPlugin : Plugin<Project> {
                 add("androidTestImplementation", kotlin("test"))
                 add("androidTestImplementation", project(":core:testing"))
 
-                add("implementation", libs.findLibrary("coil.kt").get())
-                add("implementation", libs.findLibrary("coil.kt.compose").get())
+                add("implementation", libs.`coil-kt`)
+                add("implementation", libs.`coil-kt-compose`)
 
-                add("implementation", libs.findLibrary("androidx.hilt.navigation.compose").get())
-                add("implementation", libs.findLibrary("androidx.lifecycle.runtimeCompose").get())
-                add("implementation", libs.findLibrary("androidx.lifecycle.viewModelCompose").get())
+                add("implementation", libs.`androidx-hilt-navigation-compose`)
+                add("implementation", libs.`androidx-lifecycle-runtimeCompose`)
+                add("implementation", libs.`androidx-lifecycle-viewModelCompose`)
 
-                add("implementation", libs.findLibrary("kotlinx.coroutines.android").get())
+                add("implementation", libs.`kotlinx-coroutines-android`)
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
@@ -14,11 +14,10 @@
  *   limitations under the License.
  */
 
+import com.google.samples.apps.nowinandroid.nia
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
 
 class AndroidHiltConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -30,11 +29,11 @@ class AndroidHiltConventionPlugin : Plugin<Project> {
                 apply("org.jetbrains.kotlin.kapt")
             }
 
-            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+            val libs = nia().libraries
             dependencies {
-                "implementation"(libs.findLibrary("hilt.android").get())
-                "kapt"(libs.findLibrary("hilt.compiler").get())
-                "kaptAndroidTest"(libs.findLibrary("hilt.compiler").get())
+                "implementation"(libs.`hilt-android`)
+                "kapt"(libs.`hilt-compiler`)
+                "kaptAndroidTest"(libs.`hilt-compiler`)
             }
 
         }

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -21,12 +21,11 @@ import com.google.samples.apps.nowinandroid.configureGradleManagedDevices
 import com.google.samples.apps.nowinandroid.configureKotlinAndroid
 import com.google.samples.apps.nowinandroid.configurePrintApksTask
 import com.google.samples.apps.nowinandroid.disableUnnecessaryAndroidTests
+import com.google.samples.apps.nowinandroid.nia
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.kotlin
 
 class AndroidLibraryConventionPlugin : Plugin<Project> {
@@ -47,10 +46,9 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 configurePrintApksTask(this)
                 disableUnnecessaryAndroidTests(target)
             }
-            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
             configurations.configureEach {
                 resolutionStrategy {
-                    force(libs.findLibrary("junit4").get())
+                    force(nia().libraries.junit4)
                     // Temporary workaround for https://issuetracker.google.com/174733673
                     force("org.objenesis:objenesis:2.6")
                 }

--- a/build-logic/convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
@@ -15,15 +15,14 @@
  */
 
 import com.google.devtools.ksp.gradle.KspExtension
+import com.google.samples.apps.nowinandroid.nia
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
 import org.gradle.process.CommandLineArgumentProvider
 import java.io.File
 
@@ -40,11 +39,11 @@ class AndroidRoomConventionPlugin : Plugin<Project> {
                 arg(RoomSchemaArgProvider(File(projectDir, "schemas")))
             }
 
-            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+            val libs = nia().libraries
             dependencies {
-                add("implementation", libs.findLibrary("room.runtime").get())
-                add("implementation", libs.findLibrary("room.ktx").get())
-                add("ksp", libs.findLibrary("room.compiler").get())
+                add("implementation", libs.`room-runtime`)
+                add("implementation", libs.`room-ktx`)
+                add("ksp", libs.`room-compiler`)
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidCompose.kt
@@ -18,9 +18,7 @@ package com.google.samples.apps.nowinandroid
 
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
@@ -31,7 +29,6 @@ import java.io.File
 internal fun Project.configureAndroidCompose(
     commonExtension: CommonExtension<*, *, *, *>,
 ) {
-    val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 
     commonExtension.apply {
         buildFeatures {
@@ -39,11 +36,11 @@ internal fun Project.configureAndroidCompose(
         }
 
         composeOptions {
-            kotlinCompilerExtensionVersion = libs.findVersion("androidxComposeCompiler").get().toString()
+            kotlinCompilerExtensionVersion = nia().versions.androidxComposeCompiler.toString()
         }
 
         dependencies {
-            val bom = libs.findLibrary("androidx-compose-bom").get()
+            val bom = nia().libraries.`androidx-compose-bom`
             add("implementation", platform(bom))
             add("androidTestImplementation", platform(bom))
         }

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Jacoco.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Jacoco.kt
@@ -18,10 +18,8 @@ package com.google.samples.apps.nowinandroid
 
 import com.android.build.api.variant.AndroidComponentsExtension
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
@@ -44,10 +42,8 @@ private fun String.capitalize() = replaceFirstChar {
 internal fun Project.configureJacoco(
     androidComponentsExtension: AndroidComponentsExtension<*, *, *>,
 ) {
-    val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
-
     configure<JacocoPluginExtension> {
-        toolVersion = libs.findVersion("jacoco").get().toString()
+        toolVersion = nia().versions.jacoco.toString()
     }
 
     val jacocoTestReport = tasks.create("jacocoTestReport")

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
@@ -16,20 +16,14 @@
 
 package com.google.samples.apps.nowinandroid
 
-import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**
@@ -56,10 +50,8 @@ internal fun Project.configureKotlinAndroid(
 
     configureKotlin()
 
-    val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
-
     dependencies {
-        add("coreLibraryDesugaring", libs.findLibrary("android.desugarJdkLibs").get())
+        add("coreLibraryDesugaring", nia().libraries.`android-desugarJdkLibs`)
     }
 }
 

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaProperties.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaProperties.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.artifacts.VersionConstraint
+import org.gradle.api.provider.Provider
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.provideDelegate
+import kotlin.reflect.KProperty
+
+internal fun Project.nia() = NiaProperties(this)
+
+internal class NiaProperties private constructor(project: Project) {
+    private val catalog by lazy(project.rootProject::getVersionsCatalog)
+    val libraries by lazy { NiaLibraries(catalog) }
+    val versions by lazy { NiaVersions(catalog) }
+
+    companion object {
+        private const val EXT_KEY = "com.google.samples.apps.nowinandroid.NiaProperties"
+        operator fun invoke(project: Project) = project.getOrCreateExtra(EXT_KEY, ::NiaProperties)
+    }
+}
+
+internal class NiaVersions(catalog: VersionCatalog) {
+    val androidxComposeCompiler by catalog
+    val jacoco by catalog
+
+    private operator fun VersionCatalog.getValue(
+        thisRef: Any?,
+        property: KProperty<*>,
+    ): VersionConstraint = findVersion(property.name).orElseThrow {
+        IllegalStateException("Missing catalog version '${property.name}'")
+    }
+}
+
+@Suppress("PropertyName")
+internal class NiaLibraries(catalog: VersionCatalog) {
+    val `android-desugarJdkLibs` by catalog
+    val `androidx-compose-bom` by catalog
+    val `androidx-hilt-navigation-compose` by catalog
+    val `androidx-lifecycle-runtimeCompose` by catalog
+    val `androidx-lifecycle-viewModelCompose` by catalog
+    val `coil-kt-compose` by catalog
+    val `coil-kt` by catalog
+    val `firebase-analytics` by catalog
+    val `firebase-bom` by catalog
+    val `firebase-crashlytics` by catalog
+    val `firebase-performance` by catalog
+    val `hilt-android` by catalog
+    val `hilt-compiler` by catalog
+    val `kotlinx-coroutines-android` by catalog
+    val `room-compiler` by catalog
+    val `room-ktx` by catalog
+    val `room-runtime` by catalog
+    val junit4 by catalog
+
+    private operator fun VersionCatalog.getValue(
+        thisRef: Any?,
+        property: KProperty<*>,
+    ): Provider<MinimalExternalModuleDependency> = findLibrary(property.name).orElseThrow {
+        IllegalStateException("Missing catalog library '${property.name}'")
+    }
+}
+
+private fun Project.getVersionsCatalog(): VersionCatalog = runCatching {
+    project.extensions.getByType<VersionCatalogsExtension>().named("libs")
+}.recoverCatching {
+    throw IllegalStateException("No versions catalog found!", it)
+}.getOrThrow()
+
+private fun <T> Project.getOrCreateExtra(
+    key: String,
+    create: (Project) -> T,
+): T = extensions.extraProperties.run {
+    @Suppress("UNCHECKED_CAST")
+    (if (has(key)) get(key) as? T else null) ?: create(project).also { set(key, it) }
+}


### PR DESCRIPTION
I'd like to get your feedback on this change.

- Before:
  ```kotlin
  dependencies {
      val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
      add("implementation", libs.findLibrary("x.y.z").get())
  }
  ```

- After:
  ```kotlin
  dependencies {
      add("implementation", nia().libraries.`x-y-z`)
  }
  ```

If the name in the catalog changes, or an unknown name is requested, the following error will be thrown by Gradle:

```
An exception occurred applying plugin request [id: 'x.y.z']
> Failed to apply plugin 'x.y.z'.
   > Missing catalog library 'foo'
```

It uses a caching strategy (based on `extensions.extraProperties`) to prevent creating multiple instances of `NiaProperties`.

---

And if we really want to push the "transparent" API (and get the same names as we get in other Gradle modules) we could introduce a dynamic getter:

```kotlin
internal val Project.libs get() = NiaProperties(this).libraries
```

----

Edit: one step closer to #317