### PR TITLE
Use SdkConstants for getting aapt2 executable location

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -36,6 +36,7 @@ tasks.withType<KotlinCompile>().configureEach {
 
 dependencies {
     compileOnly(libs.android.gradlePlugin)
+    compileOnly(libs.android.tools.common)
     compileOnly(libs.firebase.crashlytics.gradlePlugin)
     compileOnly(libs.firebase.performance.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
@@ -19,6 +19,7 @@ package com.google.samples.apps.nowinandroid
 import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.gradle.BaseExtension
+import com.android.SdkConstants
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -113,7 +114,9 @@ fun Project.configureBadgingTasks(
                 aapt2Executable.set(
                     File(
                         baseExtension.sdkDirectory,
-                        "build-tools/${baseExtension.buildToolsVersion}/aapt2",
+                        "${SdkConstants.FD_BUILD_TOOLS}/" +
+                            "${baseExtension.buildToolsVersion}/" +
+                            SdkConstants.FN_AAPT2,
                     ),
                 )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,9 @@
 [versions]
 accompanist = "0.32.0"
 androidDesugarJdkLibs = "2.0.3"
+# AGP and tools should be updated together
 androidGradlePlugin = "8.1.2"
+androidTools = "31.1.2"
 androidxActivity = "1.8.0"
 androidxAppCompat = "1.6.1"
 androidxBrowser = "1.6.0"
@@ -139,6 +141,7 @@ turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine
 
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
+android-tools-common = { group = "com.android.tools", name = "common", version.ref = "androidTools" }
 firebase-crashlytics-gradlePlugin = { group = "com.google.firebase", name = "firebase-crashlytics-gradle", version.ref = "firebaseCrashlyticsPlugin" }
 firebase-performance-gradlePlugin = { group = "com.google.firebase", name = "perf-plugin", version.ref = "firebasePerfPlugin" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
Pulls in `com.android.tools:common` into the build script in order to access `SdkConstants` for getting the location of the `aapt2` executable. These constants are OS dependent, so should allow badging to run on Windows and fix #1007 
