### PR TITLE
fix: close tag in ModularizationLearningJourney.md

### DIFF
--- a/docs/ModularizationLearningJourney.md
+++ b/docs/ModularizationLearningJourney.md
@@ -171,7 +171,7 @@ Using the above modularization strategy, the Now in Android app has the followin
   <tr>
    <td><code>core:ui</code>
    </td>
-   <td>Composite UI components and resources used by feature modules, such as the news feed. Unlike the <code>designsystem<code> module, it is dependent on the data layer since it renders models, like news resources. 
+   <td>Composite UI components and resources used by feature modules, such as the news feed. Unlike the <code>designsystem</code> module, it is dependent on the data layer since it renders models, like news resources. 
    </td>
    <td> <code>NewsFeed</code> <code>NewsResourceCardExpanded</code>
    </td>


### PR DESCRIPTION
There was a display breakdown because the closing tag was missing.

| Before | After |
|--------|--------|
|<img width="489" alt="スクリーンショット 2023-06-20 午前7 07 57" src="https://github.com/android/nowinandroid/assets/1281509/7a551fe1-39a5-4342-8c58-8fc970f876c9">|<img width="486" alt="スクリーンショット 2023-06-20 午前7 08 03" src="https://github.com/android/nowinandroid/assets/1281509/55e60d9b-050b-415a-bd45-b13aa47bd3a6">|
