### PR TITLE
Create different icons for each build variant

### DIFF
--- a/app/src/benchmark/res/values-night/colors.xml
+++ b/app/src/benchmark/res/values-night/colors.xml
@@ -15,8 +15,6 @@
      limitations under the License.
 -->
 <resources>
-    <color name="blue40">#FF006780</color>
-
     <color name="ic_launcher_background_tint">#FFFFFF</color>
-    <color name="ic_launcher_foreground_tint">@color/blue40</color>
+    <color name="ic_launcher_foreground_tint">#FF006780</color>
 </resources>

--- a/app/src/benchmark/res/values-night/colors.xml
+++ b/app/src/benchmark/res/values-night/colors.xml
@@ -15,6 +15,8 @@
      limitations under the License.
 -->
 <resources>
-    <color name="ic_launcher_background_tint">#2296F3</color>
-    <color name="ic_launcher_foreground_tint">#FFFFFF</color>
+    <color name="blue40">#FF006780</color>
+
+    <color name="ic_launcher_background_tint">#FFFFFF</color>
+    <color name="ic_launcher_foreground_tint">@color/blue40</color>
 </resources>

--- a/app/src/benchmark/res/values-night/colors.xml
+++ b/app/src/benchmark/res/values-night/colors.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2023 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+    <color name="ic_launcher_background_tint">#2296F3</color>
+    <color name="ic_launcher_foreground_tint">#FFFFFF</color>
+</resources>

--- a/app/src/benchmark/res/values/colors.xml
+++ b/app/src/benchmark/res/values/colors.xml
@@ -15,9 +15,6 @@
      limitations under the License.
 -->
 <resources>
-    <color name="black30">#4D000000</color>
-    <color name="blue40">#FF006780</color>
-
     <color name="ic_launcher_background_tint">#000000</color>
-    <color name="ic_launcher_foreground_tint">@color/blue40</color>
+    <color name="ic_launcher_foreground_tint">#FF006780</color>
 </resources>

--- a/app/src/benchmark/res/values/colors.xml
+++ b/app/src/benchmark/res/values/colors.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2023 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+    <!-- Status bar -->
+    <color name="black30">#4D000000</color>
+
+    <color name="ic_launcher_background_tint">#2296F3</color>
+    <color name="ic_launcher_foreground_tint">#000000</color>
+</resources>

--- a/app/src/benchmark/res/values/colors.xml
+++ b/app/src/benchmark/res/values/colors.xml
@@ -17,7 +17,8 @@
 <resources>
     <!-- Status bar -->
     <color name="black30">#4D000000</color>
+    <color name="blue40">#FF006780</color>
 
-    <color name="ic_launcher_background_tint">#2296F3</color>
-    <color name="ic_launcher_foreground_tint">#000000</color>
+    <color name="ic_launcher_background_tint">#000000</color>
+    <color name="ic_launcher_foreground_tint">@color/blue40</color>
 </resources>

--- a/app/src/benchmark/res/values/colors.xml
+++ b/app/src/benchmark/res/values/colors.xml
@@ -15,7 +15,6 @@
      limitations under the License.
 -->
 <resources>
-    <!-- Status bar -->
     <color name="black30">#4D000000</color>
     <color name="blue40">#FF006780</color>
 

--- a/app/src/debug/res/values-night/colors.xml
+++ b/app/src/debug/res/values-night/colors.xml
@@ -15,6 +15,8 @@
      limitations under the License.
 -->
 <resources>
+    <color name="orange40">#FFA23F16</color>
+
     <color name="ic_launcher_background_tint">#FFFFFF</color>
-    <color name="ic_launcher_foreground_tint">#2296F3</color>
+    <color name="ic_launcher_foreground_tint">@color/orange40</color>
 </resources>

--- a/app/src/debug/res/values-night/colors.xml
+++ b/app/src/debug/res/values-night/colors.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2023 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+    <color name="ic_launcher_background_tint">#FFFFFF</color>
+    <color name="ic_launcher_foreground_tint">#2296F3</color>
+</resources>

--- a/app/src/debug/res/values-night/colors.xml
+++ b/app/src/debug/res/values-night/colors.xml
@@ -15,8 +15,6 @@
      limitations under the License.
 -->
 <resources>
-    <color name="orange40">#FFA23F16</color>
-
     <color name="ic_launcher_background_tint">#FFFFFF</color>
-    <color name="ic_launcher_foreground_tint">@color/orange40</color>
+    <color name="ic_launcher_foreground_tint">#FFA23F16</color>
 </resources>

--- a/app/src/debug/res/values/colors.xml
+++ b/app/src/debug/res/values/colors.xml
@@ -17,7 +17,8 @@
 <resources>
     <!-- Status bar -->
     <color name="black30">#4D000000</color>
+    <color name="orange40">#FFA23F16</color>
 
     <color name="ic_launcher_background_tint">#000000</color>
-    <color name="ic_launcher_foreground_tint">#2296F3</color>
+    <color name="ic_launcher_foreground_tint">@color/orange40</color>
 </resources>

--- a/app/src/debug/res/values/colors.xml
+++ b/app/src/debug/res/values/colors.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2023 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+    <!-- Status bar -->
+    <color name="black30">#4D000000</color>
+
+    <color name="ic_launcher_background_tint">#000000</color>
+    <color name="ic_launcher_foreground_tint">#2296F3</color>
+</resources>

--- a/app/src/debug/res/values/colors.xml
+++ b/app/src/debug/res/values/colors.xml
@@ -15,9 +15,6 @@
      limitations under the License.
 -->
 <resources>
-    <color name="black30">#4D000000</color>
-    <color name="orange40">#FFA23F16</color>
-
     <color name="ic_launcher_background_tint">#000000</color>
-    <color name="ic_launcher_foreground_tint">@color/orange40</color>
+    <color name="ic_launcher_foreground_tint">#FFA23F16</color>
 </resources>

--- a/app/src/debug/res/values/colors.xml
+++ b/app/src/debug/res/values/colors.xml
@@ -15,7 +15,6 @@
      limitations under the License.
 -->
 <resources>
-    <!-- Status bar -->
     <color name="black30">#4D000000</color>
     <color name="orange40">#FFA23F16</color>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -33,5 +33,4 @@
         <item name="postSplashScreenTheme">@style/Theme.Nia</item>
     </style>
 
-
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -33,4 +33,5 @@
         <item name="postSplashScreenTheme">@style/Theme.Nia</item>
     </style>
 
+
 </resources>


### PR DESCRIPTION
Closes #800 

Added color values for DEBUG and BENCHMARK build variants.

The dark mode of each one will just switch the black and white in the icon (so non-release builds will have blue), I'm happy to update these if there is a different color combination that would be better.

![Screenshot_20231016_002041](https://github.com/android/nowinandroid/assets/19813378/cb10021e-8ab7-4378-a5d2-73b29c234c0a)
