### PR TITLE
Enable stricter validation for build-logic convention plugins

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
+      - name: Check build-logic
+        run: ./gradlew check -p build-logic
+
       - name: Check spotless
         run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
 

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -43,6 +43,13 @@ dependencies {
     compileOnly(libs.ksp.gradlePlugin)
 }
 
+tasks {
+    validatePlugins {
+        enableStricterValidation.set(true)
+        failOnWarning.set(true)
+    }
+}
+
 gradlePlugin {
     plugins {
         register("androidApplicationCompose") {

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -45,8 +45,8 @@ dependencies {
 
 tasks {
     validatePlugins {
-        enableStricterValidation.set(true)
-        failOnWarning.set(true)
+        enableStricterValidation = true
+        failOnWarning = true
     }
 }
 

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
@@ -26,11 +26,14 @@ import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.kotlin.dsl.register
@@ -40,14 +43,17 @@ import java.io.File
 import java.nio.file.Files
 import javax.inject.Inject
 
+@CacheableTask
 abstract class GenerateBadgingTask : DefaultTask() {
 
     @get:OutputFile
     abstract val badging: RegularFileProperty
 
+    @get:PathSensitive(PathSensitivity.NONE)
     @get:InputFile
     abstract val apk: RegularFileProperty
 
+    @get:PathSensitive(PathSensitivity.NONE)
     @get:InputFile
     abstract val aapt2Executable: RegularFileProperty
 
@@ -68,6 +74,7 @@ abstract class GenerateBadgingTask : DefaultTask() {
     }
 }
 
+@CacheableTask
 abstract class CheckBadgingTask : DefaultTask() {
 
     // In order for the task to be up-to-date when the inputs have not changed,
@@ -76,9 +83,11 @@ abstract class CheckBadgingTask : DefaultTask() {
     @get:OutputDirectory
     abstract val output: DirectoryProperty
 
+    @get:PathSensitive(PathSensitivity.NONE)
     @get:InputFile
     abstract val goldenBadging: RegularFileProperty
 
+    @get:PathSensitive(PathSensitivity.NONE)
     @get:InputFile
     abstract val generatedBadging: RegularFileProperty
 

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/PrintTestApks.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/PrintTestApks.kt
@@ -30,7 +30,10 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 
 internal fun Project.configurePrintApksTask(extension: AndroidComponentsExtension<*, *, *>) {
@@ -62,10 +65,14 @@ internal fun Project.configurePrintApksTask(extension: AndroidComponentsExtensio
     }
 }
 
+@DisableCachingByDefault(because = "Prints output")
 internal abstract class PrintApkLocationTask : DefaultTask() {
+
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputDirectory
     abstract val apkFolder: DirectoryProperty
 
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFiles
     abstract val sources: ListProperty<Directory>
 


### PR DESCRIPTION
Enables stricter validation for the convention plugins, and fixes the resulting reported issues around caching and file sensitivity.
