### PR TITLE
Revert "Apply spotless automatically during build and commit to PR"

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -34,11 +34,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Apply formatting if failed
-        run: ./gradlew spotlessApply --init-script gradle/init.gradle.kts --no-configuration-cache
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: Apply Spotless
+      - name: Check spotless
+        run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
 
       - name: Build all build type and flavor permutations
         run: ./gradlew assemble


### PR DESCRIPTION
Reverts android/nowinandroid#1010. 

This approach doesn't work with PRs submitted from forks so I'm reverting it until we can come up with a more robust solution. 