### PR TITLE
Don't run unit tests on prodDebug variant

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -75,7 +75,7 @@ jobs:
       # Run local tests after screenshot tests to avoid wrong UP-TO-DATE. TODO: Ignore screenshots.
       - name: Run local tests
         if: always()
-        run: ./gradlew testDemoDebug testProdDebug :lint:test
+        run: ./gradlew testDemoDebug :lint:test
       # Replace task exclusions with `-Pandroidx.baselineprofile.skipgeneration` when
       # https://android-review.googlesource.com/c/platform/frameworks/support/+/2602790 landed in a
       # release build


### PR DESCRIPTION
`prod` doesn't have any tests. There is no point in running tests on the `prodDebug` variant when we have already run all tests from the `demoDebug` variant. 
