### PR TITLE
Gradle configure cache property is no longer `unsafe`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.configureondemand=false
 org.gradle.caching=true
 
 # Enable configuration caching between builds.
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true
 
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK


### PR DESCRIPTION
<html>
<body>
<!--StartFragment-->

Incubating property | Finalized property
-- | --
org.gradle.unsafe.configuration-cache | org.gradle.configuration-cache
org.gradle.unsafe.configuration-cache-problems | org.gradle.configuration-cache.problems*
org.gradle.unsafe.configuration-cache.max-problems | org.gradle.configuration-cache.max-problems

<!--EndFragment-->
</body>
</html>

https://docs.gradle.org/current/userguide/upgrading_version_8.html#configuration_caching_options_renamed