### PR TITLE
Update IDE copyright to match spotless configuration

### DIFF
--- a/.idea/copyright/The_Android_Open_Source_Project.xml
+++ b/.idea/copyright/The_Android_Open_Source_Project.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="Copyright &amp;#36;today.year The Android Open Source Project&#10; &#10;  Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;  you may not use this file except in compliance with the License.&#10;  You may obtain a copy of the License at&#10; &#10;      https://www.apache.org/licenses/LICENSE-2.0&#10; &#10;  Unless required by applicable law or agreed to in writing, software&#10;  distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;  See the License for the specific language governing permissions and&#10;  limitations under the License." />
+    <option name="notice" value="Copyright &amp;#36;today.year The Android Open Source Project&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    https://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
     <option name="myName" value="The Android Open Source Project" />
   </copyright>
 </component>


### PR DESCRIPTION
Files created through the IDE currently have a different copyright (because of indentation) and fails the `spotlessCheck` task.

```diff
 /*
  * Copyright 2023 The Android Open Source Project
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
```