### PR TITLE
Fix `emptyResultIsReturned_withNotMatchingQuery` unit test

### DIFF
--- a/core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/repository/TestSearchContentsRepository.kt
+++ b/core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/repository/TestSearchContentsRepository.kt
@@ -21,45 +21,39 @@ import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
 import com.google.samples.apps.nowinandroid.core.model.data.SearchResult
 import com.google.samples.apps.nowinandroid.core.model.data.Topic
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
 
 class TestSearchContentsRepository : SearchContentsRepository {
 
-    private val cachedTopics: MutableList<Topic> = mutableListOf()
-    private val cachedNewsResources: MutableList<NewsResource> = mutableListOf()
+    private val cachedTopics = MutableStateFlow(emptyList<Topic>())
+    private val cachedNewsResources = MutableStateFlow(emptyList<NewsResource>())
 
     override suspend fun populateFtsData() { /* no-op */ }
 
-    override fun searchContents(searchQuery: String): Flow<SearchResult> = flowOf(
-        SearchResult(
-            topics = cachedTopics.filter {
-                it.name.contains(searchQuery) ||
-                    it.shortDescription.contains(searchQuery) ||
-                    it.longDescription.contains(searchQuery)
-            },
-            newsResources = cachedNewsResources.filter {
-                it.content.contains(searchQuery) ||
-                    it.title.contains(searchQuery)
-            },
-        ),
-    )
+    override fun searchContents(searchQuery: String): Flow<SearchResult> =
+        combine(cachedTopics, cachedNewsResources) { topics, news ->
+            SearchResult(
+                topics = topics.filter {
+                    searchQuery in it.name || searchQuery in it.shortDescription || searchQuery in it.longDescription
+                },
+                newsResources = news.filter {
+                    searchQuery in it.content || searchQuery in it.title
+                },
+            )
+        }
 
-    override fun getSearchContentsCount(): Flow<Int> = flow {
-        emit(cachedTopics.size + cachedNewsResources.size)
-    }
+    override fun getSearchContentsCount(): Flow<Int> = combine(cachedTopics, cachedNewsResources) { topics, news -> topics.size + news.size }
 
     /**
      * Test only method to add the topics to the stored list in memory
      */
-    fun addTopics(topics: List<Topic>) {
-        cachedTopics.addAll(topics)
-    }
+    fun addTopics(topics: List<Topic>) = cachedTopics.update { it + topics }
 
     /**
      * Test only method to add the news resources to the stored list in memory
      */
-    fun addNewsResources(newsResources: List<NewsResource>) {
-        cachedNewsResources.addAll(newsResources)
-    }
+    fun addNewsResources(newsResources: List<NewsResource>) =
+        cachedNewsResources.update { newsResources }
 }

--- a/feature/search/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchViewModelTest.kt
+++ b/feature/search/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchViewModelTest.kt
@@ -26,6 +26,7 @@ import com.google.samples.apps.nowinandroid.core.testing.data.topicsTestData
 import com.google.samples.apps.nowinandroid.core.testing.repository.TestRecentSearchRepository
 import com.google.samples.apps.nowinandroid.core.testing.repository.TestSearchContentsRepository
 import com.google.samples.apps.nowinandroid.core.testing.repository.TestUserDataRepository
+import com.google.samples.apps.nowinandroid.core.testing.repository.emptyUserData
 import com.google.samples.apps.nowinandroid.core.testing.util.MainDispatcherRule
 import com.google.samples.apps.nowinandroid.feature.search.RecentSearchQueriesUiState.Success
 import com.google.samples.apps.nowinandroid.feature.search.SearchResultUiState.EmptyQuery
@@ -71,6 +72,7 @@ class SearchViewModelTest {
             recentSearchRepository = recentSearchRepository,
             analyticsHelper = NoOpAnalyticsHelper(),
         )
+        userDataRepository.setUserData(emptyUserData)
     }
 
     @Test
@@ -100,8 +102,7 @@ class SearchViewModelTest {
         searchContentsRepository.addTopics(topicsTestData)
 
         val result = viewModel.searchResultUiState.value
-        // TODO: Figure out to get the latest emitted ui State? The result is emitted as EmptyQuery
-        // assertIs<Success>(result)
+        assertIs<SearchResultUiState.Success>(result)
 
         collectJob.cancel()
     }


### PR DESCRIPTION
`searchResultUiState` transitively relied on `getSearchContentsCount` updates and on `userDataRepository` to emit something.