### PR TITLE
fix: add label to animations for fixing lint issue

### DIFF
--- a/core/designsystem/src/main/java/com/google/samples/apps/nowinandroid/core/designsystem/component/LoadingWheel.kt
+++ b/core/designsystem/src/main/java/com/google/samples/apps/nowinandroid/core/designsystem/component/LoadingWheel.kt
@@ -55,7 +55,7 @@ fun NiaLoadingWheel(
     contentDesc: String,
     modifier: Modifier = Modifier,
 ) {
-    val infiniteTransition = rememberInfiniteTransition()
+    val infiniteTransition = rememberInfiniteTransition(label = "wheel transition")
 
     // Specifies the float animation for slowly drawing out the lines on entering
     val startValue = if (LocalInspectionMode.current) 0F else 1F
@@ -82,6 +82,7 @@ fun NiaLoadingWheel(
         animationSpec = infiniteRepeatable(
             animation = tween(durationMillis = ROTATION_TIME, easing = LinearEasing),
         ),
+        label = "wheel rotation animation",
     )
 
     // Specifies the color animation for the base-to-progress line color change
@@ -100,6 +101,7 @@ fun NiaLoadingWheel(
                 repeatMode = RepeatMode.Restart,
                 initialStartOffset = StartOffset(ROTATION_TIME / NUM_OF_LINES / 2 * index),
             ),
+            label = "wheel color animation",
         )
     }
 


### PR DESCRIPTION
Fix lint issues for missing the `label` param in animation functions.