### PR TITLE
[CI] Runs build in macos to generate a cache for androidTest runs

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -11,44 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties        
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: 17
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-
-      - name: Check spotless
-        run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
-
-      - name: Build all build type and flavor permutations
-        run: ./gradlew assemble
-
-      - name: Upload build outputs (APKs)
-        uses: actions/upload-artifact@v3
-        with:
-          name: APKs
-          path: '**/build/outputs/apk/**/*.apk'
-
-      - name: Run local tests
-        run: ./gradlew testDemoDebug testProdDebug :lint:test
-
   test:
     runs-on: ubuntu-latest
 
@@ -128,7 +90,45 @@ jobs:
       - name: Check badging
         run: ./gradlew :app:checkProdReleaseBadging
 
-  androidTest:
+  androidTest-build:
+    runs-on: macos-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties        
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Check spotless
+        run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
+
+      - name: Build all build type and flavor permutations
+        run: ./gradlew assemble
+
+      - name: Upload build outputs (APKs)
+        uses: actions/upload-artifact@v3
+        with:
+          name: APKs
+          path: '**/build/outputs/apk/**/*.apk'
+
+      - name: Run local tests
+        run: ./gradlew testDemoDebug testProdDebug :lint:test
+
+  androidTest-run:
     needs: build
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine
     timeout-minutes: 55
@@ -151,9 +151,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-
-      - name: Build AndroidTest apps
-        run: ./gradlew packageDemoDebug packageDemoDebugAndroidTest --daemon
+        with:
+          cache-read-only: true # No need to write to cache in the run job
 
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -127,7 +127,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Build projects before running emulator
-        run: ./gradlew :packageDemoDebug
+        run: ./gradlew packageDemoDebug
 
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -11,7 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  test_and_apk:
+    name: "Local tests and APKs"
     runs-on: ubuntu-latest
 
     permissions:
@@ -68,7 +69,19 @@ jobs:
       # Run local tests after screenshot tests to avoid wrong UP-TO-DATE. TODO: Ignore screenshots.
       - name: Run local tests
         if: always()
-        run: ./gradlew testDemoDebug testProdDebug
+        run: ./gradlew testDemoDebug testProdDebug :lint:test
+
+      - name: Check spotless
+        run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
+
+      - name: Build all build type and flavor permutations
+        run: ./gradlew assemble
+
+      - name: Upload build outputs (APKs)
+        uses: actions/upload-artifact@v3
+        with:
+          name: APKs
+          path: '**/build/outputs/apk/**/*.apk'
 
       - name: Upload test results (XML)
         if: always()
@@ -91,6 +104,7 @@ jobs:
         run: ./gradlew :app:checkProdReleaseBadging
 
   androidTest-build:
+    name: "Build for device tests"
     runs-on: macos-latest
     timeout-minutes: 90
 
@@ -113,20 +127,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Check spotless
-        run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
-
-      - name: Build all build type and flavor permutations
-        run: ./gradlew assemble
-
-      - name: Upload build outputs (APKs)
-        uses: actions/upload-artifact@v3
-        with:
-          name: APKs
-          path: '**/build/outputs/apk/**/*.apk'
-
-      - name: Run local tests
-        run: ./gradlew testDemoDebug testProdDebug :lint:test
 
   androidTest-run:
     needs: androidTest-build

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -127,6 +127,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
+      - name: Build AndroidTest apps
+        run: ./gradlew packageDemoDebug packageDemoDebugAndroidTest --daemon
+
 
   androidTest-run:
     needs: androidTest-build

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -127,7 +127,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Build projects before running emulator
-        run: ./gradlew packageDemoDebug
+        run: ./gradlew packageDemoDebug packageDemoDebugAndroidTest
 
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -103,36 +103,7 @@ jobs:
       - name: Check badging
         run: ./gradlew :app:checkProdReleaseBadging
 
-  androidTest-build:
-    name: "Build for device tests"
-    runs-on: macos-latest
-    timeout-minutes: 90
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties        
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: 17
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-
-      - name: Build AndroidTest apps
-        run: ./gradlew packageDemoDebug packageDemoDebugAndroidTest --daemon
-
-
-  androidTest-run:
-    needs: androidTest-build
+  androidTest:
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine
     timeout-minutes: 55
     strategy:
@@ -154,8 +125,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-        with:
-          cache-read-only: true # No need to write to cache in the run job
 
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -129,7 +129,7 @@ jobs:
         run: ./gradlew testDemoDebug testProdDebug :lint:test
 
   androidTest-run:
-    needs: build
+    needs: androidTest-build
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine
     timeout-minutes: 55
     strategy:

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
+      - name: Check spotless
+        run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
+
       - name: Run all local screenshot tests (Roborazzi)
         id: screenshotsverify
         continue-on-error: true
@@ -70,9 +73,6 @@ jobs:
       - name: Run local tests
         if: always()
         run: ./gradlew testDemoDebug testProdDebug :lint:test
-
-      - name: Check spotless
-        run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
 
       - name: Build all build type and flavor permutations
         run: ./gradlew assemble

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -126,6 +126,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
+      - name: Build projects before running emulator
+        run: ./gradlew :packageDemoDebug
+
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
+++ b/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
@@ -43,7 +43,6 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
+++ b/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
@@ -42,6 +42,7 @@ import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -265,12 +266,14 @@ class NavigationTest {
     }
 
     @Test
-    fun navigationBar_multipleBackStackInterests() = runTest {
+    fun navigationBar_multipleBackStackInterests() {
         composeTestRule.apply {
             onNodeWithText(interests).performClick()
 
             // Select the last topic
-            val topic = topicsRepository.getTopics().first().sortedBy(Topic::name).last().name
+            val topic = runBlocking {
+                topicsRepository.getTopics().first().sortedBy(Topic::name).last().name
+            }
             onNodeWithTag("interests:topics").performScrollToNode(hasText(topic))
             onNodeWithText(topic).performClick()
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,10 @@ org.gradle.caching=true
 
 # Enable configuration caching between builds.
 org.gradle.configuration-cache=true
+# This option is set because of https://github.com/google/play-services-plugins/issues/246
+# to generate the Configuration Cache regardless of incompatible tasks.
+# See https://github.com/android/nowinandroid/issues/1022 before using it.
+org.gradle.configuration-cache.problems=warn
 
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
@@ -35,3 +39,4 @@ kotlin.code.style=official
 # https://developer.android.com/build/releases/gradle-plugin#default-changes
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,4 +39,3 @@ kotlin.code.style=official
 # https://developer.android.com/build/releases/gradle-plugin#default-changes
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
-


### PR DESCRIPTION
Experiments to fix #1011 and #1018

Relying on gradle-build-action for cache sharing. Followed some guidance in:

https://github.com/gradle/gradle-build-action#deduplication-of-gradle-user-home-cache-entries

