### PR TITLE
Update GMD workflow

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -138,13 +138,16 @@ jobs:
         run: ./gradlew packageDemoDebug packageDemoDebugAndroidTest
 
       - name: Run instrumented tests with GMD
-        run: ./gradlew cleanManagedDevices --unused-only &&
-          ./gradlew ciDemoDebugAndroidTest -Dorg.gradle.workers.max=1
+        run: ./gradlew ciDemoDebugAndroidTest --no-parallel --max-workers=1
           -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true
 
       - name: Upload test reports
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
-          name: test-reports
+          name: test-reports-GMD
           path: '**/build/reports/androidTests'
+
+      - name: Print disk space usage
+        if: failure()
+        run: df -h


### PR DESCRIPTION
- Add `--no-parallel --max-workers=1` (was not able to trigger the error locally whit this combination).
- Remove useless `cleanManagedDevices` as devices are not persisted across runs.
- Rename test reports artifact to `test-reports-GMD` similar to `test-reports-${{ matrix.api-level }}`.
- Print disk space usage in case of failure.