### PR TITLE
Grant `POST_NOTIFICATIONS` permission in more instrumented tests

### DIFF
--- a/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
@@ -33,6 +33,7 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.NoActivityResumedException
 import com.google.samples.apps.nowinandroid.MainActivity
 import com.google.samples.apps.nowinandroid.R
+import com.google.samples.apps.nowinandroid.core.rules.GrantPostNotificationsPermissionRule
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -66,9 +67,15 @@ class NavigationTest {
     val tmpFolder: TemporaryFolder = TemporaryFolder.builder().assureDeletion().build()
 
     /**
-     * Use the primary activity to initialize the app normally.
+     * Grant [android.Manifest.permission.POST_NOTIFICATIONS] permission.
      */
     @get:Rule(order = 2)
+    val postNotificationsPermission = GrantPostNotificationsPermissionRule()
+
+    /**
+     * Use the primary activity to initialize the app normally.
+     */
+    @get:Rule(order = 3)
     val composeTestRule = createAndroidComposeRule<MainActivity>()
 
     private fun AndroidComposeTestRule<*, *>.stringResource(@StringRes resId: Int) =

--- a/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationUiTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationUiTest.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import com.google.accompanist.testharness.TestHarness
 import com.google.samples.apps.nowinandroid.core.data.repository.CompositeUserNewsResourceRepository
 import com.google.samples.apps.nowinandroid.core.data.util.NetworkMonitor
+import com.google.samples.apps.nowinandroid.core.rules.GrantPostNotificationsPermissionRule
 import com.google.samples.apps.nowinandroid.core.testing.repository.TestNewsRepository
 import com.google.samples.apps.nowinandroid.core.testing.repository.TestUserDataRepository
 import com.google.samples.apps.nowinandroid.uitesthiltmanifest.HiltComponentActivity
@@ -61,9 +62,15 @@ class NavigationUiTest {
     val tmpFolder: TemporaryFolder = TemporaryFolder.builder().assureDeletion().build()
 
     /**
-     * Use a test activity to set the content on.
+     * Grant [android.Manifest.permission.POST_NOTIFICATIONS] permission.
      */
     @get:Rule(order = 2)
+    val postNotificationsPermission = GrantPostNotificationsPermissionRule()
+
+    /**
+     * Use a test activity to set the content on.
+     */
+    @get:Rule(order = 3)
     val composeTestRule = createAndroidComposeRule<HiltComponentActivity>()
 
     val userNewsResourceRepository = CompositeUserNewsResourceRepository(

--- a/core/testing/src/main/java/com/google/samples/apps/nowinandroid/core/rules/GrantPostNotificationsPermissionRule.kt
+++ b/core/testing/src/main/java/com/google/samples/apps/nowinandroid/core/rules/GrantPostNotificationsPermissionRule.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid.core.rules
+
+import android.Manifest.permission.POST_NOTIFICATIONS
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.TIRAMISU
+import androidx.test.rule.GrantPermissionRule.grant
+import org.junit.rules.TestRule
+
+/**
+ * [TestRule] granting [POST_NOTIFICATIONS] permission if running on [SDK_INT] greater than [TIRAMISU].
+ */
+class GrantPostNotificationsPermissionRule :
+    TestRule by if (SDK_INT >= TIRAMISU) grant(POST_NOTIFICATIONS) else grant()

--- a/feature/foryou/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreenTest.kt
+++ b/feature/foryou/src/androidTest/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreenTest.kt
@@ -16,9 +16,6 @@
 
 package com.google.samples.apps.nowinandroid.feature.foryou
 
-import android.Manifest
-import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.ui.test.assertHasClickAction
@@ -31,8 +28,7 @@ import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollToNode
-import androidx.test.rule.GrantPermissionRule
-import androidx.test.rule.GrantPermissionRule.grant
+import com.google.samples.apps.nowinandroid.core.rules.GrantPostNotificationsPermissionRule
 import com.google.samples.apps.nowinandroid.core.testing.data.followableTopicTestData
 import com.google.samples.apps.nowinandroid.core.testing.data.userNewsResourcesTestData
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState
@@ -41,15 +37,10 @@ import org.junit.Test
 
 class ForYouScreenTest {
 
-    @get:Rule
-    val permissionTestRule: GrantPermissionRule =
-        if (SDK_INT >= TIRAMISU) {
-            grant(Manifest.permission.POST_NOTIFICATIONS)
-        } else {
-            grant()
-        }
+    @get:Rule(order = 0)
+    val postNotificationsPermission = GrantPostNotificationsPermissionRule()
 
-    @get:Rule
+    @get:Rule(order = 1)
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     private val doneButtonMatcher by lazy {


### PR DESCRIPTION
Continues the work initiated in #738.
Extract the SDK version check inside a `GrantPostNotificationPermissionRule` class that delegates to a regular `GrantPermissionRule`.