### PR TITLE
Allow localised date format

### DIFF
--- a/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
+++ b/core/ui/src/main/java/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
@@ -70,6 +70,7 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.toJavaInstant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import java.util.Locale
 import com.google.samples.apps.nowinandroid.core.designsystem.R as DesignsystemR
 
@@ -230,8 +231,11 @@ fun dateFormatted(publishDate: Instant): String {
         }
     }
 
-    return DateTimeFormatter.ofPattern("MMM d, yyyy")
-        .withZone(zoneId).format(publishDate.toJavaInstant())
+    return DateTimeFormatter
+        .ofLocalizedDate(FormatStyle.MEDIUM)
+        .withLocale(Locale.getDefault())
+        .withZone(zoneId)
+        .format(publishDate.toJavaInstant())
 }
 
 @Composable


### PR DESCRIPTION
## **Describe the problem** [#819](https://github.com/android/nowinandroid/issues/819)

For some reason this app hard codes the date format in the `NewsResourceCard` instead of using the user defined Locale, So it's better to let the user choose the format rather than the developer.

## **Describe the solution**

### In the `NewsResourceCard` I have used


```
  return DateTimeFormatter
        .ofLocalizedDate(MEDIUM)
        .withLocale(Locale.getDefault())
        .withZone(zoneId)
        .format(publishDate.toJavaInstant())
```


### instead of


 ```
    return DateTimeFormatter
        .ofPattern("MMM d, yyyy")
        .withZone(zoneId)
        .format(publishDate.toJavaInstant())
```

### This PR is part of [GTC](https://www.facebook.com/groups/gazatechcommunity/) open source initiative