### PR TITLE
Optimize compilation time by adjusting the order of the repository

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -16,8 +16,8 @@
 
 dependencyResolutionManagement {
     repositories {
-        google()
         mavenCentral()
+        google()
     }
     versionCatalogs {
         create("libs") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,8 +16,8 @@
 
 buildscript {
     repositories {
-        google()
         mavenCentral()
+        google()
 
         // Android Build Server
         maven { url = uri("../nowinandroid-prebuilts/m2repository") }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,8 +17,8 @@
 pluginManagement {
     includeBuild("build-logic")
     repositories {
-        google()
         mavenCentral()
+        google()
         gradlePluginPortal()
     }
 }
@@ -26,8 +26,8 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        google()
         mavenCentral()
+        google()
     }
 }
 rootProject.name = "nowinandroid"


### PR DESCRIPTION
ref: [link](https://docs.gradle.org/current/userguide/performance.html#optimize_repository_order)

[Optimize repository order](https://docs.gradle.org/current/userguide/performance.html#optimize_repository_order)
When Gradle resolves dependencies, it searches through each repository in the declared order. To reduce the time spent searching for dependencies, declare the repository hosting the largest number of your dependencies first. This minimizes the number of network requests required to resolve all dependencies.