### PR TITLE
Add truth for better badging diff output

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     compileOnly(libs.firebase.performance.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.ksp.gradlePlugin)
+    implementation(libs.truth)
 }
 
 tasks {

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
@@ -20,8 +20,8 @@ import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.gradle.BaseExtension
 import com.android.SdkConstants
+import com.google.common.truth.Truth.assertWithMessage
 import org.gradle.api.DefaultTask
-import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -40,7 +40,6 @@ import org.gradle.kotlin.dsl.register
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.process.ExecOperations
 import java.io.File
-import java.nio.file.Files
 import javax.inject.Inject
 
 @CacheableTask
@@ -98,17 +97,12 @@ abstract class CheckBadgingTask : DefaultTask() {
 
     @TaskAction
     fun taskAction() {
-        if (
-            Files.mismatch(
-                goldenBadging.get().asFile.toPath(),
-                generatedBadging.get().asFile.toPath(),
-            ) != -1L
-        ) {
-            throw GradleException(
-                "Generated badging is different from golden badging! " +
-                    "If this change is intended, run ./gradlew ${updateBadgingTaskName.get()}",
-            )
-        }
+        assertWithMessage(
+            "Generated badging is different from golden badging! " +
+                "If this change is intended, run ./gradlew ${updateBadgingTaskName.get()}",
+        )
+            .that(generatedBadging.get().asFile.readText())
+            .isEqualTo(goldenBadging.get().asFile.readText())
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ robolectric = "4.11.1"
 roborazzi = "1.6.0"
 room = "2.6.0"
 secrets = "2.0.1"
+truth = "1.1.5"
 turbine = "1.0.0"
 
 [libraries]
@@ -140,6 +141,7 @@ roborazzi = { group = "io.github.takahirom.roborazzi", name = "roborazzi", versi
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 
 # Dependencies of the included build-logic


### PR DESCRIPTION
Adds truth to the badging task to give a better diff output for the golden and generated badging files.

Error message before:
```
> Task :app:checkProdReleaseBadging FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:checkProdReleaseBadging'.
> Generated badging is different from golden badging! If this change is intended, run ./gradlew updateProdReleaseBadging

```

Error message after:

```
> Task :app:checkProdReleaseBadging FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:checkProdReleaseBadging'.
> Generated badging is different from golden badging! If this change is intended, run ./gradlew updateProdReleaseBadging
  value of:
      readText$default(...)
  diff (-expected +actual):
      @@ -2,6 +2,7 @@
       sdkVersion:'21'
       targetSdkVersion:'34'
       uses-permission: name='android.permission.INTERNET'
      +uses-permission: name='android.permission.RECORD_AUDIO'
       uses-permission: name='android.permission.ACCESS_NETWORK_STATE'
       uses-permission: name='android.permission.POST_NOTIFICATIONS'
       uses-permission: name='android.permission.WAKE_LOCK'
      @@ -111,6 +112,8 @@
       feature-group: label=''
         uses-feature: name='android.hardware.faketouch'
         uses-implied-feature: name='android.hardware.faketouch' reason='default feature for all apps'
      +  uses-feature: name='android.hardware.microphone'
      +  uses-implied-feature: name='android.hardware.microphone' reason='requested android.permission.RECORD_AUDIO permission'
       main
       other-activities
       other-receivers

```