### PR TITLE
Update max concurrent PRs for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
           - "org.jetbrains.kotlin.jvm"
           - "com.google.devtools.ksp"
           - "androidx.compose.compiler:compiler"
+    open-pull-requests-limit: 10
 registries:
   maven-google:
     type: "maven-repository"


### PR DESCRIPTION
We currently have many pending updates that are not listed and the default 5 concurrent PRs is very limiting.

See documentation on https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit

- https://github.com/android/nowinandroid/issues/1083
