### PR TITLE
Create `Compose compiler metrics` permanent run configuration

### DIFF
--- a/.run/Compose compiler metrics.run.xml
+++ b/.run/Compose compiler metrics.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Compose compiler metrics" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-PenableComposeCompilerMetrics=true -PenableComposeCompilerReports=true" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="assembleRelease" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Then copy the resulting baseline profile from the emulator to [`app/src/main/bas
 
 ## Compose compiler metrics
 
-Run the following command to get and analyse compose compiler metrics:
+Execute the `Compose compiler metrics` run configuration, or the following command to get and analyse compose compiler metrics:
 
 ```bash
 ./gradlew assembleRelease -PenableComposeCompilerMetrics=true -PenableComposeCompilerReports=true


### PR DESCRIPTION
This will help devs run the right command, and it's easier to find.

![image](https://github.com/android/nowinandroid/assets/1921278/9ca77b2f-17e5-4bad-a2fb-63c37c3ddea1)
