### PR TITLE
Fix name and message of dependency guard actions

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -55,11 +55,10 @@ jobs:
         continue-on-error: false
         if: steps.dependencyguard_verify.outcome == 'failure' && github.event.pull_request.head.repo.full_name != github.repository
         run: |
-          echo "::error::Dependency Guard failed, please run the following to update baselines:\n" \
-               "    ./gradlew dependencyGuardBaseline" && exit 1
+          echo "::error::Dependency Guard failed, please update baselines with: ./gradlew dependencyGuardBaseline" && exit 1
 
         # Runs if previous job failed
-      - name: Generate new screenshots if verification failed and it's a PR
+      - name: Generate new Dependency Guard baselines if verification failed and it's a PR
         id: dependencyguard_baseline
         if: steps.dependencyguard_verify.outcome == 'failure' && github.event_name == 'pull_request'
         run: |


### PR DESCRIPTION
- The action to update baselines erroneously says "screenshots".
- Update message in the action to check forks because "\n" doesn't print a newline. 