### PR TITLE
Fix typo in TopicViewModel.kt

### DIFF
--- a/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
@@ -76,7 +76,7 @@ internal fun TopicRoute(
     viewModel: TopicViewModel = hiltViewModel(),
 ) {
     val topicUiState: TopicUiState by viewModel.topicUiState.collectAsStateWithLifecycle()
-    val newsUiState: NewsUiState by viewModel.newUiState.collectAsStateWithLifecycle()
+    val newsUiState: NewsUiState by viewModel.newsUiState.collectAsStateWithLifecycle()
 
     TrackScreenViewEvent(screenName = "Topic: ${viewModel.topicId}")
     TopicScreen(

--- a/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt
@@ -62,7 +62,7 @@ class TopicViewModel @Inject constructor(
             initialValue = TopicUiState.Loading,
         )
 
-    val newUiState: StateFlow<NewsUiState> = newsUiState(
+    val newsUiState: StateFlow<NewsUiState> = newsUiState(
         topicId = topicArgs.topicId,
         userDataRepository = userDataRepository,
         userNewsResourceRepository = userNewsResourceRepository,

--- a/feature/topic/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModelTest.kt
@@ -91,7 +91,7 @@ class TopicViewModelTest {
 
     @Test
     fun uiStateNews_whenInitialized_thenShowLoading() = runTest {
-        assertEquals(NewsUiState.Loading, viewModel.newUiState.value)
+        assertEquals(NewsUiState.Loading, viewModel.newsUiState.value)
     }
 
     @Test
@@ -117,7 +117,7 @@ class TopicViewModelTest {
             topicsRepository.sendTopics(testInputTopics.map { it.topic })
             userDataRepository.setFollowedTopicIds(setOf(testInputTopics[1].topic.id))
             val topicUiState = viewModel.topicUiState.value
-            val newsUiState = viewModel.newUiState.value
+            val newsUiState = viewModel.newsUiState.value
 
             assertIs<TopicUiState.Success>(topicUiState)
             assertIs<NewsUiState.Loading>(newsUiState)
@@ -131,7 +131,7 @@ class TopicViewModelTest {
             val collectJob = launch(UnconfinedTestDispatcher()) {
                 combine(
                     viewModel.topicUiState,
-                    viewModel.newUiState,
+                    viewModel.newsUiState,
                     ::Pair,
                 ).collect()
             }
@@ -139,7 +139,7 @@ class TopicViewModelTest {
             userDataRepository.setFollowedTopicIds(setOf(testInputTopics[1].topic.id))
             newsRepository.sendNewsResources(sampleNewsResources)
             val topicUiState = viewModel.topicUiState.value
-            val newsUiState = viewModel.newUiState.value
+            val newsUiState = viewModel.newsUiState.value
 
             assertIs<TopicUiState.Success>(topicUiState)
             assertIs<NewsUiState.Success>(newsUiState)


### PR DESCRIPTION
Fixes typo in TopicScreen, TopicViewModel and TopicViewModelTest.

Wrong: newUiState
Correct: newsUiState