### PR TITLE
Fix for Retrofit R8 issue, bump version to 0.1.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,8 +29,8 @@ plugins {
 android {
     defaultConfig {
         applicationId = "com.google.samples.apps.nowinandroid"
-        versionCode = 7
-        versionName = "0.1.1" // X.Y.Z; X = Major, Y = minor, Z = Patch level
+        versionCode = 8
+        versionName = "0.1.2" // X.Y.Z; X = Major, Y = minor, Z = Patch level
 
         // Custom test runner to set up Hilt dependency graph
         testInstrumentationRunner = "com.google.samples.apps.nowinandroid.core.testing.NiaTestRunner"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -7,3 +7,13 @@
 -dontwarn org.openjsse.javax.net.ssl.SSLParameters
 -dontwarn org.openjsse.javax.net.ssl.SSLSocket
 -dontwarn org.openjsse.net.ssl.OpenJSSE
+
+# Fix for Retrofit issue https://github.com/square/retrofit/issues/3751
+# Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+
+# With R8 full mode generic signatures are stripped for classes that are not
+# kept. Suspend functions are wrapped in continuations where the type argument
+# is used.
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation


### PR DESCRIPTION
This fixes an issue where data would not load from the backend because of an exception thrown by retrofit. Users would see a loading spinner for a short time but no new data would be loaded from the server. The following would be seen in logcat: 

```
2023-07-26 15:59:15.186 12572-12678 suspendRunCatching      com...gle.samples.apps.nowinandroid  I  Failed to evaluate a suspendRunCatchingBlock. Returning failure Result
                                                                                                    java.lang.ClassCastException: java.lang.Class cannot be cast to java.lang.reflect.ParameterizedType
```

Cause: https://github.com/square/retrofit/issues/3751
Solution: Add proguard rules to stop Retrofit classes from being removed