### PR TITLE
Add Test for Saved Top Level Destination

### DIFF
--- a/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
+++ b/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
@@ -166,7 +166,10 @@ class NavigationTest {
         composeTestRule.apply {
             // GIVEN the user is on any of the top level destinations, THEN the Up arrow is not shown.
             onNodeWithContentDescription(navigateUp).assertDoesNotExist()
-            // TODO: Add top level destinations here, see b/226357686.
+
+            onNodeWithText(saved).performClick()
+            onNodeWithContentDescription(navigateUp).assertDoesNotExist()
+
             onNodeWithText(interests).performClick()
             onNodeWithContentDescription(navigateUp).assertDoesNotExist()
         }


### PR DESCRIPTION
This Pull Request addresses an existing TODO in the codebase.
It adds a test to verify that the ‘Up’ arrow does not show when the user is on the ‘Saved’ top level destination. This ensures consistency with the existing tests for the ‘For you’ and ‘Interests’ top level destinations.

This code change still passes all the relevant tests.

Please let me know if any changes are required. Thank you for considering this contribution!