### PR TITLE
Add general application scope, use IO dispatcher for DataStore

### DIFF
--- a/core/common/src/main/java/com/google/samples/apps/nowinandroid/core/network/di/CoroutineScopesModule.kt
+++ b/core/common/src/main/java/com/google/samples/apps/nowinandroid/core/network/di/CoroutineScopesModule.kt
@@ -17,7 +17,7 @@
 package com.google.samples.apps.nowinandroid.core.network.di
 
 import com.google.samples.apps.nowinandroid.core.network.Dispatcher
-import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.IO
+import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.Default
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -25,15 +25,20 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import javax.inject.Qualifier
 import javax.inject.Singleton
+
+@Retention(AnnotationRetention.RUNTIME)
+@Qualifier
+annotation class ApplicationScope
 
 @Module
 @InstallIn(SingletonComponent::class)
 object CoroutineScopesModule {
     @Provides
     @Singleton
-    @Dispatcher(IO)
-    fun providesIOCoroutineScope(
-        @Dispatcher(IO) ioDispatcher: CoroutineDispatcher,
-    ): CoroutineScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    @ApplicationScope
+    fun providesCoroutineScope(
+        @Dispatcher(Default) dispatcher: CoroutineDispatcher,
+    ): CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
 }

--- a/core/data-test/build.gradle.kts
+++ b/core/data-test/build.gradle.kts
@@ -25,4 +25,5 @@ android {
 dependencies {
     api(project(":core:data"))
     implementation(project(":core:testing"))
+    implementation(project(":core:common"))
 }

--- a/core/datastore-test/build.gradle.kts
+++ b/core/datastore-test/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     api(project(":core:datastore"))
     api(libs.androidx.dataStore.core)
 
+    implementation(libs.protobuf.kotlin.lite)
     implementation(project(":core:common"))
     implementation(project(":core:testing"))
 }

--- a/core/datastore-test/src/main/java/com/google/samples/apps/nowinandroid/core/datastore/test/TestDataStoreModule.kt
+++ b/core/datastore-test/src/main/java/com/google/samples/apps/nowinandroid/core/datastore/test/TestDataStoreModule.kt
@@ -21,8 +21,7 @@ import androidx.datastore.core.DataStoreFactory
 import com.google.samples.apps.nowinandroid.core.datastore.UserPreferences
 import com.google.samples.apps.nowinandroid.core.datastore.UserPreferencesSerializer
 import com.google.samples.apps.nowinandroid.core.datastore.di.DataStoreModule
-import com.google.samples.apps.nowinandroid.core.network.Dispatcher
-import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.IO
+import com.google.samples.apps.nowinandroid.core.network.di.ApplicationScope
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
@@ -41,12 +40,12 @@ object TestDataStoreModule {
     @Provides
     @Singleton
     fun providesUserPreferencesDataStore(
-        @Dispatcher(IO) ioScope: CoroutineScope,
+        @ApplicationScope scope: CoroutineScope,
         userPreferencesSerializer: UserPreferencesSerializer,
         tmpFolder: TemporaryFolder,
     ): DataStore<UserPreferences> =
         tmpFolder.testUserPreferencesDataStore(
-            coroutineScope = ioScope,
+            coroutineScope = scope,
             userPreferencesSerializer = userPreferencesSerializer,
         )
 }

--- a/core/datastore/src/main/java/com/google/samples/apps/nowinandroid/core/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/java/com/google/samples/apps/nowinandroid/core/datastore/di/DataStoreModule.kt
@@ -25,11 +25,13 @@ import com.google.samples.apps.nowinandroid.core.datastore.UserPreferences
 import com.google.samples.apps.nowinandroid.core.datastore.UserPreferencesSerializer
 import com.google.samples.apps.nowinandroid.core.network.Dispatcher
 import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.IO
+import com.google.samples.apps.nowinandroid.core.network.di.ApplicationScope
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import javax.inject.Singleton
 
@@ -41,12 +43,13 @@ object DataStoreModule {
     @Singleton
     fun providesUserPreferencesDataStore(
         @ApplicationContext context: Context,
-        @Dispatcher(IO) ioScope: CoroutineScope,
+        @Dispatcher(IO) ioDispatcher: CoroutineDispatcher,
+        @ApplicationScope scope: CoroutineScope,
         userPreferencesSerializer: UserPreferencesSerializer,
     ): DataStore<UserPreferences> =
         DataStoreFactory.create(
             serializer = userPreferencesSerializer,
-            scope = ioScope,
+            scope = CoroutineScope(scope.coroutineContext + ioDispatcher),
             migrations = listOf(
                 IntToStringIdsMigration,
             ),

--- a/core/testing/src/main/java/com/google/samples/apps/nowinandroid/core/testing/di/TestDispatchersModule.kt
+++ b/core/testing/src/main/java/com/google/samples/apps/nowinandroid/core/testing/di/TestDispatchersModule.kt
@@ -17,6 +17,7 @@
 package com.google.samples.apps.nowinandroid.core.testing.di
 
 import com.google.samples.apps.nowinandroid.core.network.Dispatcher
+import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.Default
 import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.IO
 import com.google.samples.apps.nowinandroid.core.network.di.DispatchersModule
 import dagger.Module
@@ -35,4 +36,10 @@ object TestDispatchersModule {
     @Provides
     @Dispatcher(IO)
     fun providesIODispatcher(testDispatcher: TestDispatcher): CoroutineDispatcher = testDispatcher
+
+    @Provides
+    @Dispatcher(Default)
+    fun providesDefaultDispatcher(
+        testDispatcher: TestDispatcher,
+    ): CoroutineDispatcher = testDispatcher
 }


### PR DESCRIPTION
After chatting to colleagues (@manuelvicnt and @zsmb13) about @SimonMarquis's PR (https://github.com/android/nowinandroid/pull/681) to add an application-wide scope, we concluded that there should only be a single application scope, and if consumers of that scope (e.g. for DataStore access) need to use a different dispatcher then they should just override it, like so: 

```
CoroutineScope(applicationScope.context + differentDispatcher)
```

This PR implements those changes. 

