### PR TITLE
Apply Composable Parameter Ordering Guidelines

### DIFF
--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/Navigation.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/Navigation.kt
@@ -53,12 +53,12 @@ import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 fun RowScope.NiaNavigationBarItem(
     selected: Boolean,
     onClick: () -> Unit,
-    icon: @Composable () -> Unit,
     modifier: Modifier = Modifier,
-    selectedIcon: @Composable () -> Unit = icon,
     enabled: Boolean = true,
-    label: @Composable (() -> Unit)? = null,
     alwaysShowLabel: Boolean = true,
+    icon: @Composable () -> Unit,
+    selectedIcon: @Composable () -> Unit = icon,
+    label: @Composable (() -> Unit)? = null,
 ) {
     NavigationBarItem(
         selected = selected,
@@ -117,12 +117,12 @@ fun NiaNavigationBar(
 fun NiaNavigationRailItem(
     selected: Boolean,
     onClick: () -> Unit,
-    icon: @Composable () -> Unit,
     modifier: Modifier = Modifier,
-    selectedIcon: @Composable () -> Unit = icon,
     enabled: Boolean = true,
-    label: @Composable (() -> Unit)? = null,
     alwaysShowLabel: Boolean = true,
+    icon: @Composable () -> Unit,
+    selectedIcon: @Composable () -> Unit = icon,
+    label: @Composable (() -> Unit)? = null,
 ) {
     NavigationRailItem(
         selected = selected,

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
@@ -75,10 +75,10 @@ private const val SCROLLBAR_INACTIVE_TO_DORMANT_TIME_IN_MS = 2_000L
  */
 @Composable
 fun ScrollableState.DraggableScrollbar(
-    modifier: Modifier = Modifier,
     state: ScrollbarState,
     orientation: Orientation,
     onThumbMoved: (Float) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     Scrollbar(
@@ -105,9 +105,9 @@ fun ScrollableState.DraggableScrollbar(
  */
 @Composable
 fun ScrollableState.DecorativeScrollbar(
-    modifier: Modifier = Modifier,
     state: ScrollbarState,
     orientation: Orientation,
+    modifier: Modifier = Modifier,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     Scrollbar(

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/Scrollbar.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/Scrollbar.kt
@@ -195,13 +195,13 @@ internal fun Orientation.valueOf(intOffset: IntOffset) = when (this) {
  */
 @Composable
 fun Scrollbar(
-    modifier: Modifier = Modifier,
     orientation: Orientation,
     state: ScrollbarState,
-    minThumbSize: Dp = 40.dp,
+    modifier: Modifier = Modifier,
     interactionSource: MutableInteractionSource? = null,
-    thumb: @Composable () -> Unit,
+    minThumbSize: Dp = 40.dp,
     onThumbMoved: ((Float) -> Unit)? = null,
+    thumb: @Composable () -> Unit,
 ) {
     // Using Offset.Unspecified and Float.NaN instead of null
     // to prevent unnecessary boxing of primitives


### PR DESCRIPTION
Change-Id: Id456e91b5ce8bd5807c40df67c3deac008c61670

Thanks for submitting a pull request. Please include the following information.

**What I have done and why**

The guideline for the order of parameters in Composable components was as follows: [link](https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/docs/compose-component-api-guidelines.md#parameters-order)
I followed this guideline to correct the order of parameters in Composables that were mixed up.

**Do tests pass?**
- [x] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [x] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`

**Is this your first pull request?**
- [x] [Sign the CLA](https://cla.developers.google.com/)
- [x] Run `./tools/setup.sh`
- [x] Import the code formatting style as explained in [the setup script](/tools/setup.sh#L40).


