### PR TITLE
Fix lint warnings `ComposableModifierFactory` and `ModifierFactoryExtensionFunction`

### DIFF
--- a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -279,16 +280,15 @@ private fun NiaBottomBar(
                     }
                 },
                 label = { Text(stringResource(destination.iconTextId)) },
-                modifier = if (hasUnread) notificationDot() else Modifier,
+                modifier = if (hasUnread) Modifier.notificationDot() else Modifier,
             )
         }
     }
 }
 
-@Composable
-private fun notificationDot(): Modifier {
+private fun Modifier.notificationDot(): Modifier = composed {
     val tertiaryColor = MaterialTheme.colorScheme.tertiary
-    return Modifier.drawWithContent {
+    drawWithContent {
         drawContent()
         drawCircle(
             tertiaryColor,


### PR DESCRIPTION
- `ComposableModifierFactory`: Modifier factory functions that need to be aware of the composition should use androidx.compose.ui.composed {} in their implementation instead of being marked as @Composable. This allows Modifiers to be referenced in top level variables and constructed outside of the composition.

- `ModifierFactoryExtensionFunction`: Modifier factory functions should be defined as extension functions on Modifier to allow modifiers to be fluently chained.