### PR TITLE
Rename Fake to Demo

### DIFF
--- a/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/repository/FakeNewsRepository.kt
+++ b/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/repository/FakeNewsRepository.kt
@@ -25,7 +25,7 @@ import com.google.samples.apps.nowinandroid.core.database.model.asExternalModel
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
 import com.google.samples.apps.nowinandroid.core.network.Dispatcher
 import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.IO
-import com.google.samples.apps.nowinandroid.core.network.fake.FakeNiaNetworkDataSource
+import com.google.samples.apps.nowinandroid.core.network.demo.DemoNiaNetworkDataSource
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkNewsResource
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -41,7 +41,7 @@ import javax.inject.Inject
  */
 internal class FakeNewsRepository @Inject constructor(
     @Dispatcher(IO) private val ioDispatcher: CoroutineDispatcher,
-    private val datasource: FakeNiaNetworkDataSource,
+    private val datasource: DemoNiaNetworkDataSource,
 ) : NewsRepository {
 
     override fun getNewsResources(

--- a/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/repository/FakeTopicsRepository.kt
+++ b/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/repository/FakeTopicsRepository.kt
@@ -21,7 +21,7 @@ import com.google.samples.apps.nowinandroid.core.data.repository.TopicsRepositor
 import com.google.samples.apps.nowinandroid.core.model.data.Topic
 import com.google.samples.apps.nowinandroid.core.network.Dispatcher
 import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.IO
-import com.google.samples.apps.nowinandroid.core.network.fake.FakeNiaNetworkDataSource
+import com.google.samples.apps.nowinandroid.core.network.demo.DemoNiaNetworkDataSource
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -38,7 +38,7 @@ import javax.inject.Inject
  */
 internal class FakeTopicsRepository @Inject constructor(
     @Dispatcher(IO) private val ioDispatcher: CoroutineDispatcher,
-    private val datasource: FakeNiaNetworkDataSource,
+    private val datasource: DemoNiaNetworkDataSource,
 ) : TopicsRepository {
     override fun getTopics(): Flow<List<Topic>> = flow {
         emit(

--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNiaNetworkDataSource.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNiaNetworkDataSource.kt
@@ -17,7 +17,7 @@
 package com.google.samples.apps.nowinandroid.core.data.testdoubles
 
 import com.google.samples.apps.nowinandroid.core.network.NiaNetworkDataSource
-import com.google.samples.apps.nowinandroid.core.network.fake.FakeNiaNetworkDataSource
+import com.google.samples.apps.nowinandroid.core.network.demo.DemoNiaNetworkDataSource
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkChangeList
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkNewsResource
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkTopic
@@ -35,7 +35,7 @@ enum class CollectionType {
  */
 class TestNiaNetworkDataSource : NiaNetworkDataSource {
 
-    private val source = FakeNiaNetworkDataSource(
+    private val source = DemoNiaNetworkDataSource(
         UnconfinedTestDispatcher(),
         Json { ignoreUnknownKeys = true },
     )

--- a/core/network/src/demo/kotlin/com/google/samples/apps/nowinandroid/core/network/di/FlavoredNetworkModule.kt
+++ b/core/network/src/demo/kotlin/com/google/samples/apps/nowinandroid/core/network/di/FlavoredNetworkModule.kt
@@ -17,7 +17,7 @@
 package com.google.samples.apps.nowinandroid.core.network.di
 
 import com.google.samples.apps.nowinandroid.core.network.NiaNetworkDataSource
-import com.google.samples.apps.nowinandroid.core.network.fake.FakeNiaNetworkDataSource
+import com.google.samples.apps.nowinandroid.core.network.demo.DemoNiaNetworkDataSource
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -28,5 +28,5 @@ import dagger.hilt.components.SingletonComponent
 internal interface FlavoredNetworkModule {
 
     @Binds
-    fun binds(impl: FakeNiaNetworkDataSource): NiaNetworkDataSource
+    fun binds(impl: DemoNiaNetworkDataSource): NiaNetworkDataSource
 }

--- a/core/network/src/main/kotlin/JvmUnitTestDemoAssetManager.kt
+++ b/core/network/src/main/kotlin/JvmUnitTestDemoAssetManager.kt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import androidx.annotation.VisibleForTesting
 import com.google.samples.apps.nowinandroid.core.network.demo.DemoAssetManager
 import java.io.File
 import java.io.InputStream
@@ -25,7 +24,7 @@ import java.util.Properties
  * It must remain on the root package for an easier [Class.getResource] with relative paths.
  * @see <a href="https://developer.android.com/reference/tools/gradle-api/7.3/com/android/build/api/dsl/UnitTestOptions">UnitTestOptions</a>
  */
-@VisibleForTesting
+
 internal object JvmUnitTestDemoAssetManager : DemoAssetManager {
     private val config =
         requireNotNull(javaClass.getResource("com/android/tools/test_config.properties")) {

--- a/core/network/src/main/kotlin/JvmUnitTestDemoAssetManager.kt
+++ b/core/network/src/main/kotlin/JvmUnitTestDemoAssetManager.kt
@@ -15,7 +15,7 @@
  */
 
 import androidx.annotation.VisibleForTesting
-import com.google.samples.apps.nowinandroid.core.network.fake.FakeAssetManager
+import com.google.samples.apps.nowinandroid.core.network.demo.DemoAssetManager
 import java.io.File
 import java.io.InputStream
 import java.util.Properties
@@ -26,7 +26,7 @@ import java.util.Properties
  * @see <a href="https://developer.android.com/reference/tools/gradle-api/7.3/com/android/build/api/dsl/UnitTestOptions">UnitTestOptions</a>
  */
 @VisibleForTesting
-internal object JvmUnitTestFakeAssetManager : FakeAssetManager {
+internal object JvmUnitTestDemoAssetManager : DemoAssetManager {
     private val config =
         requireNotNull(javaClass.getResource("com/android/tools/test_config.properties")) {
             """

--- a/core/network/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/demo/DemoAssetManager.kt
+++ b/core/network/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/demo/DemoAssetManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.samples.apps.nowinandroid.core.network.fake
+package com.google.samples.apps.nowinandroid.core.network.demo
 
 import java.io.InputStream
 
-fun interface FakeAssetManager {
+fun interface DemoAssetManager {
     fun open(fileName: String): InputStream
 }

--- a/core/network/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/demo/DemoNiaNetworkDataSource.kt
+++ b/core/network/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/demo/DemoNiaNetworkDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.google.samples.apps.nowinandroid.core.network.fake
+package com.google.samples.apps.nowinandroid.core.network.demo
 
-import JvmUnitTestFakeAssetManager
+import JvmUnitTestDemoAssetManager
 import com.google.samples.apps.nowinandroid.core.network.Dispatcher
 import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.IO
 import com.google.samples.apps.nowinandroid.core.network.NiaNetworkDataSource
@@ -33,10 +33,10 @@ import javax.inject.Inject
 /**
  * [NiaNetworkDataSource] implementation that provides static news resources to aid development
  */
-class FakeNiaNetworkDataSource @Inject constructor(
+class DemoNiaNetworkDataSource @Inject constructor(
     @Dispatcher(IO) private val ioDispatcher: CoroutineDispatcher,
     private val networkJson: Json,
-    private val assets: FakeAssetManager = JvmUnitTestFakeAssetManager,
+    private val assets: DemoAssetManager = JvmUnitTestDemoAssetManager,
 ) : NiaNetworkDataSource {
 
     @OptIn(ExperimentalSerializationApi::class)

--- a/core/network/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/di/NetworkModule.kt
@@ -22,7 +22,7 @@ import coil.ImageLoader
 import coil.decode.SvgDecoder
 import coil.util.DebugLogger
 import com.google.samples.apps.nowinandroid.core.network.BuildConfig
-import com.google.samples.apps.nowinandroid.core.network.fake.FakeAssetManager
+import com.google.samples.apps.nowinandroid.core.network.demo.DemoAssetManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -48,7 +48,7 @@ internal object NetworkModule {
     @Singleton
     fun providesFakeAssetManager(
         @ApplicationContext context: Context,
-    ): FakeAssetManager = FakeAssetManager(context.assets::open)
+    ): DemoAssetManager = DemoAssetManager(context.assets::open)
 
     @Provides
     @Singleton

--- a/core/network/src/test/kotlin/com/google/samples/apps/nowinandroid/core/network/demo/DemoNiaNetworkDataSourceTest.kt
+++ b/core/network/src/test/kotlin/com/google/samples/apps/nowinandroid/core/network/demo/DemoNiaNetworkDataSourceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.google.samples.apps.nowinandroid.core.network.fake
+package com.google.samples.apps.nowinandroid.core.network.demo
 
-import JvmUnitTestFakeAssetManager
+import JvmUnitTestDemoAssetManager
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkNewsResource
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkTopic
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -29,18 +29,18 @@ import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 
-class FakeNiaNetworkDataSourceTest {
+class DemoNiaNetworkDataSourceTest {
 
-    private lateinit var subject: FakeNiaNetworkDataSource
+    private lateinit var subject: DemoNiaNetworkDataSource
 
     private val testDispatcher = StandardTestDispatcher()
 
     @Before
     fun setUp() {
-        subject = FakeNiaNetworkDataSource(
+        subject = DemoNiaNetworkDataSource(
             ioDispatcher = testDispatcher,
             networkJson = Json { ignoreUnknownKeys = true },
-            assets = JvmUnitTestFakeAssetManager,
+            assets = JvmUnitTestDemoAssetManager,
         )
     }
 


### PR DESCRIPTION
**What I have done and why**
Rename Fake to Demo.
it is make analysis hard, the problem is naming.
Actually it is not fake because it is for demo to build on not product code.
The only ```NiaNetworkDataSource``` reference is ```FakeNiaNetworkDataSource``` in non-production build.
So, I think it is better to rename Fake to Demo.