### PR TITLE
[Feature] Optimizing the populated news resources based on filtering

### DIFF
--- a/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepository.kt
+++ b/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepository.kt
@@ -80,17 +80,14 @@ class OfflineFirstNewsRepository @Inject constructor(
                 val hasOnboarded = userData.shouldHideOnboarding
                 val followedTopicIds = userData.followedTopics
 
-                // TODO: Make this more efficient, there is no need to retrieve populated
-                //  news resources when all that's needed are the ids
                 val existingNewsResourceIdsThatHaveChanged = when {
-                    hasOnboarded -> newsResourceDao.getNewsResources(
+                    hasOnboarded -> newsResourceDao.getNewsResourceIdsByFilter(
                         useFilterTopicIds = true,
-                        filterTopicIds = followedTopicIds,
+                        filterTopicIds = followedTopicIds.toSet(),
                         useFilterNewsIds = true,
                         filterNewsIds = changedIds.toSet(),
                     )
                         .first()
-                        .map { it.entity.id }
                         .toSet()
                     // No need to retrieve anything if notifications won't be sent
                     else -> emptySet()

--- a/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNewsResourceDao.kt
+++ b/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNewsResourceDao.kt
@@ -75,9 +75,11 @@ class TestNewsResourceDao : NewsResourceDao {
     ): Flow<List<String>> {
         val filteredNewsResourceIds = entitiesStateFlow.map { newsResourceEntities ->
             newsResourceEntities.filter { entity ->
-                !useFilterTopicIds || topicCrossReferences.any {
-                    it.newsResourceId == entity.id && it.topicId in filterTopicIds
-                } && (!useFilterNewsIds || entity.id in filterNewsIds)
+                (
+                    !useFilterTopicIds || topicCrossReferences.any {
+                        it.newsResourceId == entity.id && it.topicId in filterTopicIds
+                    }
+                    ) && (!useFilterNewsIds || entity.id in filterNewsIds)
             }.map { it.id }
         }
         return filteredNewsResourceIds

--- a/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNewsResourceDao.kt
+++ b/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNewsResourceDao.kt
@@ -75,12 +75,9 @@ class TestNewsResourceDao : NewsResourceDao {
     ): Flow<List<String>> {
         val filteredNewsResourceIds = entitiesStateFlow.map { newsResourceEntities ->
             newsResourceEntities.filter { entity ->
-                (
-                    !useFilterTopicIds || topicCrossReferences.any {
-                        it.newsResourceId == entity.id && it.topicId in filterTopicIds
-                    }
-                    ) &&
-                    (!useFilterNewsIds || entity.id in filterNewsIds)
+                !useFilterTopicIds || topicCrossReferences.any {
+                    it.newsResourceId == entity.id && it.topicId in filterTopicIds
+                } && (!useFilterNewsIds || entity.id in filterNewsIds)
             }.map { it.id }
         }
         return filteredNewsResourceIds

--- a/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNewsResourceDao.kt
+++ b/core/data/src/test/java/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNewsResourceDao.kt
@@ -67,6 +67,25 @@ class TestNewsResourceDao : NewsResourceDao {
                 result
             }
 
+    override fun getNewsResourceIdsByFilter(
+        useFilterTopicIds: Boolean,
+        filterTopicIds: Set<String>,
+        useFilterNewsIds: Boolean,
+        filterNewsIds: Set<String>,
+    ): Flow<List<String>> {
+        val filteredNewsResourceIds = entitiesStateFlow.map { newsResourceEntities ->
+            newsResourceEntities.filter { entity ->
+                (
+                    !useFilterTopicIds || topicCrossReferences.any {
+                        it.newsResourceId == entity.id && it.topicId in filterTopicIds
+                    }
+                    ) &&
+                    (!useFilterNewsIds || entity.id in filterNewsIds)
+            }.map { it.id }
+        }
+        return filteredNewsResourceIds
+    }
+
     override suspend fun insertOrIgnoreNewsResources(
         entities: List<NewsResourceEntity>,
     ): List<Long> {

--- a/core/database/src/androidTest/java/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceDaoTest.kt
+++ b/core/database/src/androidTest/java/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceDaoTest.kt
@@ -25,6 +25,7 @@ import com.google.samples.apps.nowinandroid.core.database.model.NewsResourceTopi
 import com.google.samples.apps.nowinandroid.core.database.model.TopicEntity
 import com.google.samples.apps.nowinandroid.core.database.model.asExternalModel
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResourceType
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
@@ -50,6 +51,7 @@ class NewsResourceDaoTest {
     }
 
     @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun newsResourceDao_fetches_items_by_descending_publish_date() = runTest {
         val newsResourceEntities = listOf(
             testNewsResource(
@@ -85,6 +87,7 @@ class NewsResourceDaoTest {
     }
 
     @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun newsResourceDao_filters_items_by_news_ids_by_descending_publish_date() = runTest {
         val newsResourceEntities = listOf(
             testNewsResource(
@@ -123,6 +126,7 @@ class NewsResourceDaoTest {
     }
 
     @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun newsResourceDao_filters_items_by_topic_ids_by_descending_publish_date() = runTest {
         val topicEntities = listOf(
             testTopicEntity(
@@ -183,6 +187,7 @@ class NewsResourceDaoTest {
     }
 
     @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun newsResourceDao_filters_items_by_news_and_topic_ids_by_descending_publish_date() = runTest {
         val topicEntities = listOf(
             testTopicEntity(
@@ -245,42 +250,42 @@ class NewsResourceDaoTest {
     }
 
     @Test
-    fun newsResourceDao_deletes_items_by_ids() =
-        runTest {
-            val newsResourceEntities = listOf(
-                testNewsResource(
-                    id = "0",
-                    millisSinceEpoch = 0,
-                ),
-                testNewsResource(
-                    id = "1",
-                    millisSinceEpoch = 3,
-                ),
-                testNewsResource(
-                    id = "2",
-                    millisSinceEpoch = 1,
-                ),
-                testNewsResource(
-                    id = "3",
-                    millisSinceEpoch = 2,
-                ),
-            )
-            newsResourceDao.upsertNewsResources(newsResourceEntities)
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun newsResourceDao_deletes_items_by_ids() = runTest {
+        val newsResourceEntities = listOf(
+            testNewsResource(
+                id = "0",
+                millisSinceEpoch = 0,
+            ),
+            testNewsResource(
+                id = "1",
+                millisSinceEpoch = 3,
+            ),
+            testNewsResource(
+                id = "2",
+                millisSinceEpoch = 1,
+            ),
+            testNewsResource(
+                id = "3",
+                millisSinceEpoch = 2,
+            ),
+        )
+        newsResourceDao.upsertNewsResources(newsResourceEntities)
 
-            val (toDelete, toKeep) = newsResourceEntities.partition { it.id.toInt() % 2 == 0 }
+        val (toDelete, toKeep) = newsResourceEntities.partition { it.id.toInt() % 2 == 0 }
 
-            newsResourceDao.deleteNewsResources(
-                toDelete.map(NewsResourceEntity::id),
-            )
+        newsResourceDao.deleteNewsResources(
+            toDelete.map(NewsResourceEntity::id),
+        )
 
-            assertEquals(
-                toKeep.map(NewsResourceEntity::id)
-                    .toSet(),
-                newsResourceDao.getNewsResources().first()
-                    .map { it.entity.id }
-                    .toSet(),
-            )
-        }
+        assertEquals(
+            toKeep.map(NewsResourceEntity::id)
+                .toSet(),
+            newsResourceDao.getNewsResources().first()
+                .map { it.entity.id }
+                .toSet(),
+        )
+    }
 }
 
 private fun testTopicEntity(

--- a/core/database/src/main/java/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceDao.kt
+++ b/core/database/src/main/java/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceDao.kt
@@ -66,6 +66,26 @@ interface NewsResourceDao {
     ): Flow<List<PopulatedNewsResource>>
 
     /**
+     * Retrieves news resource IDs based on topic and news filters.
+     */
+    @Query(
+        value = """
+    SELECT news_resources.id
+    FROM news_resources
+    INNER JOIN news_resources_topics
+    ON news_resources.id = news_resources_topics.news_resource_id
+    WHERE (:useFilterTopicIds = 0 OR news_resources_topics.topic_id IN (:filterTopicIds))
+    AND (:useFilterNewsIds = 0 OR news_resources.id IN (:filterNewsIds))
+    """,
+    )
+    fun getNewsResourceIdsByFilter(
+        useFilterTopicIds: Boolean,
+        filterTopicIds: Set<String>,
+        useFilterNewsIds: Boolean,
+        filterNewsIds: Set<String>,
+    ): Flow<List<String>>
+
+    /**
      * Inserts [entities] into the db if they don't exist, and ignores those that do
      */
     @Insert(onConflict = OnConflictStrategy.IGNORE)


### PR DESCRIPTION
There was a TODO in the `OfflineFirstNewsRepository` class which was referring to making the `getNewsResources()` more efficient. In this PR, it retrieves the news resource IDs based on filter conditions using the `getNewsResourceIdsByFilter()` function and makes it more efficient.