### PR TITLE
Add comment explaining why the launcher icon colors differ per build

### DIFF
--- a/app/src/benchmark/res/values-night/colors.xml
+++ b/app/src/benchmark/res/values-night/colors.xml
@@ -15,6 +15,8 @@
      limitations under the License.
 -->
 <resources>
+    <!-- Allow users to distinguish between build variants by having a different background color
+        for the launcher icon. See https://github.com/android/nowinandroid/pull/989. -->
     <color name="ic_launcher_background_tint">#FFFFFF</color>
     <color name="ic_launcher_foreground_tint">#FF006780</color>
 </resources>

--- a/app/src/benchmark/res/values-night/colors.xml
+++ b/app/src/benchmark/res/values-night/colors.xml
@@ -14,8 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<!-- Allow users to distinguish between build variants by having a different background color for
-the launcher icon. See https://github.com/android/nowinandroid/pull/989. -->
 <resources>
     <color name="ic_launcher_background_tint">#FFFFFF</color>
     <color name="ic_launcher_foreground_tint">#FF006780</color>

--- a/app/src/benchmark/res/values-night/colors.xml
+++ b/app/src/benchmark/res/values-night/colors.xml
@@ -14,6 +14,8 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
+<!-- Allow users to distinguish between build variants by having a different background color for
+the launcher icon. See https://github.com/android/nowinandroid/pull/989. -->
 <resources>
     <color name="ic_launcher_background_tint">#FFFFFF</color>
     <color name="ic_launcher_foreground_tint">#FF006780</color>

--- a/app/src/benchmark/res/values/colors.xml
+++ b/app/src/benchmark/res/values/colors.xml
@@ -15,6 +15,8 @@
      limitations under the License.
 -->
 <resources>
+    <!-- Allow users to distinguish between build variants by having a different background color
+        for the launcher icon. See https://github.com/android/nowinandroid/pull/989. -->
     <color name="ic_launcher_background_tint">#000000</color>
     <color name="ic_launcher_foreground_tint">#FF006780</color>
 </resources>

--- a/app/src/benchmark/res/values/colors.xml
+++ b/app/src/benchmark/res/values/colors.xml
@@ -14,8 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<!-- Allow users to distinguish between build variants by having a different background color for
-the launcher icon. See https://github.com/android/nowinandroid/pull/989. -->
 <resources>
     <color name="ic_launcher_background_tint">#000000</color>
     <color name="ic_launcher_foreground_tint">#FF006780</color>

--- a/app/src/benchmark/res/values/colors.xml
+++ b/app/src/benchmark/res/values/colors.xml
@@ -14,6 +14,8 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
+<!-- Allow users to distinguish between build variants by having a different background color for
+the launcher icon. See https://github.com/android/nowinandroid/pull/989. -->
 <resources>
     <color name="ic_launcher_background_tint">#000000</color>
     <color name="ic_launcher_foreground_tint">#FF006780</color>

--- a/app/src/debug/res/values-night/colors.xml
+++ b/app/src/debug/res/values-night/colors.xml
@@ -15,6 +15,8 @@
      limitations under the License.
 -->
 <resources>
+    <!-- Allow users to distinguish between build variants by having a different background color
+    for the launcher icon. See https://github.com/android/nowinandroid/pull/989. -->
     <color name="ic_launcher_background_tint">#FFFFFF</color>
     <color name="ic_launcher_foreground_tint">#FFA23F16</color>
 </resources>

--- a/app/src/debug/res/values-night/colors.xml
+++ b/app/src/debug/res/values-night/colors.xml
@@ -14,6 +14,8 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
+<!-- Allow users to distinguish between build variants by having a different background color for
+the launcher icon. See https://github.com/android/nowinandroid/pull/989. -->
 <resources>
     <color name="ic_launcher_background_tint">#FFFFFF</color>
     <color name="ic_launcher_foreground_tint">#FFA23F16</color>

--- a/app/src/debug/res/values-night/colors.xml
+++ b/app/src/debug/res/values-night/colors.xml
@@ -14,8 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<!-- Allow users to distinguish between build variants by having a different background color for
-the launcher icon. See https://github.com/android/nowinandroid/pull/989. -->
 <resources>
     <color name="ic_launcher_background_tint">#FFFFFF</color>
     <color name="ic_launcher_foreground_tint">#FFA23F16</color>

--- a/app/src/debug/res/values/colors.xml
+++ b/app/src/debug/res/values/colors.xml
@@ -15,6 +15,8 @@
      limitations under the License.
 -->
 <resources>
+    <!-- Allow users to distinguish between build variants by having a different background color
+    for the launcher icon. See https://github.com/android/nowinandroid/pull/989. -->
     <color name="ic_launcher_background_tint">#000000</color>
     <color name="ic_launcher_foreground_tint">#FFA23F16</color>
 </resources>

--- a/app/src/debug/res/values/colors.xml
+++ b/app/src/debug/res/values/colors.xml
@@ -14,8 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<!-- Allow users to distinguish between build variants by having a different background color for
-the launcher icon. See https://github.com/android/nowinandroid/pull/989. -->
 <resources>
     <color name="ic_launcher_background_tint">#000000</color>
     <color name="ic_launcher_foreground_tint">#FFA23F16</color>

--- a/app/src/debug/res/values/colors.xml
+++ b/app/src/debug/res/values/colors.xml
@@ -14,6 +14,8 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
+<!-- Allow users to distinguish between build variants by having a different background color for
+the launcher icon. See https://github.com/android/nowinandroid/pull/989. -->
 <resources>
     <color name="ic_launcher_background_tint">#000000</color>
     <color name="ic_launcher_foreground_tint">#FFA23F16</color>


### PR DESCRIPTION
When you open the `app/src/debug|benchmark` folders it's not immediately clear why the `colors.xml` files are different. Added a comment explaining this. 


