### PR TITLE
Startup benchmarks: allow notifications

### DIFF
--- a/benchmarks/src/main/java/com/google/samples/apps/nowinandroid/startup/StartupBenchmark.kt
+++ b/benchmarks/src/main/java/com/google/samples/apps/nowinandroid/startup/StartupBenchmark.kt
@@ -27,6 +27,7 @@ import androidx.benchmark.macro.StartupTimingMetric
 import androidx.benchmark.macro.junit4.MacrobenchmarkRule
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import com.google.samples.apps.nowinandroid.PACKAGE_NAME
+import com.google.samples.apps.nowinandroid.allowNotifications
 import com.google.samples.apps.nowinandroid.foryou.forYouWaitForContent
 import org.junit.Rule
 import org.junit.Test
@@ -86,6 +87,7 @@ abstract class AbstractStartupBenchmark(private val startupMode: StartupMode) {
         },
     ) {
         startActivityAndWait()
+        allowNotifications()
         // Waits until the content is ready to capture Time To Full Display
         forYouWaitForContent()
     }


### PR DESCRIPTION
Without this, trying to run the benchmarks fails with 

```
 E  java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object androidx.test.uiautomator.UiObject2.wait(androidx.test.uiautomator.UiObject2Condition, long)' on a null object reference
    	at com.google.samples.apps.nowinandroid.foryou.ForYouActionsKt.forYouWaitForContent(ForYouActions.kt:32)
    	at com.google.samples.apps.nowinandroid.startup.AbstractStartupBenchmark$startup$2.invoke(StartupBenchmark.kt:92)
    	at com.google.samples.apps.nowinandroid.startup.AbstractStartupBenchmark$startup$2.invoke(StartupBenchmark.kt:79)
    	at androidx.benchmark.macro.MacrobenchmarkKt$macrobenchmark$3$2.invoke(Macrobenchmark.kt:209)
    	at androidx.benchmark.macro.MacrobenchmarkKt$macrobenchmark$3$2.invoke(Macrobenchmark.kt:207)
```

I'm guessing because the permission popup hides the content below:

<img src="https://github.com/android/nowinandroid/assets/3974977/44a639d4-53e9-49ce-a50e-f884c40cc1c3" width=200 />

Now I'm wondering how much this popup biases the test in the first place cause we certainly don't want to measure the time to display the permission popup by the system?


Edit: I see there's some prior work [here](https://github.com/android/nowinandroid/pull/775) but unsure what the status is?