### PR TITLE
Remove `nonTransitiveRClass` flag

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -31,9 +31,6 @@ android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 
-# Non-transitive R classes is recommended and is faster/smaller
-android.nonTransitiveRClass=true
-
 # Disable build features that are enabled by default,
 # https://developer.android.com/build/releases/gradle-plugin#default-changes
 android.defaults.buildfeatures.resvalues=false


### PR DESCRIPTION
It's the default from AGP 8.0, see https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#default-changes