### PR TITLE
Replace `Enum.values()` with `Enum.entries`

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
@@ -115,7 +115,7 @@ class NiaAppState(
      * Map of top level destinations to be used in the TopBar, BottomBar and NavRail. The key is the
      * route.
      */
-    val topLevelDestinations: List<TopLevelDestination> = TopLevelDestination.values().asList()
+    val topLevelDestinations: List<TopLevelDestination> = TopLevelDestination.entries
 
     /**
      * The top level destinations that have unread news resources.

--- a/benchmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/interests/ScrollTopicListPowerMetricsBenchmark.kt
+++ b/benchmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/interests/ScrollTopicListPowerMetricsBenchmark.kt
@@ -45,7 +45,7 @@ class ScrollTopicListPowerMetricsBenchmark {
     @get:Rule
     val benchmarkRule = MacrobenchmarkRule()
 
-    private val categories = PowerCategory.values()
+    private val categories = PowerCategory.entries
         .associateWith { PowerCategoryDisplayLevel.TOTAL }
 
     @Test

--- a/core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/util/ScreenshotHelper.kt
+++ b/core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/util/ScreenshotHelper.kt
@@ -53,7 +53,7 @@ fun <A : ComponentActivity> AndroidComposeTestRule<ActivityScenarioRule<A>, A>.c
     screenshotName: String,
     body: @Composable () -> Unit,
 ) {
-    DefaultTestDevices.values().forEach {
+    DefaultTestDevices.entries.forEach {
         this.captureForDevice(it.description, it.spec, screenshotName, body = body)
     }
 }


### PR DESCRIPTION
'Enum.values()' is recommended to be replaced by 'Enum.entries' since 1.9