### PR TITLE
Ensure DAO exposes only reactive types

### DIFF
--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/DefaultSearchContentsRepository.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/DefaultSearchContentsRepository.kt
@@ -20,6 +20,7 @@ import com.google.samples.apps.nowinandroid.core.database.dao.NewsResourceDao
 import com.google.samples.apps.nowinandroid.core.database.dao.NewsResourceFtsDao
 import com.google.samples.apps.nowinandroid.core.database.dao.TopicDao
 import com.google.samples.apps.nowinandroid.core.database.dao.TopicFtsDao
+import com.google.samples.apps.nowinandroid.core.database.model.PopulatedNewsResource
 import com.google.samples.apps.nowinandroid.core.database.model.asExternalModel
 import com.google.samples.apps.nowinandroid.core.database.model.asFtsEntity
 import com.google.samples.apps.nowinandroid.core.model.data.SearchResult
@@ -29,6 +30,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.withContext
@@ -45,7 +47,12 @@ class DefaultSearchContentsRepository @Inject constructor(
     override suspend fun populateFtsData() {
         withContext(ioDispatcher) {
             newsResourceFtsDao.insertAll(
-                newsResourceDao.getOneOffNewsResources().map { it.asFtsEntity() },
+                newsResourceDao.getNewsResources(
+                    useFilterTopicIds = false,
+                    useFilterNewsIds = false,
+                )
+                    .first()
+                    .map(PopulatedNewsResource::asFtsEntity),
             )
             topicFtsDao.insertAll(topicDao.getOneOffTopicEntities().map { it.asFtsEntity() })
         }

--- a/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNewsResourceDao.kt
+++ b/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNewsResourceDao.kt
@@ -67,8 +67,6 @@ class TestNewsResourceDao : NewsResourceDao {
                 result
             }
 
-    override suspend fun getOneOffNewsResources(): List<PopulatedNewsResource> = emptyList()
-
     override suspend fun insertOrIgnoreNewsResources(
         entities: List<NewsResourceEntity>,
     ): List<Long> {

--- a/core/database/src/main/java/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceDao.kt
+++ b/core/database/src/main/java/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceDao.kt
@@ -65,10 +65,6 @@ interface NewsResourceDao {
         filterNewsIds: Set<String> = emptySet(),
     ): Flow<List<PopulatedNewsResource>>
 
-    @Transaction
-    @Query(value = "SELECT * FROM news_resources ORDER BY publish_date DESC")
-    suspend fun getOneOffNewsResources(): List<PopulatedNewsResource>
-
     /**
      * Inserts [entities] into the db if they don't exist, and ignores those that do
      */


### PR DESCRIPTION
The [architecture design](https://github.com/android/nowinandroid/blob/main/docs/ArchitectureLearningJourney.md) of NiA requires that all types exposed by the data layer are reactive. This is make sure consumers are aware that data may change over time and must be ready to react to that change.

If a consumer wants a snapshot of data, they _MUST_ explicitly opt out of reactivity, in the case of the PR by using the `first()` operator. This is also done in `OfflineFirstNewsRepository` when it is posting notifications.