### PR TITLE
[CI] No-op to check config cache performance

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -105,7 +105,7 @@ jobs:
 
   androidTest:
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine
-    timeout-minutes: 55
+    timeout-minutes: 60
     strategy:
       matrix:
         api-level: [26, 30]


### PR DESCRIPTION
Thanks for submitting a pull request. Please include the following information.

**What I have done and why**
Include a summary of what your pull request contains, and why you have made these changes.

Fixes #<issue_number_goes_here>

**Do tests pass?**
- [ ] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [ ] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`

**Is this your first pull request?**
- [ ] [Sign the CLA](https://cla.developers.google.com/)
- [ ] Run `./tools/setup.sh`
- [ ] Import the code formatting style as explained in [the setup script](/tools/setup.sh#L40).


