### PR TITLE
Revert "Remove `ExperimentalCoroutinesApi` and `FlowPreview` opt-in"

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
@@ -88,6 +88,9 @@ private fun Project.configureKotlin() {
             allWarningsAsErrors = warningsAsErrors.toBoolean()
             freeCompilerArgs = freeCompilerArgs + listOf(
                 "-opt-in=kotlin.RequiresOptIn",
+                // Enable experimental coroutines APIs, including Flow
+                "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+                "-opt-in=kotlinx.coroutines.FlowPreview",
             )
         }
     }


### PR DESCRIPTION
Reverts android/nowinandroid#758

Unfortunately, the "real" issue was that `:core:model` could not resolve these Opt-in requirement markers because it does not use Kotlin coroutines.
The opt-in could be declared only on modules using the dependencies, but then it becomes tedious to fix.

Sorry for that.