### PR TITLE
Remove forced resolution strategy

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,7 +126,5 @@ dependencies {
 configurations.configureEach {
     resolutionStrategy {
         force(libs.junit4)
-        // Temporary workaround for https://issuetracker.google.com/174733673
-        force("org.objenesis:objenesis:2.6")
     }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,10 +121,3 @@ dependencies {
     implementation(libs.androidx.profileinstaller)
     implementation(libs.coil.kt)
 }
-
-// androidx.test is forcing JUnit, 4.12. This forces it to use 4.13
-configurations.configureEach {
-    resolutionStrategy {
-        force(libs.junit4)
-    }
-}

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -49,8 +49,6 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             configurations.configureEach {
                 resolutionStrategy {
                     force(libs.findLibrary("junit4").get())
-                    // Temporary workaround for https://issuetracker.google.com/174733673
-                    force("org.objenesis:objenesis:2.6")
                 }
             }
             dependencies {

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -21,7 +21,6 @@ import com.google.samples.apps.nowinandroid.configureGradleManagedDevices
 import com.google.samples.apps.nowinandroid.configureKotlinAndroid
 import com.google.samples.apps.nowinandroid.configurePrintApksTask
 import com.google.samples.apps.nowinandroid.disableUnnecessaryAndroidTests
-import com.google.samples.apps.nowinandroid.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -45,11 +44,6 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             extensions.configure<LibraryAndroidComponentsExtension> {
                 configurePrintApksTask(this)
                 disableUnnecessaryAndroidTests(target)
-            }
-            configurations.configureEach {
-                resolutionStrategy {
-                    force(libs.findLibrary("junit4").get())
-                }
             }
             dependencies {
                 add("androidTestImplementation", kotlin("test"))


### PR DESCRIPTION
- `objenesis`: the linked issue is marked as resolved, and not able to reproduce the mentioned compilation error.
- `junit`: By looking at the Gradle scan's dependency tab, junit 4.12  is already replaced by 4.13.2. There is no need to manually force this at the configuration level.