### PR TITLE
Replace enableAndroidTest with androidTest.enable

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidInstrumentedTests.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidInstrumentedTests.kt
@@ -30,6 +30,6 @@ import org.gradle.api.Project
 internal fun LibraryAndroidComponentsExtension.disableUnnecessaryAndroidTests(
     project: Project,
 ) = beforeVariants {
-    it.enableAndroidTest = it.enableAndroidTest
+    it.androidTest.enable = it.androidTest.enable
         && project.projectDir.resolve("src/androidTest").exists()
 }


### PR DESCRIPTION
**What I have done and why**
Replace `enableAndroidTest` with `androidTest.enable`.
This is because `enableAndroidTest` is deprecated.

Fixes #1272 



