### PR TITLE
Apply spotless automatically during build and commit to PR

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -34,8 +34,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Check spotless
-        run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
+      - name: Apply formatting if failed
+        run: ./gradlew spotlessApply --init-script gradle/init.gradle.kts --no-configuration-cache
+      - uses: stefanweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Apply Spotless
 
       - name: Build all build type and flavor permutations
         run: ./gradlew assemble


### PR DESCRIPTION
Update our CI build workflow to apply spotless formatting and add a commit to the source PR, instead of just checking it and failing the build. 

This avoids situations like this where formatting issues cause the build to fail: https://github.com/android/nowinandroid/actions/runs/6713253053/job/18297469836?pr=1006
