### PR TITLE
[do not merge] Build project with K2 compiler

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,3 +38,6 @@ android.nonTransitiveRClass=true
 # https://developer.android.com/build/releases/gradle-plugin#default-changes
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
+
+# Use K2 compiler
+kotlin.experimental.tryK2=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,5 +39,12 @@ android.nonTransitiveRClass=true
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 
+# Use latest lint alpha for best available K2 support
+# https://googlesamples.github.io/android-custom-lint-rules/usage/newer-lint.md.html
+android.experimental.lint.version=8.2.0-alpha14
+
 # Use K2 compiler
 kotlin.experimental.tryK2=true
+
+# Run lint on K2
+android.lint.useK2Uast=true


### PR DESCRIPTION
This PR demonstrates trying the [K2 compiler](https://kotlinlang.org/docs/whatsnew19.html#new-kotlin-k2-compiler-updates) in an Android project.

It should be continuously rebased onto `main` to ensure that everything still works on the K2 compiler, but only merged once K2 is stable.