### PR TITLE
Remove legacy benchmark build type

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -109,13 +109,9 @@ jobs:
       - name: Build all build type and flavor permutations
         run: ./gradlew :app:assemble :benchmarks:assemble
           -x pixel6Api33ProdNonMinifiedReleaseAndroidTest
-          -x pixel6Api33ProdNonMinifiedBenchmarkAndroidTest
           -x pixel6Api33DemoNonMinifiedReleaseAndroidTest
-          -x pixel6Api33DemoNonMinifiedBenchmarkAndroidTest
           -x collectDemoNonMinifiedReleaseBaselineProfile
-          -x collectDemoNonMinifiedBenchmarkBaselineProfile
           -x collectProdNonMinifiedReleaseBaselineProfile
-          -x collectProdNonMinifiedBenchmarkBaselineProfile
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v4

--- a/app-nia-catalog/dependencies/releaseRuntimeClasspath.txt
+++ b/app-nia-catalog/dependencies/releaseRuntimeClasspath.txt
@@ -70,7 +70,8 @@ androidx.profileinstaller:profileinstaller:1.3.1
 androidx.savedstate:savedstate-ktx:1.2.1
 androidx.savedstate:savedstate:1.2.1
 androidx.startup:startup-runtime:1.1.1
-androidx.tracing:tracing:1.0.0
+androidx.tracing:tracing-ktx:1.3.0-alpha02
+androidx.tracing:tracing:1.3.0-alpha02
 androidx.vectordrawable:vectordrawable-animated:1.1.0
 androidx.vectordrawable:vectordrawable:1.1.0
 androidx.versionedparcelable:versionedparcelable:1.1.1

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,17 +57,6 @@ android {
             // Ensure Baseline Profile is fresh for release builds.
             baselineProfile.automaticGenerationDuringBuild = true
         }
-        create("benchmark") {
-            // Enable all the optimizations from release build through initWith(release).
-            initWith(release)
-            matchingFallbacks.add("release")
-            // Debug key signing is available to everyone.
-            signingConfig = signingConfigs.getByName("debug")
-            // Only use benchmark proguard rules
-            proguardFiles("benchmark-rules.pro")
-            isMinifyEnabled = true
-            applicationIdSuffix = NiaBuildType.BENCHMARK.applicationIdSuffix
-        }
     }
 
     packaging {

--- a/app/dependencies/prodReleaseRuntimeClasspath.txt
+++ b/app/dependencies/prodReleaseRuntimeClasspath.txt
@@ -105,8 +105,8 @@ androidx.savedstate:savedstate:1.2.1
 androidx.sqlite:sqlite-framework:2.4.0
 androidx.sqlite:sqlite:2.4.0
 androidx.startup:startup-runtime:1.1.1
-androidx.tracing:tracing-ktx:1.1.0
-androidx.tracing:tracing:1.1.0
+androidx.tracing:tracing-ktx:1.3.0-alpha02
+androidx.tracing:tracing:1.3.0-alpha02
 androidx.vectordrawable:vectordrawable-animated:1.1.0
 androidx.vectordrawable:vectordrawable:1.1.0
 androidx.versionedparcelable:versionedparcelable:1.1.1

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import com.google.samples.apps.nowinandroid.NiaBuildType
 import com.google.samples.apps.nowinandroid.configureFlavors
 
 plugins {
@@ -33,23 +32,6 @@ android {
 
     buildFeatures {
         buildConfig = true
-    }
-
-    buildTypes {
-        // This benchmark buildType is used for benchmarking, and should function like your
-        // release build (for example, with minification on). It's signed with a debug key
-        // for easy local/CI testing.
-        create("benchmark") {
-            // Keep the build type debuggable so we can attach a debugger if needed.
-            isDebuggable = true
-            signingConfig = signingConfigs.getByName("debug")
-            matchingFallbacks.add("release")
-            buildConfigField(
-                "String",
-                "APP_BUILD_TYPE_SUFFIX",
-                "\"${NiaBuildType.BENCHMARK.applicationIdSuffix ?: ""}\""
-            )
-        }
     }
 
     // Use the same flavor dimensions as the application to allow generating Baseline Profiles on prod,

--- a/benchmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/Utils.kt
+++ b/benchmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/Utils.kt
@@ -30,7 +30,6 @@ import java.io.ByteArrayOutputStream
 val PACKAGE_NAME = buildString {
     append("com.google.samples.apps.nowinandroid")
     append(BuildConfig.APP_FLAVOR_SUFFIX)
-    append(BuildConfig.APP_BUILD_TYPE_SUFFIX)
 }
 
 fun UiDevice.flingElementDownUp(element: UiObject2) {

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaBuildType.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaBuildType.kt
@@ -22,5 +22,4 @@ package com.google.samples.apps.nowinandroid
 enum class NiaBuildType(val applicationIdSuffix: String? = null) {
     DEBUG(".debug"),
     RELEASE,
-    BENCHMARK(".benchmark")
 }

--- a/feature/foryou/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -81,9 +81,9 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
 import androidx.compose.ui.unit.sp
-import androidx.tracing.trace
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tracing.trace
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus.Denied
 import com.google.accompanist.permissions.rememberPermissionState


### PR DESCRIPTION
Now that we have the baseline profile gradle plugin, there is no need for a benchmark build type.
The plugin does the setup and configuration and runs against the correct app flavor.

Change-Id: I7df90c982e7a27c2fd2051ada441038ac1c76484

Thanks for submitting a pull request. Please include the following information.

**What I have done and why**
Include a summary of what your pull request contains, and why you have made these changes.

Fixes #<issue_number_goes_here>

**Do tests pass?**
- [x] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [x] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`


