### PR TITLE
Remove benchmark androidTest task exclusion

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -100,7 +100,7 @@ jobs:
           disable-animations: true
           disk-size: 6000M
           heap-size: 600M
-          script: ./gradlew connectedDemoDebugAndroidTest -x :benchmark:connectedDemoBenchmarkAndroidTest --daemon
+          script: ./gradlew connectedDemoDebugAndroidTest --daemon
 
       - name: Upload test reports
         if: always()


### PR DESCRIPTION
Task `:benchmark:connectedDemoBenchmarkAndroidTest` is not part of the `connectedDemoDebugAndroidTest` task graph and can therefore safely be removed.