### PR TITLE
Move Scrollbar state reads out of composition

### DIFF
--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
@@ -38,7 +38,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -67,7 +66,7 @@ private const val SCROLLBAR_INACTIVE_TO_DORMANT_TIME_IN_MS = 2_000L
 @Composable
 fun ScrollableState.DraggableScrollbar(
     modifier: Modifier = Modifier,
-    state: State<ScrollbarState>,
+    state: ScrollbarState,
     orientation: Orientation,
     onThumbMoved: (Float) -> Unit,
 ) {
@@ -97,7 +96,7 @@ fun ScrollableState.DraggableScrollbar(
 @Composable
 fun ScrollableState.DecorativeScrollbar(
     modifier: Modifier = Modifier,
-    state: State<ScrollbarState>,
+    state: ScrollbarState,
     orientation: Orientation,
 ) {
     val interactionSource = remember { MutableInteractionSource() }

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -66,7 +67,7 @@ private const val SCROLLBAR_INACTIVE_TO_DORMANT_TIME_IN_MS = 2_000L
 @Composable
 fun ScrollableState.DraggableScrollbar(
     modifier: Modifier = Modifier,
-    state: ScrollbarState,
+    state: State<ScrollbarState>,
     orientation: Orientation,
     onThumbMoved: (Float) -> Unit,
 ) {
@@ -96,7 +97,7 @@ fun ScrollableState.DraggableScrollbar(
 @Composable
 fun ScrollableState.DecorativeScrollbar(
     modifier: Modifier = Modifier,
-    state: ScrollbarState,
+    state: State<ScrollbarState>,
     orientation: Orientation,
 ) {
     val interactionSource = remember { MutableInteractionSource() }

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
@@ -20,7 +20,6 @@ import android.annotation.SuppressLint
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.SpringSpec
-import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.Orientation.Horizontal
 import androidx.compose.foundation.gestures.Orientation.Vertical
@@ -49,7 +48,6 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorProducer
 import androidx.compose.ui.graphics.Outline
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.drawOutline
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.node.DrawModifierNode
@@ -60,10 +58,7 @@ import androidx.compose.ui.unit.dp
 import com.google.samples.apps.nowinandroid.core.designsystem.component.scrollbar.ThumbState.Active
 import com.google.samples.apps.nowinandroid.core.designsystem.component.scrollbar.ThumbState.Dormant
 import com.google.samples.apps.nowinandroid.core.designsystem.component.scrollbar.ThumbState.Inactive
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.mapLatest
-import kotlinx.coroutines.launch
 
 /**
  * The time period for showing the scrollbar thumb after interacting with it, before it fades away
@@ -175,14 +170,14 @@ private fun ScrollableState.DecorativeScrollbarThumb(
 @Composable
 private fun Modifier.scrollThumb(
     scrollableState: ScrollableState,
-    interactionSource: InteractionSource
+    interactionSource: InteractionSource,
 ): Modifier {
     val colorState = scrollbarThumbColor(scrollableState, interactionSource)
     return this then ScrollThumbElement { colorState.value }
 }
 
-private data class ScrollThumbElement(val colorProducer: ColorProducer)
-    : ModifierNodeElement<ScrollThumbNode>() {
+private data class ScrollThumbElement(val colorProducer: ColorProducer) :
+    ModifierNodeElement<ScrollThumbNode>() {
     override fun create(): ScrollThumbNode = ScrollThumbNode(colorProducer)
     override fun update(node: ScrollThumbNode) {
         node.colorProducer = colorProducer
@@ -190,7 +185,7 @@ private data class ScrollThumbElement(val colorProducer: ColorProducer)
     }
 }
 
-private class ScrollThumbNode(var colorProducer: ColorProducer): DrawModifierNode, Modifier.Node() {
+private class ScrollThumbNode(var colorProducer: ColorProducer) : DrawModifierNode, Modifier.Node() {
     private val shape = RoundedCornerShape(16.dp)
 
     // naive cache outline calculation if size is the same
@@ -221,7 +216,7 @@ private class ScrollThumbNode(var colorProducer: ColorProducer): DrawModifierNod
 @Composable
 private fun scrollbarThumbColor(
     scrollableState: ScrollableState,
-    interactionSource: InteractionSource
+    interactionSource: InteractionSource,
 ): State<Color> {
     var state by remember { mutableStateOf(Dormant) }
     val pressed by interactionSource.collectIsPressedAsState()

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
@@ -16,6 +16,7 @@
 
 package com.google.samples.apps.nowinandroid.core.designsystem.component.scrollbar
 
+import android.annotation.SuppressLint
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.SpringSpec
@@ -38,17 +39,31 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorProducer
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.google.samples.apps.nowinandroid.core.designsystem.component.scrollbar.ThumbState.Active
 import com.google.samples.apps.nowinandroid.core.designsystem.component.scrollbar.ThumbState.Dormant
 import com.google.samples.apps.nowinandroid.core.designsystem.component.scrollbar.ThumbState.Inactive
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.launch
 
 /**
  * The time period for showing the scrollbar thumb after interacting with it, before it fades away
@@ -130,12 +145,7 @@ private fun ScrollableState.DraggableScrollbarThumb(
                     Horizontal -> height(12.dp).fillMaxWidth()
                 }
             }
-            .background(
-                color = scrollbarThumbColor(
-                    interactionSource = interactionSource,
-                ),
-                shape = RoundedCornerShape(16.dp),
-            ),
+            .scrollThumb(this, interactionSource),
     )
 }
 
@@ -155,13 +165,53 @@ private fun ScrollableState.DecorativeScrollbarThumb(
                     Horizontal -> height(2.dp).fillMaxWidth()
                 }
             }
-            .background(
-                color = scrollbarThumbColor(
-                    interactionSource = interactionSource,
-                ),
-                shape = RoundedCornerShape(16.dp),
-            ),
+            .scrollThumb(this, interactionSource),
     )
+}
+
+// TODO: This lint is removed in 1.6 as the recommendation has changed
+// remove when project is upgraded
+@SuppressLint("ComposableModifierFactory")
+@Composable
+private fun Modifier.scrollThumb(
+    scrollableState: ScrollableState,
+    interactionSource: InteractionSource
+): Modifier {
+    val colorState = scrollbarThumbColor(scrollableState, interactionSource)
+    return this then ScrollThumbElement { colorState.value }
+}
+
+private data class ScrollThumbElement(val colorProducer: ColorProducer)
+    : ModifierNodeElement<ScrollThumbNode>() {
+    override fun create(): ScrollThumbNode = ScrollThumbNode(colorProducer)
+    override fun update(node: ScrollThumbNode) {
+        node.colorProducer = colorProducer
+        node.invalidateDraw()
+    }
+}
+
+private class ScrollThumbNode(var colorProducer: ColorProducer): DrawModifierNode, Modifier.Node() {
+    private val shape = RoundedCornerShape(16.dp)
+
+    // naive cache outline calculation if size is the same
+    private var lastSize: Size? = null
+    private var lastLayoutDirection: LayoutDirection? = null
+    private var lastOutline: Outline? = null
+
+    override fun ContentDrawScope.draw() {
+        val color = colorProducer()
+        val outline =
+            if (size == lastSize && layoutDirection == lastLayoutDirection) {
+                lastOutline!!
+            } else {
+                shape.createOutline(size, layoutDirection, this)
+            }
+        if (color != Color.Unspecified) drawOutline(outline, color = color)
+
+        lastOutline = outline
+        lastSize = size
+        lastLayoutDirection = layoutDirection
+    }
 }
 
 /**
@@ -169,17 +219,18 @@ private fun ScrollableState.DecorativeScrollbarThumb(
  * @param interactionSource source of interactions in the scrolling container
  */
 @Composable
-private fun ScrollableState.scrollbarThumbColor(
-    interactionSource: InteractionSource,
-): Color {
+private fun scrollbarThumbColor(
+    scrollableState: ScrollableState,
+    interactionSource: InteractionSource
+): State<Color> {
     var state by remember { mutableStateOf(Dormant) }
     val pressed by interactionSource.collectIsPressedAsState()
     val hovered by interactionSource.collectIsHoveredAsState()
     val dragged by interactionSource.collectIsDraggedAsState()
-    val active = (canScrollForward || canScrollForward) &&
-        (pressed || hovered || dragged || isScrollInProgress)
+    val active = (scrollableState.canScrollForward || scrollableState.canScrollForward) &&
+        (pressed || hovered || dragged || scrollableState.isScrollInProgress)
 
-    val color by animateColorAsState(
+    val color = animateColorAsState(
         targetValue = when (state) {
             Active -> MaterialTheme.colorScheme.onSurface.copy(0.5f)
             Inactive -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/Scrollbar.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/Scrollbar.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerInputChange
@@ -48,7 +47,6 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
@@ -340,13 +338,13 @@ fun Scrollbar(
                 Horizontal -> {
                     constraints.copy(
                         minWidth = thumbSizePx.roundToInt(),
-                        maxWidth = thumbSizePx.roundToInt()
+                        maxWidth = thumbSizePx.roundToInt(),
                     )
                 }
                 Vertical -> {
                     constraints.copy(
                         minHeight = thumbSizePx.roundToInt(),
-                        maxHeight = thumbSizePx.roundToInt()
+                        maxHeight = thumbSizePx.roundToInt(),
                     )
                 }
             }
@@ -392,8 +390,6 @@ fun Scrollbar(
                 interactionThumbTravelPercent = currentThumbMovedPercent
                 delay(SCROLLBAR_PRESS_DELAY_MS)
             }
-
-
         }
     }
 

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/ScrollbarExt.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/ScrollbarExt.kt
@@ -24,8 +24,8 @@ import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridItemInfo
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
-import androidx.compose.runtime.produceState
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
@@ -41,57 +41,57 @@ import kotlin.math.min
 fun LazyListState.scrollbarState(
     itemsAvailable: Int,
     itemIndex: (LazyListItemInfo) -> Int = LazyListItemInfo::index,
-): State<ScrollbarState> = produceState(
-    initialValue = ScrollbarState.FULL,
-    key1 = this,
-    key2 = itemsAvailable,
-) {
-    snapshotFlow {
-        if (itemsAvailable == 0) return@snapshotFlow null
+): ScrollbarState {
+    val state = remember { ScrollbarState() }
+    LaunchedEffect(this, itemsAvailable) {
+        snapshotFlow {
+            if (itemsAvailable == 0) return@snapshotFlow null
 
-        val visibleItemsInfo = layoutInfo.visibleItemsInfo
-        if (visibleItemsInfo.isEmpty()) return@snapshotFlow null
+            val visibleItemsInfo = layoutInfo.visibleItemsInfo
+            if (visibleItemsInfo.isEmpty()) return@snapshotFlow null
 
-        val firstIndex = min(
-            a = interpolateFirstItemIndex(
-                visibleItems = visibleItemsInfo,
-                itemSize = { it.size },
-                offset = { it.offset },
-                nextItemOnMainAxis = { first -> visibleItemsInfo.find { it != first } },
-                itemIndex = itemIndex,
-            ),
-            b = itemsAvailable.toFloat(),
-        )
-        if (firstIndex.isNaN()) return@snapshotFlow null
+            val firstIndex = min(
+                a = interpolateFirstItemIndex(
+                    visibleItems = visibleItemsInfo,
+                    itemSize = { it.size },
+                    offset = { it.offset },
+                    nextItemOnMainAxis = { first -> visibleItemsInfo.find { it != first } },
+                    itemIndex = itemIndex,
+                ),
+                b = itemsAvailable.toFloat(),
+            )
+            if (firstIndex.isNaN()) return@snapshotFlow null
 
-        val itemsVisible = visibleItemsInfo.floatSumOf { itemInfo ->
-            itemVisibilityPercentage(
-                itemSize = itemInfo.size,
-                itemStartOffset = itemInfo.offset,
-                viewportStartOffset = layoutInfo.viewportStartOffset,
-                viewportEndOffset = layoutInfo.viewportEndOffset,
+            val itemsVisible = visibleItemsInfo.floatSumOf { itemInfo ->
+                itemVisibilityPercentage(
+                    itemSize = itemInfo.size,
+                    itemStartOffset = itemInfo.offset,
+                    viewportStartOffset = layoutInfo.viewportStartOffset,
+                    viewportEndOffset = layoutInfo.viewportEndOffset,
+                )
+            }
+
+            val thumbTravelPercent = min(
+                a = firstIndex / itemsAvailable,
+                b = 1f,
+            )
+            val thumbSizePercent = min(
+                a = itemsVisible / itemsAvailable,
+                b = 1f,
+            )
+            scrollbarStateValue(
+                thumbSizePercent = thumbSizePercent,
+                thumbMovedPercent = when {
+                    layoutInfo.reverseLayout -> 1f - thumbTravelPercent
+                    else -> thumbTravelPercent
+                },
             )
         }
-
-        val thumbTravelPercent = min(
-            a = firstIndex / itemsAvailable,
-            b = 1f,
-        )
-        val thumbSizePercent = min(
-            a = itemsVisible / itemsAvailable,
-            b = 1f,
-        )
-        ScrollbarState(
-            thumbSizePercent = thumbSizePercent,
-            thumbMovedPercent = when {
-                layoutInfo.reverseLayout -> 1f - thumbTravelPercent
-                else -> thumbTravelPercent
-            },
-        )
+            .filterNotNull()
+            .distinctUntilChanged()
+            .collect { state.onScroll(it) }
     }
-        .filterNotNull()
-        .distinctUntilChanged()
-        .collect { value = it }
+    return state
 }
 
 /**
@@ -104,67 +104,67 @@ fun LazyListState.scrollbarState(
 fun LazyGridState.scrollbarState(
     itemsAvailable: Int,
     itemIndex: (LazyGridItemInfo) -> Int = LazyGridItemInfo::index,
-): State<ScrollbarState> = produceState(
-    initialValue = ScrollbarState.FULL,
-    key1 = this,
-    key2 = itemsAvailable,
-) {
-    snapshotFlow {
-        if (itemsAvailable == 0) return@snapshotFlow null
+): ScrollbarState {
+    val state = remember { ScrollbarState() }
+    LaunchedEffect(this, itemsAvailable) {
+        snapshotFlow {
+            if (itemsAvailable == 0) return@snapshotFlow null
 
-        val visibleItemsInfo = layoutInfo.visibleItemsInfo
-        if (visibleItemsInfo.isEmpty()) return@snapshotFlow null
+            val visibleItemsInfo = layoutInfo.visibleItemsInfo
+            if (visibleItemsInfo.isEmpty()) return@snapshotFlow null
 
-        val firstIndex = min(
-            a = interpolateFirstItemIndex(
-                visibleItems = visibleItemsInfo,
-                itemSize = { layoutInfo.orientation.valueOf(it.size) },
-                offset = { layoutInfo.orientation.valueOf(it.offset) },
-                nextItemOnMainAxis = { first ->
-                    when (layoutInfo.orientation) {
-                        Orientation.Vertical -> visibleItemsInfo.find {
-                            it != first && it.row != first.row
+            val firstIndex = min(
+                a = interpolateFirstItemIndex(
+                    visibleItems = visibleItemsInfo,
+                    itemSize = { layoutInfo.orientation.valueOf(it.size) },
+                    offset = { layoutInfo.orientation.valueOf(it.offset) },
+                    nextItemOnMainAxis = { first ->
+                        when (layoutInfo.orientation) {
+                            Orientation.Vertical -> visibleItemsInfo.find {
+                                it != first && it.row != first.row
+                            }
+
+                            Orientation.Horizontal -> visibleItemsInfo.find {
+                                it != first && it.column != first.column
+                            }
                         }
+                    },
+                    itemIndex = itemIndex,
+                ),
+                b = itemsAvailable.toFloat(),
+            )
+            if (firstIndex.isNaN()) return@snapshotFlow null
 
-                        Orientation.Horizontal -> visibleItemsInfo.find {
-                            it != first && it.column != first.column
-                        }
-                    }
+            val itemsVisible = visibleItemsInfo.floatSumOf { itemInfo ->
+                itemVisibilityPercentage(
+                    itemSize = layoutInfo.orientation.valueOf(itemInfo.size),
+                    itemStartOffset = layoutInfo.orientation.valueOf(itemInfo.offset),
+                    viewportStartOffset = layoutInfo.viewportStartOffset,
+                    viewportEndOffset = layoutInfo.viewportEndOffset,
+                )
+            }
+
+            val thumbTravelPercent = min(
+                a = firstIndex / itemsAvailable,
+                b = 1f,
+            )
+            val thumbSizePercent = min(
+                a = itemsVisible / itemsAvailable,
+                b = 1f,
+            )
+            scrollbarStateValue(
+                thumbSizePercent = thumbSizePercent,
+                thumbMovedPercent = when {
+                    layoutInfo.reverseLayout -> 1f - thumbTravelPercent
+                    else -> thumbTravelPercent
                 },
-                itemIndex = itemIndex,
-            ),
-            b = itemsAvailable.toFloat(),
-        )
-        if (firstIndex.isNaN()) return@snapshotFlow null
-
-        val itemsVisible = visibleItemsInfo.floatSumOf { itemInfo ->
-            itemVisibilityPercentage(
-                itemSize = layoutInfo.orientation.valueOf(itemInfo.size),
-                itemStartOffset = layoutInfo.orientation.valueOf(itemInfo.offset),
-                viewportStartOffset = layoutInfo.viewportStartOffset,
-                viewportEndOffset = layoutInfo.viewportEndOffset,
             )
         }
-
-        val thumbTravelPercent = min(
-            a = firstIndex / itemsAvailable,
-            b = 1f,
-        )
-        val thumbSizePercent = min(
-            a = itemsVisible / itemsAvailable,
-            b = 1f,
-        )
-        ScrollbarState(
-            thumbSizePercent = thumbSizePercent,
-            thumbMovedPercent = when {
-                layoutInfo.reverseLayout -> 1f - thumbTravelPercent
-                else -> thumbTravelPercent
-            },
-        )
+            .filterNotNull()
+            .distinctUntilChanged()
+            .collect { state.onScroll(it) }
     }
-        .filterNotNull()
-        .distinctUntilChanged()
-        .collect { value = it }
+    return state
 }
 
 /**
@@ -178,56 +178,56 @@ fun LazyGridState.scrollbarState(
 fun LazyStaggeredGridState.scrollbarState(
     itemsAvailable: Int,
     itemIndex: (LazyStaggeredGridItemInfo) -> Int = LazyStaggeredGridItemInfo::index,
-): State<ScrollbarState> = produceState(
-    initialValue = ScrollbarState.FULL,
-    key1 = this,
-    key2 = itemsAvailable,
-) {
-    snapshotFlow {
-        if (itemsAvailable == 0) return@snapshotFlow null
+): ScrollbarState {
+    val state = remember { ScrollbarState() }
+    LaunchedEffect(this, itemsAvailable) {
+        snapshotFlow {
+            if (itemsAvailable == 0) return@snapshotFlow null
 
-        val visibleItemsInfo = layoutInfo.visibleItemsInfo
-        if (visibleItemsInfo.isEmpty()) return@snapshotFlow null
+            val visibleItemsInfo = layoutInfo.visibleItemsInfo
+            if (visibleItemsInfo.isEmpty()) return@snapshotFlow null
 
-        val firstIndex = min(
-            a = interpolateFirstItemIndex(
-                visibleItems = visibleItemsInfo,
-                itemSize = { layoutInfo.orientation.valueOf(it.size) },
-                offset = { layoutInfo.orientation.valueOf(it.offset) },
-                nextItemOnMainAxis = { first ->
-                    visibleItemsInfo.find { it != first && it.lane == first.lane }
-                },
-                itemIndex = itemIndex,
-            ),
-            b = itemsAvailable.toFloat(),
-        )
-        if (firstIndex.isNaN()) return@snapshotFlow null
+            val firstIndex = min(
+                a = interpolateFirstItemIndex(
+                    visibleItems = visibleItemsInfo,
+                    itemSize = { layoutInfo.orientation.valueOf(it.size) },
+                    offset = { layoutInfo.orientation.valueOf(it.offset) },
+                    nextItemOnMainAxis = { first ->
+                        visibleItemsInfo.find { it != first && it.lane == first.lane }
+                    },
+                    itemIndex = itemIndex,
+                ),
+                b = itemsAvailable.toFloat(),
+            )
+            if (firstIndex.isNaN()) return@snapshotFlow null
 
-        val itemsVisible = visibleItemsInfo.floatSumOf { itemInfo ->
-            itemVisibilityPercentage(
-                itemSize = layoutInfo.orientation.valueOf(itemInfo.size),
-                itemStartOffset = layoutInfo.orientation.valueOf(itemInfo.offset),
-                viewportStartOffset = layoutInfo.viewportStartOffset,
-                viewportEndOffset = layoutInfo.viewportEndOffset,
+            val itemsVisible = visibleItemsInfo.floatSumOf { itemInfo ->
+                itemVisibilityPercentage(
+                    itemSize = layoutInfo.orientation.valueOf(itemInfo.size),
+                    itemStartOffset = layoutInfo.orientation.valueOf(itemInfo.offset),
+                    viewportStartOffset = layoutInfo.viewportStartOffset,
+                    viewportEndOffset = layoutInfo.viewportEndOffset,
+                )
+            }
+
+            val thumbTravelPercent = min(
+                a = firstIndex / itemsAvailable,
+                b = 1f,
+            )
+            val thumbSizePercent = min(
+                a = itemsVisible / itemsAvailable,
+                b = 1f,
+            )
+            scrollbarStateValue(
+                thumbSizePercent = thumbSizePercent,
+                thumbMovedPercent = thumbTravelPercent,
             )
         }
-
-        val thumbTravelPercent = min(
-            a = firstIndex / itemsAvailable,
-            b = 1f,
-        )
-        val thumbSizePercent = min(
-            a = itemsVisible / itemsAvailable,
-            b = 1f,
-        )
-        ScrollbarState(
-            thumbSizePercent = thumbSizePercent,
-            thumbMovedPercent = thumbTravelPercent,
-        )
+            .filterNotNull()
+            .distinctUntilChanged()
+            .collect { state.onScroll(it) }
     }
-        .filterNotNull()
-        .distinctUntilChanged()
-        .collect { value = it }
+    return state
 }
 
 private inline fun <T> List<T>.floatSumOf(selector: (T) -> Float): Float {

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/ScrollbarExt.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/ScrollbarExt.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridItemInfo
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -40,7 +41,7 @@ import kotlin.math.min
 fun LazyListState.scrollbarState(
     itemsAvailable: Int,
     itemIndex: (LazyListItemInfo) -> Int = LazyListItemInfo::index,
-): ScrollbarState = produceState(
+): State<ScrollbarState> = produceState(
     initialValue = ScrollbarState.FULL,
     key1 = this,
     key2 = itemsAvailable,
@@ -91,7 +92,7 @@ fun LazyListState.scrollbarState(
         .filterNotNull()
         .distinctUntilChanged()
         .collect { value = it }
-}.value
+}
 
 /**
  * Calculates a [ScrollbarState] driven by the changes in a [LazyGridState]
@@ -103,7 +104,7 @@ fun LazyListState.scrollbarState(
 fun LazyGridState.scrollbarState(
     itemsAvailable: Int,
     itemIndex: (LazyGridItemInfo) -> Int = LazyGridItemInfo::index,
-): ScrollbarState = produceState(
+): State<ScrollbarState> = produceState(
     initialValue = ScrollbarState.FULL,
     key1 = this,
     key2 = itemsAvailable,
@@ -164,7 +165,7 @@ fun LazyGridState.scrollbarState(
         .filterNotNull()
         .distinctUntilChanged()
         .collect { value = it }
-}.value
+}
 
 /**
  * Remembers a [ScrollbarState] driven by the changes in a [LazyStaggeredGridState]
@@ -177,7 +178,7 @@ fun LazyGridState.scrollbarState(
 fun LazyStaggeredGridState.scrollbarState(
     itemsAvailable: Int,
     itemIndex: (LazyStaggeredGridItemInfo) -> Int = LazyStaggeredGridItemInfo::index,
-): ScrollbarState = produceState(
+): State<ScrollbarState> = produceState(
     initialValue = ScrollbarState.FULL,
     key1 = this,
     key2 = itemsAvailable,
@@ -227,7 +228,7 @@ fun LazyStaggeredGridState.scrollbarState(
         .filterNotNull()
         .distinctUntilChanged()
         .collect { value = it }
-}.value
+}
 
 private inline fun <T> List<T>.floatSumOf(selector: (T) -> Float): Float {
     var sum = 0f


### PR DESCRIPTION
The way scrollbar was implemented, it observes all changes in composition. This is bad for scroll performance causing recomposition on every frame of scroll that doesn't need to happen.

This PR moves the work of observing the scroll state into the layout phase.

### Benchmarks Results
Iterations: 10 (so probably liable to a lot of noise)
#### Before
```
ScrollForYouFeedBenchmark_scrollFeedCompilationBaselineProfile
frameDurationCpuMs   P50   7.0,   P90   9.0,   P95  14.0,   P99  15.2
frameOverrunMs       P50  -5.7,   P90  -1.1,   P95   5.0,   P99   5.8
Traces: Iteration 0 1 2 3 4 5 6 7 8 9
```
#### After
```
ScrollForYouFeedBenchmark_scrollFeedCompilationBaselineProfile
frameDurationCpuMs   P50   3.7 (+89%),   P90  6.7 (+34%),   P95  10.7  (+30%),   P99  16.0 (-5%)
frameOverrunMs       P50  -8.3,   P90 -5.4,   P95  -1.0,   P99   5.5
Traces: Iteration 0 1 2 3 4 5 6 7 8 9
```

