### PR TITLE
Fix wrong configuration name, leaking `work-testing` to runtime classpath

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -128,8 +128,8 @@ dependencies {
     testImplementation(project(":core:network"))
     testImplementation(libs.androidx.navigation.testing)
     testImplementation(libs.accompanist.testharness)
+    testImplementation(libs.work.testing)
     testImplementation(kotlin("test"))
-    implementation(libs.work.testing)
     kaptTest(libs.hilt.compiler)
 
 }


### PR DESCRIPTION
Typo introduced recently when Roborazzi was added to the project:

https://github.com/android/nowinandroid/commit/886158d3cb9c7271bdf46241addc4db694174473#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46