### PR TITLE
Add contentType to news feed

### DIFF
--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
@@ -58,7 +58,7 @@ fun LazyGridScope.newsFeed(
         NewsFeedUiState.Loading -> Unit
         is NewsFeedUiState.Success -> {
             items(
-                feedState.feed,
+                items = feedState.feed,
                 key = { it.id },
                 contentType = { "newsFeedItem" },
             ) { userNewsResource ->

--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
@@ -57,7 +57,11 @@ fun LazyGridScope.newsFeed(
     when (feedState) {
         NewsFeedUiState.Loading -> Unit
         is NewsFeedUiState.Success -> {
-            items(feedState.feed, key = { it.id }) { userNewsResource ->
+            items(
+                feedState.feed,
+                key = { it.id },
+                contentType = { "newsFeedItem" },
+            ) { userNewsResource ->
                 val resourceUrl by remember {
                     mutableStateOf(Uri.parse(userNewsResource.url))
                 }

--- a/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -182,7 +182,7 @@ internal fun ForYouScreen(
             onTopicClick = onTopicClick,
         )
 
-        item(span = { GridItemSpan(maxLineSpan) }, contentType = { "bottomSpacing" }) {
+        item(span = { GridItemSpan(maxLineSpan) }, contentType = "bottomSpacing") {
             Column {
                 Spacer(modifier = Modifier.height(8.dp))
                 // Add space for the content to clear the "offline" snackbar.

--- a/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/java/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -182,7 +182,7 @@ internal fun ForYouScreen(
             onTopicClick = onTopicClick,
         )
 
-        item(span = { GridItemSpan(maxLineSpan) }) {
+        item(span = { GridItemSpan(maxLineSpan) }, contentType = { "bottomSpacing" }) {
             Column {
                 Spacer(modifier = Modifier.height(8.dp))
                 // Add space for the content to clear the "offline" snackbar.
@@ -240,7 +240,7 @@ private fun LazyGridScope.onboarding(
         -> Unit
 
         is OnboardingUiState.Shown -> {
-            item(span = { GridItemSpan(maxLineSpan) }) {
+            item(span = { GridItemSpan(maxLineSpan) }, contentType = "onboarding") {
                 Column(modifier = interestsItemModifier) {
                     Text(
                         text = stringResource(R.string.onboarding_guidance_title),


### PR DESCRIPTION
Small change with some performance improvements when scrolling the feed.
Tested on Pixel 6 API 33.

Before
```
ScrollForYouFeedBenchmark_scrollFeedCompilationFull
frameDurationCpuMs   P50   4.9,   P90   6.9,   P95   7.6,   P99   9.5
frameOverrunMs       P50  -10.3,   P90  -6.8,   P95  -2.8,   P99  -2.1
Traces: Iteration 0 1 2 3 4 5 6 7 8 9
```

After
```
ScrollForYouFeedBenchmark_scrollFeedCompilationFull
frameDurationCpuMs   P50   4.6,   P90   6.3,   P95   7.2,   P99   9.2
frameOverrunMs       P50  -10.6,   P90  -8.7,   P95  -7.8,   P99  -4.7
Traces: Iteration 0 1 2 3 4 5 6 7 8 9
```