### PR TITLE
clean up di module in core.database package

### DIFF
--- a/core/database/src/main/kotlin/com/google/samples/apps/nowinandroid/core/database/di/DaosModule.kt
+++ b/core/database/src/main/kotlin/com/google/samples/apps/nowinandroid/core/database/di/DaosModule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.google.samples.apps.nowinandroid.core.database
+package com.google.samples.apps.nowinandroid.core.database.di
 
+import com.google.samples.apps.nowinandroid.core.database.NiaDatabase
 import com.google.samples.apps.nowinandroid.core.database.dao.NewsResourceDao
 import com.google.samples.apps.nowinandroid.core.database.dao.NewsResourceFtsDao
 import com.google.samples.apps.nowinandroid.core.database.dao.RecentSearchQueryDao

--- a/core/database/src/main/kotlin/com/google/samples/apps/nowinandroid/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/com/google/samples/apps/nowinandroid/core/database/di/DatabaseModule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package com.google.samples.apps.nowinandroid.core.database
+package com.google.samples.apps.nowinandroid.core.database.di
 
 import android.content.Context
 import androidx.room.Room
+import com.google.samples.apps.nowinandroid.core.database.NiaDatabase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn


### PR DESCRIPTION
**[what i have done]** 
moving di container module('DaosModule' and 'DatabaseModule') into di package which is newly created

**[why i have done]**
all di container modules are within di package. for example, 'core.data', 'core.datastore', 'core.network' etc... all have di package in which have dagger hilt module. so to manage package consistently, i pull request to main branch.

**Do tests pass?**
- [ ] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [ ] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`

**Is this your first pull request?**
- [x] [Sign the CLA](https://cla.developers.google.com/)
- [x] Run `./tools/setup.sh`
- [x] Import the code formatting style as explained in [the setup script](/tools/setup.sh#L40).


