### PR TITLE
Fix ForYouScreen Compose Previews

### DIFF
--- a/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -407,7 +407,8 @@ fun TopicIcon(
 @Composable
 @OptIn(ExperimentalPermissionsApi::class)
 private fun NotificationPermissionEffect() {
-    // Permissions should be called from in an Activity Context, which is not present in previews
+    // Permissions should be called from in an Activity Context, which is not present
+    // in previews
     if (LocalInspectionMode.current) return
     if (VERSION.SDK_INT < VERSION_CODES.TIRAMISU) return
     val notificationsPermissionState = rememberPermissionState(

--- a/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -407,7 +407,7 @@ fun TopicIcon(
 @Composable
 @OptIn(ExperimentalPermissionsApi::class)
 private fun NotificationPermissionEffect() {
-    // Permissions should be called from in an Activity Context, which is not present
+    // Permission requests should only be made from an Activity Context, which is not present
     // in previews
     if (LocalInspectionMode.current) return
     if (VERSION.SDK_INT < VERSION_CODES.TIRAMISU) return

--- a/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -68,6 +68,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -406,6 +407,8 @@ fun TopicIcon(
 @Composable
 @OptIn(ExperimentalPermissionsApi::class)
 private fun NotificationPermissionEffect() {
+    // Permissions should be called from in an Activity Context, which is not present in previews
+    if (LocalInspectionMode.current) return
     if (VERSION.SDK_INT < VERSION_CODES.TIRAMISU) return
     val notificationsPermissionState = rememberPermissionState(
         android.Manifest.permission.POST_NOTIFICATIONS,


### PR DESCRIPTION
Permissions should only be called in an Activity context, which is a layoutlib limitation. We need to avoid launching the permission request when in LocalInspectionMode, otherwise we'll have render errors on the ForYouScreen previews.