### PR TITLE
Added TextStyle color for ClickableText

### DIFF
--- a/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/java/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
@@ -246,6 +246,7 @@ fun EmptySearchResultBody(
             text = tryAnotherSearchString,
             style = MaterialTheme.typography.bodyLarge.merge(
                 TextStyle(
+                    color = MaterialTheme.colorScheme.secondary,
                     textAlign = TextAlign.Center,
                 ),
             ),


### PR DESCRIPTION
Hi!
Regarding to #837 
My solution would be (in SearchScreen.kt) to  add in the TextStyle type the next line:
```
color = MaterialTheme.colorScheme.secondary
```
ClickableText would stay like this:

```
ClickableText(
   text = tryAnotherSearchString,
   style = MaterialTheme.typography.bodyLarge.merge(
       TextStyle(
           color = MaterialTheme.colorScheme.secondary,
           textAlign = TextAlign.Center,
       ),
   ),
       modifier = Modifier
       . padding (start = 36.dp,
   end = 36.dp, bottom = 24.dp,
)
       .clickable {},
)

```
What do you think?
