### PR TITLE
Rename constants

### DIFF
--- a/core/network/src/main/java/com/google/samples/apps/nowinandroid/core/network/retrofit/RetrofitNiaNetwork.kt
+++ b/core/network/src/main/java/com/google/samples/apps/nowinandroid/core/network/retrofit/RetrofitNiaNetwork.kt
@@ -57,10 +57,10 @@ private interface RetrofitNiaNetworkApi {
     ): List<NetworkChangeList>
 }
 
-private const val NiaBaseUrl = BuildConfig.BACKEND_URL
+private const val NIA_BASE_URL = BuildConfig.BACKEND_URL
 
 /**
- * Wrapper for data provided from the [NiaBaseUrl]
+ * Wrapper for data provided from the [NIA_BASE_URL]
  */
 @Serializable
 private data class NetworkResponse<T>(
@@ -77,7 +77,7 @@ class RetrofitNiaNetwork @Inject constructor(
 ) : NiaNetworkDataSource {
 
     private val networkApi = Retrofit.Builder()
-        .baseUrl(NiaBaseUrl)
+        .baseUrl(NIA_BASE_URL)
         .callFactory(okhttpCallFactory)
         .addConverterFactory(
             networkJson.asConverterFactory("application/json".toMediaType()),

--- a/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/navigation/InterestsNavigation.kt
+++ b/feature/interests/src/main/java/com/google/samples/apps/nowinandroid/feature/interests/navigation/InterestsNavigation.kt
@@ -23,11 +23,11 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.google.samples.apps.nowinandroid.feature.interests.InterestsRoute
 
-private const val interestsGraphRoutePattern = "interests_graph"
+private const val INTERESTS_GRAPH_ROUTE_PATTERN = "interests_graph"
 const val interestsRoute = "interests_route"
 
 fun NavController.navigateToInterestsGraph(navOptions: NavOptions? = null) {
-    this.navigate(interestsGraphRoutePattern, navOptions)
+    this.navigate(INTERESTS_GRAPH_ROUTE_PATTERN, navOptions)
 }
 
 fun NavGraphBuilder.interestsGraph(
@@ -35,7 +35,7 @@ fun NavGraphBuilder.interestsGraph(
     nestedGraphs: NavGraphBuilder.() -> Unit,
 ) {
     navigation(
-        route = interestsGraphRoutePattern,
+        route = INTERESTS_GRAPH_ROUTE_PATTERN,
         startDestination = interestsRoute,
     ) {
         composable(route = interestsRoute) {

--- a/sync/work/src/main/java/com/google/samples/apps/nowinandroid/sync/initializers/SyncWorkHelpers.kt
+++ b/sync/work/src/main/java/com/google/samples/apps/nowinandroid/sync/initializers/SyncWorkHelpers.kt
@@ -28,8 +28,8 @@ import androidx.work.NetworkType
 import com.google.samples.apps.nowinandroid.sync.R
 
 const val SYNC_TOPIC = "sync"
-private const val SyncNotificationId = 0
-private const val SyncNotificationChannelID = "SyncNotificationChannel"
+private const val SYNC_NOTIFICATION_ID = 0
+private const val SYNC_NOTIFICATION_CHANNEL_ID = "SyncNotificationChannel"
 
 // All sync work needs an internet connectionS
 val SyncConstraints
@@ -42,7 +42,7 @@ val SyncConstraints
  * run with a foreground service
  */
 fun Context.syncForegroundInfo() = ForegroundInfo(
-    SyncNotificationId,
+    SYNC_NOTIFICATION_ID,
     syncWorkNotification(),
 )
 
@@ -53,7 +53,7 @@ fun Context.syncForegroundInfo() = ForegroundInfo(
 private fun Context.syncWorkNotification(): Notification {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         val channel = NotificationChannel(
-            SyncNotificationChannelID,
+            SYNC_NOTIFICATION_CHANNEL_ID,
             getString(R.string.sync_notification_channel_name),
             NotificationManager.IMPORTANCE_DEFAULT,
         ).apply {
@@ -68,7 +68,7 @@ private fun Context.syncWorkNotification(): Notification {
 
     return NotificationCompat.Builder(
         this,
-        SyncNotificationChannelID,
+        SYNC_NOTIFICATION_CHANNEL_ID,
     )
         .setSmallIcon(
             com.google.samples.apps.nowinandroid.core.common.R.drawable.ic_nia_notification,


### PR DESCRIPTION
This pull request renames constants to resolve the following type of lint warning and follow the Kotlin coding conventions.

```
Const property name 'interestsGraphRoutePattern' doesn't match regex '[A-Z][_A-Z\d]*'
```

https://kotlinlang.org/docs/coding-conventions.html#property-names