### PR TITLE
Remove hardcoded topic names in `NavigationTest.kt`

### DIFF
--- a/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
@@ -33,7 +33,7 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.NoActivityResumedException
 import com.google.samples.apps.nowinandroid.MainActivity
 import com.google.samples.apps.nowinandroid.R
-import com.google.samples.apps.nowinandroid.core.network.fake.FakeNiaNetworkDataSource
+import com.google.samples.apps.nowinandroid.core.network.NiaNetworkDataSource
 import com.google.samples.apps.nowinandroid.core.rules.GrantPostNotificationsPermissionRule
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -83,7 +83,7 @@ class NavigationTest {
     val composeTestRule = createAndroidComposeRule<MainActivity>()
 
     @Inject
-    lateinit var datasource: FakeNiaNetworkDataSource
+    lateinit var datasource: NiaNetworkDataSource
 
     private fun AndroidComposeTestRule<*, *>.stringResource(@StringRes resId: Int) =
         ReadOnlyProperty<Any?, String> { _, _ -> activity.getString(resId) }
@@ -262,10 +262,10 @@ class NavigationTest {
 
     @Test
     fun navigationBar_multipleBackStackInterests() = runTest {
-        suspend fun randomTopicName() = datasource.getTopics(ids = null).random().name
+        val topics = datasource.getTopics(ids = null)
         composeTestRule.apply {
             onNodeWithText(interests).performClick()
-            onNodeWithText(randomTopicName()).performClick()
+            onNodeWithText(topics.random().name).performClick()
 
             // Switch tab
             onNodeWithText(forYou).performClick()
@@ -274,7 +274,7 @@ class NavigationTest {
             onNodeWithText(interests).performClick()
 
             // Verify we're not in the list of interests
-            onNodeWithText(randomTopicName()).assertDoesNotExist()
+            onNodeWithText(topics.random().name).assertDoesNotExist()
         }
     }
 }

--- a/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
@@ -27,8 +27,10 @@ import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.NoActivityResumedException
 import com.google.samples.apps.nowinandroid.MainActivity
@@ -262,10 +264,13 @@ class NavigationTest {
 
     @Test
     fun navigationBar_multipleBackStackInterests() = runTest {
-        val topics = datasource.getTopics(ids = null)
         composeTestRule.apply {
             onNodeWithText(interests).performClick()
-            onNodeWithText(topics.random().name).performClick()
+
+            // Select a random topic
+            val topic = datasource.getTopics().random().name
+            onNodeWithTag("interests:topics").performScrollToNode(hasText(topic))
+            onNodeWithText(topic).performClick()
 
             // Switch tab
             onNodeWithText(forYou).performClick()
@@ -274,7 +279,7 @@ class NavigationTest {
             onNodeWithText(interests).performClick()
 
             // Verify we're not in the list of interests
-            onNodeWithText(topics.random().name).assertDoesNotExist()
+            onNodeWithTag("interests:topics").assertDoesNotExist()
         }
     }
 }

--- a/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
@@ -35,12 +35,13 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.NoActivityResumedException
 import com.google.samples.apps.nowinandroid.MainActivity
 import com.google.samples.apps.nowinandroid.R
-import com.google.samples.apps.nowinandroid.core.network.NiaNetworkDataSource
-import com.google.samples.apps.nowinandroid.core.network.model.NetworkTopic
+import com.google.samples.apps.nowinandroid.core.data.repository.TopicsRepository
+import com.google.samples.apps.nowinandroid.core.model.data.Topic
 import com.google.samples.apps.nowinandroid.core.rules.GrantPostNotificationsPermissionRule
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -86,7 +87,7 @@ class NavigationTest {
     val composeTestRule = createAndroidComposeRule<MainActivity>()
 
     @Inject
-    lateinit var datasource: NiaNetworkDataSource
+    lateinit var topicsRepository: TopicsRepository
 
     private fun AndroidComposeTestRule<*, *>.stringResource(@StringRes resId: Int) =
         ReadOnlyProperty<Any?, String> { _, _ -> activity.getString(resId) }
@@ -269,7 +270,7 @@ class NavigationTest {
             onNodeWithText(interests).performClick()
 
             // Select the last topic
-            val topic = datasource.getTopics().sortedBy(NetworkTopic::name).last().name
+            val topic = topicsRepository.getTopics().first().sortedBy(Topic::name).last().name
             onNodeWithTag("interests:topics").performScrollToNode(hasText(topic))
             onNodeWithText(topic).performClick()
 

--- a/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
@@ -36,6 +36,7 @@ import androidx.test.espresso.NoActivityResumedException
 import com.google.samples.apps.nowinandroid.MainActivity
 import com.google.samples.apps.nowinandroid.R
 import com.google.samples.apps.nowinandroid.core.network.NiaNetworkDataSource
+import com.google.samples.apps.nowinandroid.core.network.model.NetworkTopic
 import com.google.samples.apps.nowinandroid.core.rules.GrantPostNotificationsPermissionRule
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -267,8 +268,8 @@ class NavigationTest {
         composeTestRule.apply {
             onNodeWithText(interests).performClick()
 
-            // Select a random topic
-            val topic = datasource.getTopics().random().name
+            // Select the last topic
+            val topic = datasource.getTopics().sortedBy(NetworkTopic::name).last().name
             onNodeWithTag("interests:topics").performScrollToNode(hasText(topic))
             onNodeWithText(topic).performClick()
 


### PR DESCRIPTION
This test now uses ~`NiaNetworkDataSource`~ `TopicsRepository` (provided by Hilt) to get a random topic.
This also removes potential flakiness by really checking the absence of the topic list instead of searching for text (that could match in the opened topic page).