### PR TITLE
Fix #1079: Update thumb movement range by thumb size, in app scrollbars

### DIFF
--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/Scrollbar.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/Scrollbar.kt
@@ -96,7 +96,7 @@ class ScrollbarState {
      * Returns the max distance the thumb can travel as a percentage of total track size
      */
     val thumbTrackSizePercent
-        get() = 1f - unpackFloat1(packedValue)
+        get() = 1f - thumbSizePercent
 }
 
 /**

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/ThumbExt.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/ThumbExt.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import kotlin.math.roundToInt
 
 /**
  * Remembers a function to react to [Scrollbar] thumb position displacements for a [LazyListState]
@@ -79,7 +80,7 @@ private inline fun rememberDraggableScroller(
 
     LaunchedEffect(percentage) {
         if (percentage.isNaN()) return@LaunchedEffect
-        val indexToFind = (itemCount * percentage).toInt()
+        val indexToFind = (itemCount * percentage).roundToInt()
         scroll(indexToFind)
     }
     return remember {


### PR DESCRIPTION
**What I have done and why**
Update thumb movement range by thumb size, in app scrollbars

Fixes #1079

**Do tests pass?**
- [✓] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [✓] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`

**Is this your first pull request?**
- [✓] [Sign the CLA](https://cla.developers.google.com/)
- [✓] Run `./tools/setup.sh`
- [✓] Import the code formatting style as explained in [the setup script](/tools/setup.sh#L40).


