### PR TITLE
Edit calculate list sizes using the derivedStateOf() function

### DIFF
--- a/feature/search/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -262,8 +263,7 @@ fun EmptySearchResultBody(
                 .padding(start = 36.dp, end = 36.dp, bottom = 24.dp)
                 .clickable {},
         ) { offset ->
-            tryAnotherSearchString.getStringAnnotations(start = offset, end = offset)
-                .firstOrNull()
+            tryAnotherSearchString.getStringAnnotations(start = offset, end = offset).firstOrNull()
                 ?.let {
                     onInterestsClick()
                 }
@@ -298,9 +298,11 @@ private fun SearchResultBody(
     searchQuery: String = "",
 ) {
     val state = rememberLazyStaggeredGridState()
+    val itemsAvailable by remember {
+        derivedStateOf { topics.size + newsResources.size }
+    }
     Box(
-        modifier = Modifier
-            .fillMaxSize(),
+        modifier = Modifier.fillMaxSize(),
     ) {
         LazyVerticalStaggeredGrid(
             columns = StaggeredGridCells.Adaptive(300.dp),
@@ -372,7 +374,6 @@ private fun SearchResultBody(
                 )
             }
         }
-        val itemsAvailable = topics.size + newsResources.size
         val scrollbarState = state.scrollbarState(
             itemsAvailable = itemsAvailable,
         )


### PR DESCRIPTION
If we have a list and we want to calculate the length of this list from another state object, we can use the derivedStateOf() function.

Do tests pass?

[✓] Run local tests on DemoDebug variant: ./gradlew testDemoDebug
[✓] Check formatting: ./gradlew --init-script gradle/init.gradle.kts spotlessApply
Is this your first pull request?

[ ✓] [Sign the CLA](https://cla.developers.google.com/)
[✓ ] Run ./tools/setup.sh
[✓ ] Import the code formatting style as explained in [the setup script](https://github.com/tools/setup.sh#L40).