### PR TITLE
Improve the Performance of Gradle Builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,3 +59,12 @@ tasks.register("printModulePaths") {
         }
     }
 }
+
+/**
+ * Optimize the compiler
+ * Run the compiler as a separate process
+ * [documentation](https://docs.gradle.org/current/userguide/performance.html#optimize_the_compiler)
+ */
+tasks.withType<JavaCompile>().configureEach {
+    options.isFork = true
+}


### PR DESCRIPTION
**What I have done and why**
Optimize the compiler.
Run the compiler as a separate process.
[documentation](https://docs.gradle.org/current/userguide/performance.html#optimize_the_compiler)

Total Build Time improved 2%

• Before
<img width="500" alt="before" src="https://github.com/android/nowinandroid/assets/48680511/5a6e7e53-250d-41ab-b468-57b0f98c8d33">

• After
<img width="500" alt="after" src="https://github.com/android/nowinandroid/assets/48680511/f782006b-9794-4e39-b31e-47467b258072">
