### PR TITLE
Demo bytecode upgrades in Gradle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,8 +21,8 @@ org.gradle.configureondemand=false
 # Enable caching between builds.
 org.gradle.caching=true
 
-# Enable configuration caching between builds.
-org.gradle.configuration-cache=true
+# Disable configuration caching between builds because it's not yet compatible with bytecode upgrades.
+org.gradle.configuration-cache=false
 
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,9 @@ org.gradle.caching=true
 # Disable configuration caching between builds because it's not yet compatible with bytecode upgrades.
 org.gradle.configuration-cache=false
 
+# Disable Gradle daemon, as it is not currently compatible with switching bytecode upgrades off vs on
+org.gradle.daemon=false
+
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.5-branch-provider_api_migration_android_demo-20231004162215+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Use existing plugins and run against upgrade provider API-compatible properties in Gradle.

Instructions to try the upgrades out:

1. Clean caches manually (this is just for the demo) by running:

    ```bash
    $ rm -rf ~/.gradle/caches/jars-9
    ```

2. Run `DISABLE_PROPERTY_UPGRADES=true ./gradlew assembleDebug`

    This should fail with an exception:

    ```text
    FAILURE: Build failed with an exception.
    
    * What went wrong:
    A problem occurred configuring project ':app'.
    > Failed to notify project evaluation listener.
       > 'void org.gradle.api.tasks.compile.CompileOptions.setEncoding(java.lang.String)'
    ```

    We are explicitly disabling bytecode upgrades, so the plugins used in the build run unmodified, and are faced with missing methods.

3. Run `./gradlew assembleDebug`

    This should now succeed as the plugins used in the build are bytecode-upgraded, i.e. method references to the old Gradle APIs are automatically replaced with equivalent code that uses the new APIs.