### PR TITLE
[Refactor]: Replace testharness with `DeviceConfigurationOverride`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,7 +106,7 @@ dependencies {
 
     testImplementation(projects.core.dataTest)
     testImplementation(projects.core.testing)
-    testImplementation(libs.accompanist.testharness)
+    testImplementation(libs.androidx.compose.ui.uitest)
     testImplementation(libs.hilt.android.testing)
     testImplementation(libs.work.testing)
 
@@ -117,7 +117,7 @@ dependencies {
     androidTestImplementation(projects.core.dataTest)
     androidTestImplementation(projects.core.datastoreTest)
     androidTestImplementation(libs.androidx.navigation.testing)
-    androidTestImplementation(libs.accompanist.testharness)
+    androidTestImplementation(libs.androidx.compose.ui.uitest)
     androidTestImplementation(libs.hilt.android.testing)
 
     baselineProfile(projects.benchmarks)

--- a/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationUiTest.kt
+++ b/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationUiTest.kt
@@ -19,12 +19,13 @@ package com.google.samples.apps.nowinandroid.ui
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.ui.test.DeviceConfigurationOverride
+import androidx.compose.ui.test.ForcedSize
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.testharness.TestHarness
 import com.google.samples.apps.nowinandroid.core.data.repository.CompositeUserNewsResourceRepository
 import com.google.samples.apps.nowinandroid.core.data.util.NetworkMonitor
 import com.google.samples.apps.nowinandroid.core.rules.GrantPostNotificationsPermissionRule
@@ -89,7 +90,7 @@ class NavigationUiTest {
     @Test
     fun compactWidth_compactHeight_showsNavigationBar() {
         composeTestRule.setContent {
-            TestHarness(size = DpSize(400.dp, 400.dp)) {
+            DeviceConfigurationOverride(override = DeviceConfigurationOverride.ForcedSize(size = DpSize(400.dp, 400.dp))) {
                 BoxWithConstraints {
                     NiaApp(
                         windowSizeClass = WindowSizeClass.calculateFromSize(
@@ -109,7 +110,7 @@ class NavigationUiTest {
     @Test
     fun mediumWidth_compactHeight_showsNavigationRail() {
         composeTestRule.setContent {
-            TestHarness(size = DpSize(610.dp, 400.dp)) {
+            DeviceConfigurationOverride(override = DeviceConfigurationOverride.ForcedSize(size = DpSize(610.dp, 400.dp))) {
                 BoxWithConstraints {
                     NiaApp(
                         windowSizeClass = WindowSizeClass.calculateFromSize(
@@ -129,7 +130,7 @@ class NavigationUiTest {
     @Test
     fun expandedWidth_compactHeight_showsNavigationRail() {
         composeTestRule.setContent {
-            TestHarness(size = DpSize(900.dp, 400.dp)) {
+            DeviceConfigurationOverride(override = DeviceConfigurationOverride.ForcedSize(size = DpSize(900.dp, 400.dp))) {
                 BoxWithConstraints {
                     NiaApp(
                         windowSizeClass = WindowSizeClass.calculateFromSize(
@@ -149,7 +150,7 @@ class NavigationUiTest {
     @Test
     fun compactWidth_mediumHeight_showsNavigationBar() {
         composeTestRule.setContent {
-            TestHarness(size = DpSize(400.dp, 500.dp)) {
+            DeviceConfigurationOverride(override = DeviceConfigurationOverride.ForcedSize(size = DpSize(400.dp, 500.dp))) {
                 BoxWithConstraints {
                     NiaApp(
                         windowSizeClass = WindowSizeClass.calculateFromSize(
@@ -169,7 +170,7 @@ class NavigationUiTest {
     @Test
     fun mediumWidth_mediumHeight_showsNavigationRail() {
         composeTestRule.setContent {
-            TestHarness(size = DpSize(610.dp, 500.dp)) {
+            DeviceConfigurationOverride(override = DeviceConfigurationOverride.ForcedSize(size = DpSize(610.dp, 500.dp))) {
                 BoxWithConstraints {
                     NiaApp(
                         windowSizeClass = WindowSizeClass.calculateFromSize(
@@ -189,7 +190,7 @@ class NavigationUiTest {
     @Test
     fun expandedWidth_mediumHeight_showsNavigationRail() {
         composeTestRule.setContent {
-            TestHarness(size = DpSize(900.dp, 500.dp)) {
+            DeviceConfigurationOverride(override = DeviceConfigurationOverride.ForcedSize(size = DpSize(900.dp, 500.dp))) {
                 BoxWithConstraints {
                     NiaApp(
                         windowSizeClass = WindowSizeClass.calculateFromSize(
@@ -209,7 +210,7 @@ class NavigationUiTest {
     @Test
     fun compactWidth_expandedHeight_showsNavigationBar() {
         composeTestRule.setContent {
-            TestHarness(size = DpSize(400.dp, 1000.dp)) {
+            DeviceConfigurationOverride(override = DeviceConfigurationOverride.ForcedSize(size = DpSize(400.dp, 1000.dp))) {
                 BoxWithConstraints {
                     NiaApp(
                         windowSizeClass = WindowSizeClass.calculateFromSize(
@@ -229,7 +230,7 @@ class NavigationUiTest {
     @Test
     fun mediumWidth_expandedHeight_showsNavigationRail() {
         composeTestRule.setContent {
-            TestHarness(size = DpSize(610.dp, 1000.dp)) {
+            DeviceConfigurationOverride(override = DeviceConfigurationOverride.ForcedSize(size = DpSize(610.dp, 1000.dp))) {
                 BoxWithConstraints {
                     NiaApp(
                         windowSizeClass = WindowSizeClass.calculateFromSize(
@@ -249,7 +250,7 @@ class NavigationUiTest {
     @Test
     fun expandedWidth_expandedHeight_showsNavigationRail() {
         composeTestRule.setContent {
-            TestHarness(size = DpSize(900.dp, 1000.dp)) {
+            DeviceConfigurationOverride(override = DeviceConfigurationOverride.ForcedSize(size = DpSize(900.dp, 1000.dp))) {
                 BoxWithConstraints {
                     NiaApp(
                         windowSizeClass = WindowSizeClass.calculateFromSize(

--- a/app/src/testDemo/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppScreenSizesScreenshotTests.kt
+++ b/app/src/testDemo/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppScreenSizesScreenshotTests.kt
@@ -22,6 +22,8 @@ import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSiz
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.test.DeviceConfigurationOverride
+import androidx.compose.ui.test.ForcedSize
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.Dp
@@ -32,7 +34,6 @@ import androidx.work.Configuration
 import androidx.work.testing.SynchronousExecutor
 import androidx.work.testing.WorkManagerTestInitHelper
 import com.github.takahirom.roborazzi.captureRoboImage
-import com.google.accompanist.testharness.TestHarness
 import com.google.samples.apps.nowinandroid.core.data.repository.TopicsRepository
 import com.google.samples.apps.nowinandroid.core.data.repository.UserDataRepository
 import com.google.samples.apps.nowinandroid.core.data.repository.UserNewsResourceRepository
@@ -138,7 +139,7 @@ class NiaAppScreenSizesScreenshotTests {
             CompositionLocalProvider(
                 LocalInspectionMode provides true,
             ) {
-                TestHarness(size = DpSize(width, height)) {
+                DeviceConfigurationOverride(override = DeviceConfigurationOverride.ForcedSize(size = DpSize(width, height))) {
                     BoxWithConstraints {
                         NiaApp(
                             windowSizeClass = WindowSizeClass.calculateFromSize(

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation(libs.coil.kt.compose)
 
     testImplementation(libs.androidx.compose.ui.test)
-    testImplementation(libs.accompanist.testharness)
+    testImplementation(libs.androidx.compose.ui.uitest)
     testImplementation(libs.hilt.android.testing)
     testImplementation(libs.robolectric)
     testImplementation(libs.roborazzi)

--- a/core/designsystem/src/test/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/FilterChipScreenshotTests.kt
+++ b/core/designsystem/src/test/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/FilterChipScreenshotTests.kt
@@ -21,12 +21,15 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.test.DeviceConfigurationOverride
+import androidx.compose.ui.test.FontScale
+import androidx.compose.ui.test.ForcedSize
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.then
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.github.takahirom.roborazzi.captureRoboImage
-import com.google.accompanist.testharness.TestHarness
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaBackground
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaFilterChip
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
@@ -78,7 +81,7 @@ class FilterChipScreenshotTests() {
             CompositionLocalProvider(
                 LocalInspectionMode provides true,
             ) {
-                TestHarness(fontScale = 2f, size = DpSize(80.dp, 40.dp)) {
+                DeviceConfigurationOverride(override = DeviceConfigurationOverride.FontScale(fontScale = 2f) then DeviceConfigurationOverride.ForcedSize(DpSize(80.dp, 40.dp))) {
                     NiaTheme {
                         NiaBackground {
                             NiaFilterChip(selected = true, onSelectedChange = {}) {

--- a/core/designsystem/src/test/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/NavigationScreenshotTests.kt
+++ b/core/designsystem/src/test/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/NavigationScreenshotTests.kt
@@ -23,10 +23,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.test.DeviceConfigurationOverride
+import androidx.compose.ui.test.FontScale
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import com.github.takahirom.roborazzi.captureRoboImage
-import com.google.accompanist.testharness.TestHarness
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaNavigationBar
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaNavigationBarItem
 import com.google.samples.apps.nowinandroid.core.designsystem.icon.NiaIcons
@@ -66,7 +67,7 @@ class NavigationScreenshotTests() {
             CompositionLocalProvider(
                 LocalInspectionMode provides true,
             ) {
-                TestHarness(fontScale = 2f) {
+                DeviceConfigurationOverride(override = DeviceConfigurationOverride.FontScale(fontScale = 2f)) {
                     NiaTheme {
                         NiaNavigationBarExample("Looong item")
                     }

--- a/core/designsystem/src/test/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/TabsScreenshotTests.kt
+++ b/core/designsystem/src/test/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/TabsScreenshotTests.kt
@@ -22,10 +22,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.test.DeviceConfigurationOverride
+import androidx.compose.ui.test.FontScale
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import com.github.takahirom.roborazzi.captureRoboImage
-import com.google.accompanist.testharness.TestHarness
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaTab
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaTabRow
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
@@ -62,7 +63,7 @@ class TabsScreenshotTests() {
             CompositionLocalProvider(
                 LocalInspectionMode provides true,
             ) {
-                TestHarness(fontScale = 2f) {
+                DeviceConfigurationOverride(override = DeviceConfigurationOverride.FontScale(fontScale = 2f)) {
                     NiaTheme {
                         NiaTabsExample("Looooong item")
                     }

--- a/core/designsystem/src/test/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/TagScreenshotTests.kt
+++ b/core/designsystem/src/test/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/TagScreenshotTests.kt
@@ -20,10 +20,11 @@ import androidx.activity.ComponentActivity
 import androidx.compose.material3.Text
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.test.DeviceConfigurationOverride
+import androidx.compose.ui.test.FontScale
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import com.github.takahirom.roborazzi.captureRoboImage
-import com.google.accompanist.testharness.TestHarness
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaTopicTag
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import com.google.samples.apps.nowinandroid.core.testing.util.DefaultRoborazziOptions
@@ -61,7 +62,7 @@ class TagScreenshotTests() {
             CompositionLocalProvider(
                 LocalInspectionMode provides true,
             ) {
-                TestHarness(fontScale = 2f) {
+                DeviceConfigurationOverride(override = DeviceConfigurationOverride.FontScale(fontScale = 2f)) {
                     NiaTheme {
                         NiaTopicTag(followed = true, onClick = {}) {
                             Text("LOOOOONG TOPIC")

--- a/core/designsystem/src/test/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/TopAppBarScreenshotTests.kt
+++ b/core/designsystem/src/test/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/TopAppBarScreenshotTests.kt
@@ -22,10 +22,11 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.test.DeviceConfigurationOverride
+import androidx.compose.ui.test.FontScale
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import com.github.takahirom.roborazzi.captureRoboImage
-import com.google.accompanist.testharness.TestHarness
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaTopAppBar
 import com.google.samples.apps.nowinandroid.core.designsystem.icon.NiaIcons
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
@@ -63,7 +64,7 @@ class TopAppBarScreenshotTests() {
             CompositionLocalProvider(
                 LocalInspectionMode provides true,
             ) {
-                TestHarness(fontScale = 2f) {
+                DeviceConfigurationOverride(override = DeviceConfigurationOverride.FontScale(fontScale = 2f)) {
                     NiaTheme {
                         NiaTopAppBarExample()
                     }

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 
     debugApi(libs.androidx.compose.ui.testManifest)
 
-    implementation(libs.accompanist.testharness)
+    implementation(libs.androidx.compose.ui.uitest)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.test.rules)
     implementation(libs.hilt.android.testing)

--- a/core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/util/ScreenshotHelper.kt
+++ b/core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/util/ScreenshotHelper.kt
@@ -25,6 +25,8 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.test.DarkMode
+import androidx.compose.ui.test.DeviceConfigurationOverride
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.onRoot
 import androidx.test.ext.junit.rules.ActivityScenarioRule
@@ -32,7 +34,6 @@ import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.RoborazziOptions.CompareOptions
 import com.github.takahirom.roborazzi.RoborazziOptions.RecordOptions
 import com.github.takahirom.roborazzi.captureRoboImage
-import com.google.accompanist.testharness.TestHarness
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import org.robolectric.RuntimeEnvironment
 
@@ -75,7 +76,7 @@ fun <A : ComponentActivity> AndroidComposeTestRule<ActivityScenarioRule<A>, A>.c
         CompositionLocalProvider(
             LocalInspectionMode provides true,
         ) {
-            TestHarness(darkMode = darkMode) {
+            DeviceConfigurationOverride(override = DeviceConfigurationOverride.DarkMode(isDarkMode = darkMode)) {
                 body()
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ androidxTracing = "1.3.0-alpha02"
 androidxUiAutomator = "2.2.0"
 androidxWindowManager = "1.2.0"
 androidxWork = "2.9.0"
+androidxUiTest = "1.7.0-alpha01"
 coil = "2.5.0"
 dependencyGuard = "0.4.3"
 firebaseBom = "32.4.0"
@@ -59,7 +60,6 @@ turbine = "1.0.0"
 
 [libraries]
 accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanist" }
-accompanist-testharness = { group = "com.google.accompanist", name = "accompanist-testharness", version.ref = "accompanist" }
 android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
@@ -77,6 +77,8 @@ androidx-compose-ui-testManifest = { group = "androidx.compose.ui", name = "ui-t
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-ui-util = { group = "androidx.compose.ui", name = "ui-util" }
+androidx-compose-ui-uitest = { group = "androidx.compose.ui", name = "ui-test", version.ref = "androidxUiTest" }
+
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "androidxCoreSplashscreen" }
 androidx-dataStore-core = { group = "androidx.datastore", name = "datastore", version.ref = "androidxDataStore" }


### PR DESCRIPTION
**What I have done and why**
Replace testharness with `DeviceConfigurationOverride`.
This is because `accompanist/testharness` is deprecated.

ref: https://google.github.io/accompanist/testharness/
> **This library is deprecated, with a superseding version in androidx.compose.ui.test.


Fixes #1201

