### PR TITLE
added ksp arg to generate room code in kotlin

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
@@ -15,6 +15,7 @@
  */
 
 import androidx.room.gradle.RoomExtension
+import com.google.devtools.ksp.gradle.KspExtension
 import com.google.samples.apps.nowinandroid.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -27,6 +28,10 @@ class AndroidRoomConventionPlugin : Plugin<Project> {
         with(target) {
             pluginManager.apply("androidx.room")
             pluginManager.apply("com.google.devtools.ksp")
+
+            extensions.configure<KspExtension> {
+                arg("room.generateKotlin", "true")
+            }
 
             extensions.configure<RoomExtension> {
                 // The schemas directory contains a schema file for each version of the Room database.


### PR DESCRIPTION
added KSP argument in Room convention plugin to enable KSP to generate room code in kotlin

Thanks for submitting a pull request. Please include the following information.

**What I have done and why**
Include a summary of what your pull request contains, and why you have made these changes.

Fixes #<issue_number_goes_here>

**Do tests pass?**
- [Y] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [Y] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`

**Is this your first pull request?**
- [Y] [Sign the CLA](https://cla.developers.google.com/)
- [Y] Run `./tools/setup.sh`
- [Y] Import the code formatting style as explained in [the setup script](/tools/setup.sh#L40).


