### PR TITLE
Remove editorConfigOverride and set ```ktlint_code_style``` ```android_studio``` in editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,9 @@
 # https://editorconfig.org/
 # This configuration is used by ktlint when spotless invokes it
+root = true
 
 [*.{kt,kts}]
 ij_kotlin_allow_trailing_comma=true
 ij_kotlin_allow_trailing_comma_on_call_site=true
+ktlint_code_style = android_studio
 ktlint_function_naming_ignore_when_annotated_with=Composable, Test

--- a/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
+++ b/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
@@ -38,21 +38,21 @@ import com.google.samples.apps.nowinandroid.R
 import com.google.samples.apps.nowinandroid.core.data.repository.TopicsRepository
 import com.google.samples.apps.nowinandroid.core.model.data.Topic
 import com.google.samples.apps.nowinandroid.core.rules.GrantPostNotificationsPermissionRule
+import com.google.samples.apps.nowinandroid.feature.bookmarks.R as BookmarksR
+import com.google.samples.apps.nowinandroid.feature.foryou.R as FeatureForyouR
+import com.google.samples.apps.nowinandroid.feature.search.R as FeatureSearchR
+import com.google.samples.apps.nowinandroid.feature.settings.R as SettingsR
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import javax.inject.Inject
+import kotlin.properties.ReadOnlyProperty
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import javax.inject.Inject
-import kotlin.properties.ReadOnlyProperty
-import com.google.samples.apps.nowinandroid.feature.bookmarks.R as BookmarksR
-import com.google.samples.apps.nowinandroid.feature.foryou.R as FeatureForyouR
-import com.google.samples.apps.nowinandroid.feature.search.R as FeatureSearchR
-import com.google.samples.apps.nowinandroid.feature.settings.R as SettingsR
 
 /**
  * Tests all the navigation flows that are handled by the navigation library.
@@ -93,15 +93,25 @@ class NavigationTest {
         ReadOnlyProperty<Any, String> { _, _ -> activity.getString(resId) }
 
     // The strings used for matching in these tests
-    private val navigateUp by composeTestRule.stringResource(FeatureForyouR.string.feature_foryou_navigate_up)
+    private val navigateUp by composeTestRule.stringResource(
+        FeatureForyouR.string.feature_foryou_navigate_up,
+    )
     private val forYou by composeTestRule.stringResource(FeatureForyouR.string.feature_foryou_title)
-    private val interests by composeTestRule.stringResource(FeatureSearchR.string.feature_search_interests)
+    private val interests by composeTestRule.stringResource(
+        FeatureSearchR.string.feature_search_interests,
+    )
     private val sampleTopic = "Headlines"
     private val appName by composeTestRule.stringResource(R.string.app_name)
     private val saved by composeTestRule.stringResource(BookmarksR.string.feature_bookmarks_title)
-    private val settings by composeTestRule.stringResource(SettingsR.string.feature_settings_top_app_bar_action_icon_description)
-    private val brand by composeTestRule.stringResource(SettingsR.string.feature_settings_brand_android)
-    private val ok by composeTestRule.stringResource(SettingsR.string.feature_settings_dismiss_dialog_button_text)
+    private val settings by composeTestRule.stringResource(
+        SettingsR.string.feature_settings_top_app_bar_action_icon_description,
+    )
+    private val brand by composeTestRule.stringResource(
+        SettingsR.string.feature_settings_brand_android,
+    )
+    private val ok by composeTestRule.stringResource(
+        SettingsR.string.feature_settings_dismiss_dialog_button_text,
+    )
 
     @Before
     fun setup() = hiltRule.inject()

--- a/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationUiTest.kt
+++ b/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationUiTest.kt
@@ -37,11 +37,11 @@ import com.google.samples.apps.nowinandroid.uitesthiltmanifest.HiltComponentActi
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import javax.inject.Inject
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import javax.inject.Inject
 
 /**
  * Tests that the navigation UI is rendered correctly on different screen sizes.

--- a/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppStateTest.kt
+++ b/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppStateTest.kt
@@ -35,6 +35,9 @@ import com.google.samples.apps.nowinandroid.core.testing.repository.TestNewsRepo
 import com.google.samples.apps.nowinandroid.core.testing.repository.TestUserDataRepository
 import com.google.samples.apps.nowinandroid.core.testing.util.TestNetworkMonitor
 import com.google.samples.apps.nowinandroid.core.testing.util.TestTimeZoneMonitor
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -42,9 +45,6 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.TimeZone
 import org.junit.Rule
 import org.junit.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 /**
  * Tests [NiaAppState].
@@ -167,7 +167,9 @@ class NiaAppStateTest {
     }
 
     @Test
-    fun niaAppState_whenNetworkMonitorIsOffline_StateIsOffline() = runTest(UnconfinedTestDispatcher()) {
+    fun niaAppState_whenNetworkMonitorIsOffline_StateIsOffline() = runTest(
+        UnconfinedTestDispatcher(),
+    ) {
         composeTestRule.setContent {
             state = NiaAppState(
                 navController = NavHostController(LocalContext.current),

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/MainActivity.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/MainActivity.kt
@@ -51,10 +51,10 @@ import com.google.samples.apps.nowinandroid.core.ui.LocalTimeZone
 import com.google.samples.apps.nowinandroid.ui.NiaApp
 import com.google.samples.apps.nowinandroid.ui.rememberNiaAppState
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 private const val TAG = "MainActivity"
 
@@ -172,9 +172,7 @@ class MainActivity : ComponentActivity() {
  * Returns `true` if the Android theme should be used, as a function of the [uiState].
  */
 @Composable
-private fun shouldUseAndroidTheme(
-    uiState: MainActivityUiState,
-): Boolean = when (uiState) {
+private fun shouldUseAndroidTheme(uiState: MainActivityUiState): Boolean = when (uiState) {
     Loading -> false
     is Success -> when (uiState.userData.themeBrand) {
         ThemeBrand.DEFAULT -> false
@@ -186,9 +184,7 @@ private fun shouldUseAndroidTheme(
  * Returns `true` if the dynamic color is disabled, as a function of the [uiState].
  */
 @Composable
-private fun shouldDisableDynamicTheming(
-    uiState: MainActivityUiState,
-): Boolean = when (uiState) {
+private fun shouldDisableDynamicTheming(uiState: MainActivityUiState): Boolean = when (uiState) {
     Loading -> false
     is Success -> !uiState.userData.useDynamicColor
 }
@@ -198,9 +194,7 @@ private fun shouldDisableDynamicTheming(
  * current system context.
  */
 @Composable
-private fun shouldUseDarkTheme(
-    uiState: MainActivityUiState,
-): Boolean = when (uiState) {
+private fun shouldUseDarkTheme(uiState: MainActivityUiState): Boolean = when (uiState) {
     Loading -> isSystemInDarkTheme()
     is Success -> when (uiState.userData.darkThemeConfig) {
         DarkThemeConfig.FOLLOW_SYSTEM -> isSystemInDarkTheme()

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/MainActivityViewModel.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/MainActivityViewModel.kt
@@ -23,11 +23,11 @@ import com.google.samples.apps.nowinandroid.MainActivityUiState.Success
 import com.google.samples.apps.nowinandroid.core.data.repository.UserDataRepository
 import com.google.samples.apps.nowinandroid.core.model.data.UserData
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import javax.inject.Inject
 
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/di/JankStatsModule.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/di/JankStatsModule.kt
@@ -42,8 +42,6 @@ object JankStatsModule {
     fun providesWindow(activity: Activity): Window = activity.window
 
     @Provides
-    fun providesJankStats(
-        window: Window,
-        frameListener: OnFrameListener,
-    ): JankStats = JankStats.createAndTrack(window, frameListener)
+    fun providesJankStats(window: Window, frameListener: OnFrameListener): JankStats =
+        JankStats.createAndTrack(window, frameListener)
 }

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -165,6 +165,7 @@ fun NiaApp(appState: NiaAppState) {
                         // Show the top app bar on top level destinations.
                         val destination = appState.currentTopLevelDestination
                         if (destination != null) {
+                            @Suppress("ktlint:standard:max-line-length")
                             NiaTopAppBar(
                                 titleRes = destination.titleTextId,
                                 navigationIcon = NiaIcons.Search,

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -114,7 +114,9 @@ fun NiaApp(appState: NiaAppState) {
                 )
             }
 
-            val unreadDestinations by appState.topLevelDestinationsWithUnreadResources.collectAsStateWithLifecycle()
+            val unreadDestinations by appState
+                .topLevelDestinationsWithUnreadResources
+                .collectAsStateWithLifecycle()
 
             Scaffold(
                 modifier = Modifier.semantics {
@@ -271,24 +273,23 @@ private fun NiaBottomBar(
     }
 }
 
-private fun Modifier.notificationDot(): Modifier =
-    composed {
-        val tertiaryColor = MaterialTheme.colorScheme.tertiary
-        drawWithContent {
-            drawContent()
-            drawCircle(
-                tertiaryColor,
-                radius = 5.dp.toPx(),
-                // This is based on the dimensions of the NavigationBar's "indicator pill";
-                // however, its parameters are private, so we must depend on them implicitly
-                // (NavigationBarTokens.ActiveIndicatorWidth = 64.dp)
-                center = center + Offset(
-                    64.dp.toPx() * .45f,
-                    32.dp.toPx() * -.45f - 6.dp.toPx(),
-                ),
-            )
-        }
+private fun Modifier.notificationDot(): Modifier = composed {
+    val tertiaryColor = MaterialTheme.colorScheme.tertiary
+    drawWithContent {
+        drawContent()
+        drawCircle(
+            tertiaryColor,
+            radius = 5.dp.toPx(),
+            // This is based on the dimensions of the NavigationBar's "indicator pill";
+            // however, its parameters are private, so we must depend on them implicitly
+            // (NavigationBarTokens.ActiveIndicatorWidth = 64.dp)
+            center = center + Offset(
+                64.dp.toPx() * .45f,
+                32.dp.toPx() * -.45f - 6.dp.toPx(),
+            ),
+        )
     }
+}
 
 private fun NavDestination?.isTopLevelDestinationInHierarchy(destination: TopLevelDestination) =
     this?.hierarchy?.any {

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
@@ -128,7 +128,9 @@ class NiaAppState(
      */
     val topLevelDestinationsWithUnreadResources: StateFlow<Set<TopLevelDestination>> =
         userNewsResourceRepository.observeAllForFollowedTopics()
-            .combine(userNewsResourceRepository.observeAllBookmarked()) { forYouNewsResources, bookmarkedNewsResources ->
+            .combine(
+                userNewsResourceRepository.observeAllBookmarked(),
+            ) { forYouNewsResources, bookmarkedNewsResources ->
                 setOfNotNull(
                     FOR_YOU.takeIf { forYouNewsResources.any { !it.hasBeenViewed } },
                     BOOKMARKS.takeIf { bookmarkedNewsResources.any { !it.hasBeenViewed } },

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/interests2pane/Interests2PaneViewModel.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/interests2pane/Interests2PaneViewModel.kt
@@ -20,8 +20,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import com.google.samples.apps.nowinandroid.feature.interests.navigation.TOPIC_ID_ARG
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
+import kotlinx.coroutines.flow.StateFlow
 
 @HiltViewModel
 class Interests2PaneViewModel @Inject constructor(

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/interests2pane/InterestsListDetailScreen.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/interests2pane/InterestsListDetailScreen.kt
@@ -60,9 +60,7 @@ fun NavGraphBuilder.interestsListDetailScreen() {
 }
 
 @Composable
-internal fun InterestsListDetailScreen(
-    viewModel: Interests2PaneViewModel = hiltViewModel(),
-) {
+internal fun InterestsListDetailScreen(viewModel: Interests2PaneViewModel = hiltViewModel()) {
     val selectedTopicId by viewModel.selectedTopicId.collectAsStateWithLifecycle()
     InterestsListDetailScreen(
         selectedTopicId = selectedTopicId,
@@ -72,10 +70,7 @@ internal fun InterestsListDetailScreen(
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
-internal fun InterestsListDetailScreen(
-    selectedTopicId: String?,
-    onTopicClick: (String) -> Unit,
-) {
+internal fun InterestsListDetailScreen(selectedTopicId: String?, onTopicClick: (String) -> Unit) {
     val listDetailNavigator = rememberListDetailPaneScaffoldNavigator<Nothing>()
     BackHandler(listDetailNavigator.canNavigateBack()) {
         listDetailNavigator.navigateBack()

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/util/ProfileVerifierLogger.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/util/ProfileVerifierLogger.kt
@@ -19,10 +19,10 @@ package com.google.samples.apps.nowinandroid.util
 import android.util.Log
 import androidx.profileinstaller.ProfileVerifier
 import com.google.samples.apps.nowinandroid.core.network.di.ApplicationScope
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 /**
  * Logs the app's Baseline Profile Compilation Status using [ProfileVerifier].

--- a/app/src/testDemo/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppScreenSizesScreenshotTests.kt
+++ b/app/src/testDemo/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppScreenSizesScreenshotTests.kt
@@ -45,6 +45,8 @@ import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
+import java.util.TimeZone
+import javax.inject.Inject
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -56,8 +58,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 import org.robolectric.annotation.LooperMode
-import java.util.TimeZone
-import javax.inject.Inject
 
 /**
  * Tests that the navigation UI is rendered correctly on different screen sizes.

--- a/benchmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/baselineprofile/BookmarksBaselineProfile.kt
+++ b/benchmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/baselineprofile/BookmarksBaselineProfile.kt
@@ -30,11 +30,10 @@ class BookmarksBaselineProfile {
     @get:Rule val baselineProfileRule = BaselineProfileRule()
 
     @Test
-    fun generate() =
-        baselineProfileRule.collect(PACKAGE_NAME) {
-            startActivityAndAllowNotifications()
+    fun generate() = baselineProfileRule.collect(PACKAGE_NAME) {
+        startActivityAndAllowNotifications()
 
-            // Navigate to saved screen
-            goToBookmarksScreen()
-        }
+        // Navigate to saved screen
+        goToBookmarksScreen()
+    }
 }

--- a/benchmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/baselineprofile/ForYouBaselineProfile.kt
+++ b/benchmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/baselineprofile/ForYouBaselineProfile.kt
@@ -32,13 +32,12 @@ class ForYouBaselineProfile {
     @get:Rule val baselineProfileRule = BaselineProfileRule()
 
     @Test
-    fun generate() =
-        baselineProfileRule.collect(PACKAGE_NAME) {
-            startActivityAndAllowNotifications()
+    fun generate() = baselineProfileRule.collect(PACKAGE_NAME) {
+        startActivityAndAllowNotifications()
 
-            // Scroll the feed critical user journey
-            forYouWaitForContent()
-            forYouSelectTopics(true)
-            forYouScrollFeedDownUp()
-        }
+        // Scroll the feed critical user journey
+        forYouWaitForContent()
+        forYouSelectTopics(true)
+        forYouScrollFeedDownUp()
+    }
 }

--- a/benchmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/baselineprofile/InterestsBaselineProfile.kt
+++ b/benchmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/baselineprofile/InterestsBaselineProfile.kt
@@ -31,12 +31,11 @@ class InterestsBaselineProfile {
     @get:Rule val baselineProfileRule = BaselineProfileRule()
 
     @Test
-    fun generate() =
-        baselineProfileRule.collect(PACKAGE_NAME) {
-            startActivityAndAllowNotifications()
+    fun generate() = baselineProfileRule.collect(PACKAGE_NAME) {
+        startActivityAndAllowNotifications()
 
-            // Navigate to interests screen
-            goToInterestsScreen()
-            interestsScrollTopicsDownUp()
-        }
+        // Navigate to interests screen
+        goToInterestsScreen()
+        interestsScrollTopicsDownUp()
+    }
 }

--- a/core/common/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/di/CoroutineScopesModule.kt
+++ b/core/common/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/di/CoroutineScopesModule.kt
@@ -22,11 +22,11 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
-import javax.inject.Qualifier
-import javax.inject.Singleton
 
 @Retention(AnnotationRetention.RUNTIME)
 @Qualifier

--- a/core/common/src/test/kotlin/com/google/samples/apps/nowinandroid/core/result/ResultKtTest.kt
+++ b/core/common/src/test/kotlin/com/google/samples/apps/nowinandroid/core/result/ResultKtTest.kt
@@ -17,10 +17,10 @@
 package com.google.samples.apps.nowinandroid.core.result
 
 import app.cash.turbine.test
+import kotlin.test.assertEquals
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
-import kotlin.test.assertEquals
 
 class ResultKtTest {
 

--- a/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/AlwaysOnlineNetworkMonitor.kt
+++ b/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/AlwaysOnlineNetworkMonitor.kt
@@ -17,9 +17,9 @@
 package com.google.samples.apps.nowinandroid.core.data.test
 
 import com.google.samples.apps.nowinandroid.core.data.util.NetworkMonitor
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import javax.inject.Inject
 
 class AlwaysOnlineNetworkMonitor @Inject constructor() : NetworkMonitor {
     override val isOnline: Flow<Boolean> = flowOf(true)

--- a/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/DefaultZoneIdTimeZoneMonitor.kt
+++ b/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/DefaultZoneIdTimeZoneMonitor.kt
@@ -17,10 +17,10 @@
 package com.google.samples.apps.nowinandroid.core.data.test
 
 import com.google.samples.apps.nowinandroid.core.data.util.TimeZoneMonitor
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.datetime.TimeZone
-import javax.inject.Inject
 
 class DefaultZoneIdTimeZoneMonitor @Inject constructor() : TimeZoneMonitor {
     override val currentTimeZone: Flow<TimeZone> = flowOf(TimeZone.of("Europe/Warsaw"))

--- a/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/TestDataModule.kt
+++ b/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/TestDataModule.kt
@@ -41,19 +41,13 @@ import dagger.hilt.testing.TestInstallIn
 )
 internal interface TestDataModule {
     @Binds
-    fun bindsTopicRepository(
-        fakeTopicsRepository: FakeTopicsRepository,
-    ): TopicsRepository
+    fun bindsTopicRepository(fakeTopicsRepository: FakeTopicsRepository): TopicsRepository
 
     @Binds
-    fun bindsNewsResourceRepository(
-        fakeNewsRepository: FakeNewsRepository,
-    ): NewsRepository
+    fun bindsNewsResourceRepository(fakeNewsRepository: FakeNewsRepository): NewsRepository
 
     @Binds
-    fun bindsUserDataRepository(
-        userDataRepository: FakeUserDataRepository,
-    ): UserDataRepository
+    fun bindsUserDataRepository(userDataRepository: FakeUserDataRepository): UserDataRepository
 
     @Binds
     fun bindsRecentSearchRepository(
@@ -66,9 +60,7 @@ internal interface TestDataModule {
     ): SearchContentsRepository
 
     @Binds
-    fun bindsNetworkMonitor(
-        networkMonitor: AlwaysOnlineNetworkMonitor,
-    ): NetworkMonitor
+    fun bindsNetworkMonitor(networkMonitor: AlwaysOnlineNetworkMonitor): NetworkMonitor
 
     @Binds
     fun binds(impl: DefaultZoneIdTimeZoneMonitor): TimeZoneMonitor

--- a/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/repository/FakeNewsRepository.kt
+++ b/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/repository/FakeNewsRepository.kt
@@ -27,11 +27,11 @@ import com.google.samples.apps.nowinandroid.core.network.Dispatcher
 import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.IO
 import com.google.samples.apps.nowinandroid.core.network.demo.DemoNiaNetworkDataSource
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkNewsResource
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import javax.inject.Inject
 
 /**
  * Fake implementation of the [NewsRepository] that retrieves the news resources from a JSON String.
@@ -44,30 +44,27 @@ internal class FakeNewsRepository @Inject constructor(
     private val datasource: DemoNiaNetworkDataSource,
 ) : NewsRepository {
 
-    override fun getNewsResources(
-        query: NewsResourceQuery,
-    ): Flow<List<NewsResource>> =
-        flow {
-            emit(
-                datasource
-                    .getNewsResources()
-                    .filter { networkNewsResource ->
-                        // Filter out any news resources which don't match the current query.
-                        // If no query parameters (filterTopicIds or filterNewsIds) are specified
-                        // then the news resource is returned.
-                        listOfNotNull(
-                            true,
-                            query.filterNewsIds?.contains(networkNewsResource.id),
-                            query.filterTopicIds?.let { filterTopicIds ->
-                                networkNewsResource.topics.intersect(filterTopicIds).isNotEmpty()
-                            },
-                        )
-                            .all(true::equals)
-                    }
-                    .map(NetworkNewsResource::asEntity)
-                    .map(NewsResourceEntity::asExternalModel),
-            )
-        }.flowOn(ioDispatcher)
+    override fun getNewsResources(query: NewsResourceQuery): Flow<List<NewsResource>> = flow {
+        emit(
+            datasource
+                .getNewsResources()
+                .filter { networkNewsResource ->
+                    // Filter out any news resources which don't match the current query.
+                    // If no query parameters (filterTopicIds or filterNewsIds) are specified
+                    // then the news resource is returned.
+                    listOfNotNull(
+                        true,
+                        query.filterNewsIds?.contains(networkNewsResource.id),
+                        query.filterTopicIds?.let { filterTopicIds ->
+                            networkNewsResource.topics.intersect(filterTopicIds).isNotEmpty()
+                        },
+                    )
+                        .all(true::equals)
+                }
+                .map(NetworkNewsResource::asEntity)
+                .map(NewsResourceEntity::asExternalModel),
+        )
+    }.flowOn(ioDispatcher)
 
     override suspend fun syncWith(synchronizer: Synchronizer) = true
 }

--- a/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/repository/FakeRecentSearchRepository.kt
+++ b/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/repository/FakeRecentSearchRepository.kt
@@ -18,9 +18,9 @@ package com.google.samples.apps.nowinandroid.core.data.test.repository
 
 import com.google.samples.apps.nowinandroid.core.data.model.RecentSearchQuery
 import com.google.samples.apps.nowinandroid.core.data.repository.RecentSearchRepository
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import javax.inject.Inject
 
 /**
  * Fake implementation of the [RecentSearchRepository]

--- a/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/repository/FakeSearchContentsRepository.kt
+++ b/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/repository/FakeSearchContentsRepository.kt
@@ -18,9 +18,9 @@ package com.google.samples.apps.nowinandroid.core.data.test.repository
 
 import com.google.samples.apps.nowinandroid.core.data.repository.SearchContentsRepository
 import com.google.samples.apps.nowinandroid.core.model.data.SearchResult
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import javax.inject.Inject
 
 /**
  * Fake implementation of the [SearchContentsRepository]

--- a/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/repository/FakeTopicsRepository.kt
+++ b/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/repository/FakeTopicsRepository.kt
@@ -22,12 +22,12 @@ import com.google.samples.apps.nowinandroid.core.model.data.Topic
 import com.google.samples.apps.nowinandroid.core.network.Dispatcher
 import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.IO
 import com.google.samples.apps.nowinandroid.core.network.demo.DemoNiaNetworkDataSource
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 
 /**
  * Fake implementation of the [TopicsRepository] that retrieves the topics from a JSON String, and

--- a/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/repository/FakeUserDataRepository.kt
+++ b/core/data-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/test/repository/FakeUserDataRepository.kt
@@ -21,8 +21,8 @@ import com.google.samples.apps.nowinandroid.core.datastore.NiaPreferencesDataSou
 import com.google.samples.apps.nowinandroid.core.model.data.DarkThemeConfig
 import com.google.samples.apps.nowinandroid.core.model.data.ThemeBrand
 import com.google.samples.apps.nowinandroid.core.model.data.UserData
-import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Fake implementation of the [UserDataRepository] that returns hardcoded user data.

--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/model/NewsResource.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/model/NewsResource.kt
@@ -46,17 +46,16 @@ fun NetworkNewsResourceExpanded.asEntity() = NewsResourceEntity(
  * A shell [TopicEntity] to fulfill the foreign key constraint when inserting
  * a [NewsResourceEntity] into the DB
  */
-fun NetworkNewsResource.topicEntityShells() =
-    topics.map { topicId ->
-        TopicEntity(
-            id = topicId,
-            name = "",
-            url = "",
-            imageUrl = "",
-            shortDescription = "",
-            longDescription = "",
-        )
-    }
+fun NetworkNewsResource.topicEntityShells() = topics.map { topicId ->
+    TopicEntity(
+        id = topicId,
+        name = "",
+        url = "",
+        imageUrl = "",
+        shortDescription = "",
+        longDescription = "",
+    )
+}
 
 fun NetworkNewsResource.topicCrossReferences(): List<NewsResourceTopicCrossRef> =
     topics.map { topicId ->

--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/AnalyticsExtensions.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/AnalyticsExtensions.kt
@@ -20,7 +20,10 @@ import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsEvent
 import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsEvent.Param
 import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsHelper
 
-internal fun AnalyticsHelper.logNewsResourceBookmarkToggled(newsResourceId: String, isBookmarked: Boolean) {
+internal fun AnalyticsHelper.logNewsResourceBookmarkToggled(
+    newsResourceId: String,
+    isBookmarked: Boolean,
+) {
     val eventType = if (isBookmarked) "news_resource_saved" else "news_resource_unsaved"
     val paramKey = if (isBookmarked) "saved_news_resource_id" else "unsaved_news_resource_id"
     logEvent(
@@ -46,35 +49,32 @@ internal fun AnalyticsHelper.logTopicFollowToggled(followedTopicId: String, isFo
     )
 }
 
-internal fun AnalyticsHelper.logThemeChanged(themeName: String) =
-    logEvent(
-        AnalyticsEvent(
-            type = "theme_changed",
-            extras = listOf(
-                Param(key = "theme_name", value = themeName),
-            ),
+internal fun AnalyticsHelper.logThemeChanged(themeName: String) = logEvent(
+    AnalyticsEvent(
+        type = "theme_changed",
+        extras = listOf(
+            Param(key = "theme_name", value = themeName),
         ),
-    )
+    ),
+)
 
-internal fun AnalyticsHelper.logDarkThemeConfigChanged(darkThemeConfigName: String) =
-    logEvent(
-        AnalyticsEvent(
-            type = "dark_theme_config_changed",
-            extras = listOf(
-                Param(key = "dark_theme_config", value = darkThemeConfigName),
-            ),
+internal fun AnalyticsHelper.logDarkThemeConfigChanged(darkThemeConfigName: String) = logEvent(
+    AnalyticsEvent(
+        type = "dark_theme_config_changed",
+        extras = listOf(
+            Param(key = "dark_theme_config", value = darkThemeConfigName),
         ),
-    )
+    ),
+)
 
-internal fun AnalyticsHelper.logDynamicColorPreferenceChanged(useDynamicColor: Boolean) =
-    logEvent(
-        AnalyticsEvent(
-            type = "dynamic_color_preference_changed",
-            extras = listOf(
-                Param(key = "dynamic_color_preference", value = useDynamicColor.toString()),
-            ),
+internal fun AnalyticsHelper.logDynamicColorPreferenceChanged(useDynamicColor: Boolean) = logEvent(
+    AnalyticsEvent(
+        type = "dynamic_color_preference_changed",
+        extras = listOf(
+            Param(key = "dynamic_color_preference", value = useDynamicColor.toString()),
         ),
-    )
+    ),
+)
 
 internal fun AnalyticsHelper.logOnboardingStateChanged(shouldHideOnboarding: Boolean) {
     val eventType = if (shouldHideOnboarding) "onboarding_complete" else "onboarding_reset"

--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/CompositeUserNewsResourceRepository.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/CompositeUserNewsResourceRepository.kt
@@ -18,13 +18,13 @@ package com.google.samples.apps.nowinandroid.core.data.repository
 
 import com.google.samples.apps.nowinandroid.core.model.data.UserNewsResource
 import com.google.samples.apps.nowinandroid.core.model.data.mapToUserNewsResources
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 
 /**
  * Implements a [UserNewsResourceRepository] by combining a [NewsRepository] with a
@@ -38,9 +38,7 @@ class CompositeUserNewsResourceRepository @Inject constructor(
     /**
      * Returns available news resources (joined with user data) matching the given query.
      */
-    override fun observeAll(
-        query: NewsResourceQuery,
-    ): Flow<List<UserNewsResource>> =
+    override fun observeAll(query: NewsResourceQuery): Flow<List<UserNewsResource>> =
         newsRepository.getNewsResources(query)
             .combine(userDataRepository.userData) { newsResources, userData ->
                 newsResources.mapToUserNewsResources(userData)

--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/DefaultRecentSearchRepository.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/DefaultRecentSearchRepository.kt
@@ -20,10 +20,10 @@ import com.google.samples.apps.nowinandroid.core.data.model.RecentSearchQuery
 import com.google.samples.apps.nowinandroid.core.data.model.asExternalModel
 import com.google.samples.apps.nowinandroid.core.database.dao.RecentSearchQueryDao
 import com.google.samples.apps.nowinandroid.core.database.model.RecentSearchQueryEntity
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Clock
-import javax.inject.Inject
 
 internal class DefaultRecentSearchRepository @Inject constructor(
     private val recentSearchQueryDao: RecentSearchQueryDao,

--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/DefaultSearchContentsRepository.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/DefaultSearchContentsRepository.kt
@@ -26,6 +26,7 @@ import com.google.samples.apps.nowinandroid.core.database.model.asFtsEntity
 import com.google.samples.apps.nowinandroid.core.model.data.SearchResult
 import com.google.samples.apps.nowinandroid.core.network.Dispatcher
 import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.IO
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -34,7 +35,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
 internal class DefaultSearchContentsRepository @Inject constructor(
     private val newsResourceDao: NewsResourceDao,
@@ -82,11 +82,10 @@ internal class DefaultSearchContentsRepository @Inject constructor(
         }
     }
 
-    override fun getSearchContentsCount(): Flow<Int> =
-        combine(
-            newsResourceFtsDao.getCount(),
-            topicFtsDao.getCount(),
-        ) { newsResourceCount, topicsCount ->
-            newsResourceCount + topicsCount
-        }
+    override fun getSearchContentsCount(): Flow<Int> = combine(
+        newsResourceFtsDao.getCount(),
+        topicFtsDao.getCount(),
+    ) { newsResourceCount, topicsCount ->
+        newsResourceCount + topicsCount
+    }
 }

--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepository.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepository.kt
@@ -32,10 +32,10 @@ import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
 import com.google.samples.apps.nowinandroid.core.network.NiaNetworkDataSource
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkNewsResource
 import com.google.samples.apps.nowinandroid.core.notifications.Notifier
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 
 // Heuristic value to optimize for serialization and deserialization cost on client and server
 // for each news resource batch.
@@ -53,15 +53,14 @@ internal class OfflineFirstNewsRepository @Inject constructor(
     private val notifier: Notifier,
 ) : NewsRepository {
 
-    override fun getNewsResources(
-        query: NewsResourceQuery,
-    ): Flow<List<NewsResource>> = newsResourceDao.getNewsResources(
-        useFilterTopicIds = query.filterTopicIds != null,
-        filterTopicIds = query.filterTopicIds ?: emptySet(),
-        useFilterNewsIds = query.filterNewsIds != null,
-        filterNewsIds = query.filterNewsIds ?: emptySet(),
-    )
-        .map { it.map(PopulatedNewsResource::asExternalModel) }
+    override fun getNewsResources(query: NewsResourceQuery): Flow<List<NewsResource>> =
+        newsResourceDao.getNewsResources(
+            useFilterTopicIds = query.filterTopicIds != null,
+            filterTopicIds = query.filterTopicIds ?: emptySet(),
+            useFilterNewsIds = query.filterNewsIds != null,
+            filterNewsIds = query.filterNewsIds ?: emptySet(),
+        )
+            .map { it.map(PopulatedNewsResource::asExternalModel) }
 
     override suspend fun syncWith(synchronizer: Synchronizer): Boolean {
         var isFirstSync = false

--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstTopicsRepository.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstTopicsRepository.kt
@@ -26,9 +26,9 @@ import com.google.samples.apps.nowinandroid.core.datastore.ChangeListVersions
 import com.google.samples.apps.nowinandroid.core.model.data.Topic
 import com.google.samples.apps.nowinandroid.core.network.NiaNetworkDataSource
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkTopic
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 
 /**
  * Disk storage backed implementation of the [TopicsRepository].
@@ -39,9 +39,8 @@ internal class OfflineFirstTopicsRepository @Inject constructor(
     private val network: NiaNetworkDataSource,
 ) : TopicsRepository {
 
-    override fun getTopics(): Flow<List<Topic>> =
-        topicDao.getTopicEntities()
-            .map { it.map(TopicEntity::asExternalModel) }
+    override fun getTopics(): Flow<List<Topic>> = topicDao.getTopicEntities()
+        .map { it.map(TopicEntity::asExternalModel) }
 
     override fun getTopic(id: String): Flow<Topic> =
         topicDao.getTopicEntity(id).map { it.asExternalModel() }

--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstUserDataRepository.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstUserDataRepository.kt
@@ -22,8 +22,8 @@ import com.google.samples.apps.nowinandroid.core.datastore.NiaPreferencesDataSou
 import com.google.samples.apps.nowinandroid.core.model.data.DarkThemeConfig
 import com.google.samples.apps.nowinandroid.core.model.data.ThemeBrand
 import com.google.samples.apps.nowinandroid.core.model.data.UserData
-import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
 
 internal class OfflineFirstUserDataRepository @Inject constructor(
     private val niaPreferencesDataSource: NiaPreferencesDataSource,

--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
@@ -27,11 +27,11 @@ import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import androidx.core.content.getSystemService
 import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.conflate
-import javax.inject.Inject
 
 internal class ConnectivityManagerNetworkMonitor @Inject constructor(
     @ApplicationContext private val context: Context,

--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/TimeZoneMonitor.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/TimeZoneMonitor.kt
@@ -27,6 +27,9 @@ import com.google.samples.apps.nowinandroid.core.network.Dispatcher
 import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.IO
 import com.google.samples.apps.nowinandroid.core.network.di.ApplicationScope
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.ZoneId
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
@@ -40,9 +43,6 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toKotlinTimeZone
-import java.time.ZoneId
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * Utility for reporting current timezone the device has set.

--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/CompositeUserNewsResourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/CompositeUserNewsResourceRepositoryTest.kt
@@ -24,11 +24,11 @@ import com.google.samples.apps.nowinandroid.core.model.data.mapToUserNewsResourc
 import com.google.samples.apps.nowinandroid.core.testing.repository.TestNewsRepository
 import com.google.samples.apps.nowinandroid.core.testing.repository.TestUserDataRepository
 import com.google.samples.apps.nowinandroid.core.testing.repository.emptyUserData
+import kotlin.test.assertEquals
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import org.junit.Test
-import kotlin.test.assertEquals
 
 class CompositeUserNewsResourceRepositoryTest {
 

--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/model/NetworkEntityKtTest.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/model/NetworkEntityKtTest.kt
@@ -19,9 +19,9 @@ package com.google.samples.apps.nowinandroid.core.data.model
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkNewsResource
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkNewsResourceExpanded
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkTopic
+import kotlin.test.assertEquals
 import kotlinx.datetime.Instant
 import org.junit.Test
-import kotlin.test.assertEquals
 
 class NetworkEntityKtTest {
 

--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstUserDataRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstUserDataRepositoryTest.kt
@@ -22,6 +22,9 @@ import com.google.samples.apps.nowinandroid.core.datastore.test.testUserPreferen
 import com.google.samples.apps.nowinandroid.core.model.data.DarkThemeConfig
 import com.google.samples.apps.nowinandroid.core.model.data.ThemeBrand
 import com.google.samples.apps.nowinandroid.core.model.data.UserData
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.TestScope
@@ -31,9 +34,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class OfflineFirstUserDataRepositoryTest {
 
@@ -61,21 +61,20 @@ class OfflineFirstUserDataRepositoryTest {
     }
 
     @Test
-    fun offlineFirstUserDataRepository_default_user_data_is_correct() =
-        testScope.runTest {
-            assertEquals(
-                UserData(
-                    bookmarkedNewsResources = emptySet(),
-                    viewedNewsResources = emptySet(),
-                    followedTopics = emptySet(),
-                    themeBrand = ThemeBrand.DEFAULT,
-                    darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
-                    useDynamicColor = false,
-                    shouldHideOnboarding = false,
-                ),
-                subject.userData.first(),
-            )
-        }
+    fun offlineFirstUserDataRepository_default_user_data_is_correct() = testScope.runTest {
+        assertEquals(
+            UserData(
+                bookmarkedNewsResources = emptySet(),
+                viewedNewsResources = emptySet(),
+                followedTopics = emptySet(),
+                themeBrand = ThemeBrand.DEFAULT,
+                darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
+                useDynamicColor = false,
+                shouldHideOnboarding = false,
+            ),
+            subject.userData.first(),
+        )
+    }
 
     @Test
     fun offlineFirstUserDataRepository_toggle_followed_topics_logic_delegates_to_nia_preferences() =

--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNewsResourceDao.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNewsResourceDao.kt
@@ -43,54 +43,52 @@ class TestNewsResourceDao : NewsResourceDao {
         filterTopicIds: Set<String>,
         useFilterNewsIds: Boolean,
         filterNewsIds: Set<String>,
-    ): Flow<List<PopulatedNewsResource>> =
-        entitiesStateFlow
-            .map { newsResourceEntities ->
-                newsResourceEntities.map { entity ->
-                    entity.asPopulatedNewsResource(topicCrossReferences)
+    ): Flow<List<PopulatedNewsResource>> = entitiesStateFlow
+        .map { newsResourceEntities ->
+            newsResourceEntities.map { entity ->
+                entity.asPopulatedNewsResource(topicCrossReferences)
+            }
+        }
+        .map { resources ->
+            var result = resources
+            if (useFilterTopicIds) {
+                result = result.filter { resource ->
+                    resource.topics.any { it.id in filterTopicIds }
                 }
             }
-            .map { resources ->
-                var result = resources
-                if (useFilterTopicIds) {
-                    result = result.filter { resource ->
-                        resource.topics.any { it.id in filterTopicIds }
-                    }
+            if (useFilterNewsIds) {
+                result = result.filter { resource ->
+                    resource.entity.id in filterNewsIds
                 }
-                if (useFilterNewsIds) {
-                    result = result.filter { resource ->
-                        resource.entity.id in filterNewsIds
-                    }
-                }
-                result
             }
+            result
+        }
 
     override fun getNewsResourceIds(
         useFilterTopicIds: Boolean,
         filterTopicIds: Set<String>,
         useFilterNewsIds: Boolean,
         filterNewsIds: Set<String>,
-    ): Flow<List<String>> =
-        entitiesStateFlow
-            .map { newsResourceEntities ->
-                newsResourceEntities.map { entity ->
-                    entity.asPopulatedNewsResource(topicCrossReferences)
+    ): Flow<List<String>> = entitiesStateFlow
+        .map { newsResourceEntities ->
+            newsResourceEntities.map { entity ->
+                entity.asPopulatedNewsResource(topicCrossReferences)
+            }
+        }
+        .map { resources ->
+            var result = resources
+            if (useFilterTopicIds) {
+                result = result.filter { resource ->
+                    resource.topics.any { it.id in filterTopicIds }
                 }
             }
-            .map { resources ->
-                var result = resources
-                if (useFilterTopicIds) {
-                    result = result.filter { resource ->
-                        resource.topics.any { it.id in filterTopicIds }
-                    }
+            if (useFilterNewsIds) {
+                result = result.filter { resource ->
+                    resource.entity.id in filterNewsIds
                 }
-                if (useFilterNewsIds) {
-                    result = result.filter { resource ->
-                        resource.entity.id in filterNewsIds
-                    }
-                }
-                result.map { it.entity.id }
             }
+            result.map { it.entity.id }
+        }
 
     override suspend fun upsertNewsResources(newsResourceEntities: List<NewsResourceEntity>) {
         entitiesStateFlow.update { oldValues ->

--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNiaNetworkDataSource.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNiaNetworkDataSource.kt
@@ -51,11 +51,10 @@ class TestNiaNetworkDataSource : NiaNetworkDataSource {
             .mapToChangeList(idGetter = NetworkNewsResource::id),
     )
 
-    override suspend fun getTopics(ids: List<String>?): List<NetworkTopic> =
-        allTopics.matchIds(
-            ids = ids,
-            idGetter = NetworkTopic::id,
-        )
+    override suspend fun getTopics(ids: List<String>?): List<NetworkTopic> = allTopics.matchIds(
+        ids = ids,
+        idGetter = NetworkTopic::id,
+    )
 
     override suspend fun getNewsResources(ids: List<String>?): List<NetworkNewsResource> =
         allNewsResources.matchIds(
@@ -99,10 +98,7 @@ fun List<NetworkChangeList>.after(version: Int?): List<NetworkChangeList> = when
 /**
  * Return items from [this] whose id defined by [idGetter] is in [ids] if [ids] is not null
  */
-private fun <T> List<T>.matchIds(
-    ids: List<String>?,
-    idGetter: (T) -> String,
-) = when (ids) {
+private fun <T> List<T>.matchIds(ids: List<String>?, idGetter: (T) -> String) = when (ids) {
     null -> this
     else -> ids.toSet().let { idSet -> filter { idGetter(it) in idSet } }
 }
@@ -111,9 +107,7 @@ private fun <T> List<T>.matchIds(
  * Maps items to a change list where the change list version is denoted by the index of each item.
  * [after] simulates which models have changed by excluding items before it
  */
-private fun <T> List<T>.mapToChangeList(
-    idGetter: (T) -> String,
-) = mapIndexed { index, item ->
+private fun <T> List<T>.mapToChangeList(idGetter: (T) -> String) = mapIndexed { index, item ->
     NetworkChangeList(
         id = idGetter(item),
         changeListVersion = index + 1,

--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/database/model/PopulatedNewsResourceKtTest.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/database/model/PopulatedNewsResourceKtTest.kt
@@ -18,9 +18,9 @@ package com.google.samples.apps.nowinandroid.core.database.model
 
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
 import com.google.samples.apps.nowinandroid.core.model.data.Topic
+import kotlin.test.assertEquals
 import kotlinx.datetime.Instant
 import org.junit.Test
-import kotlin.test.assertEquals
 
 class PopulatedNewsResourceKtTest {
     @Test

--- a/core/database/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/core/database/dao/NewsResourceDaoTest.kt
@@ -24,13 +24,13 @@ import com.google.samples.apps.nowinandroid.core.database.model.NewsResourceEnti
 import com.google.samples.apps.nowinandroid.core.database.model.NewsResourceTopicCrossRef
 import com.google.samples.apps.nowinandroid.core.database.model.TopicEntity
 import com.google.samples.apps.nowinandroid.core.database.model.asExternalModel
+import kotlin.test.assertEquals
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import kotlin.test.assertEquals
 
 class NewsResourceDaoTest {
 
@@ -248,48 +248,44 @@ class NewsResourceDaoTest {
     }
 
     @Test
-    fun newsResourceDao_deletes_items_by_ids() =
-        runTest {
-            val newsResourceEntities = listOf(
-                testNewsResource(
-                    id = "0",
-                    millisSinceEpoch = 0,
-                ),
-                testNewsResource(
-                    id = "1",
-                    millisSinceEpoch = 3,
-                ),
-                testNewsResource(
-                    id = "2",
-                    millisSinceEpoch = 1,
-                ),
-                testNewsResource(
-                    id = "3",
-                    millisSinceEpoch = 2,
-                ),
-            )
-            newsResourceDao.upsertNewsResources(newsResourceEntities)
+    fun newsResourceDao_deletes_items_by_ids() = runTest {
+        val newsResourceEntities = listOf(
+            testNewsResource(
+                id = "0",
+                millisSinceEpoch = 0,
+            ),
+            testNewsResource(
+                id = "1",
+                millisSinceEpoch = 3,
+            ),
+            testNewsResource(
+                id = "2",
+                millisSinceEpoch = 1,
+            ),
+            testNewsResource(
+                id = "3",
+                millisSinceEpoch = 2,
+            ),
+        )
+        newsResourceDao.upsertNewsResources(newsResourceEntities)
 
-            val (toDelete, toKeep) = newsResourceEntities.partition { it.id.toInt() % 2 == 0 }
+        val (toDelete, toKeep) = newsResourceEntities.partition { it.id.toInt() % 2 == 0 }
 
-            newsResourceDao.deleteNewsResources(
-                toDelete.map(NewsResourceEntity::id),
-            )
+        newsResourceDao.deleteNewsResources(
+            toDelete.map(NewsResourceEntity::id),
+        )
 
-            assertEquals(
-                toKeep.map(NewsResourceEntity::id)
-                    .toSet(),
-                newsResourceDao.getNewsResources().first()
-                    .map { it.entity.id }
-                    .toSet(),
-            )
-        }
+        assertEquals(
+            toKeep.map(NewsResourceEntity::id)
+                .toSet(),
+            newsResourceDao.getNewsResources().first()
+                .map { it.entity.id }
+                .toSet(),
+        )
+    }
 }
 
-private fun testTopicEntity(
-    id: String = "0",
-    name: String,
-) = TopicEntity(
+private fun testTopicEntity(id: String = "0", name: String) = TopicEntity(
     id = id,
     name = name,
     shortDescription = "",
@@ -298,10 +294,7 @@ private fun testTopicEntity(
     imageUrl = "",
 )
 
-private fun testNewsResource(
-    id: String = "0",
-    millisSinceEpoch: Long = 0,
-) = NewsResourceEntity(
+private fun testNewsResource(id: String = "0", millisSinceEpoch: Long = 0) = NewsResourceEntity(
     id = id,
     title = "",
     content = "",

--- a/core/database/src/main/kotlin/com/google/samples/apps/nowinandroid/core/database/di/DaosModule.kt
+++ b/core/database/src/main/kotlin/com/google/samples/apps/nowinandroid/core/database/di/DaosModule.kt
@@ -31,27 +31,19 @@ import dagger.hilt.components.SingletonComponent
 @InstallIn(SingletonComponent::class)
 internal object DaosModule {
     @Provides
-    fun providesTopicsDao(
-        database: NiaDatabase,
-    ): TopicDao = database.topicDao()
+    fun providesTopicsDao(database: NiaDatabase): TopicDao = database.topicDao()
 
     @Provides
-    fun providesNewsResourceDao(
-        database: NiaDatabase,
-    ): NewsResourceDao = database.newsResourceDao()
+    fun providesNewsResourceDao(database: NiaDatabase): NewsResourceDao = database.newsResourceDao()
 
     @Provides
-    fun providesTopicFtsDao(
-        database: NiaDatabase,
-    ): TopicFtsDao = database.topicFtsDao()
+    fun providesTopicFtsDao(database: NiaDatabase): TopicFtsDao = database.topicFtsDao()
 
     @Provides
-    fun providesNewsResourceFtsDao(
-        database: NiaDatabase,
-    ): NewsResourceFtsDao = database.newsResourceFtsDao()
+    fun providesNewsResourceFtsDao(database: NiaDatabase): NewsResourceFtsDao =
+        database.newsResourceFtsDao()
 
     @Provides
-    fun providesRecentSearchQueryDao(
-        database: NiaDatabase,
-    ): RecentSearchQueryDao = database.recentSearchQueryDao()
+    fun providesRecentSearchQueryDao(database: NiaDatabase): RecentSearchQueryDao =
+        database.recentSearchQueryDao()
 }

--- a/core/database/src/main/kotlin/com/google/samples/apps/nowinandroid/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/com/google/samples/apps/nowinandroid/core/database/di/DatabaseModule.kt
@@ -31,11 +31,10 @@ import javax.inject.Singleton
 internal object DatabaseModule {
     @Provides
     @Singleton
-    fun providesNiaDatabase(
-        @ApplicationContext context: Context,
-    ): NiaDatabase = Room.databaseBuilder(
-        context,
-        NiaDatabase::class.java,
-        "nia-database",
-    ).build()
+    fun providesNiaDatabase(@ApplicationContext context: Context): NiaDatabase =
+        Room.databaseBuilder(
+            context,
+            NiaDatabase::class.java,
+            "nia-database",
+        ).build()
 }

--- a/core/database/src/main/kotlin/com/google/samples/apps/nowinandroid/core/database/util/InstantConverter.kt
+++ b/core/database/src/main/kotlin/com/google/samples/apps/nowinandroid/core/database/util/InstantConverter.kt
@@ -21,10 +21,8 @@ import kotlinx.datetime.Instant
 
 internal class InstantConverter {
     @TypeConverter
-    fun longToInstant(value: Long?): Instant? =
-        value?.let(Instant::fromEpochMilliseconds)
+    fun longToInstant(value: Long?): Instant? = value?.let(Instant::fromEpochMilliseconds)
 
     @TypeConverter
-    fun instantToLong(instant: Instant?): Long? =
-        instant?.toEpochMilliseconds()
+    fun instantToLong(instant: Instant?): Long? = instant?.toEpochMilliseconds()
 }

--- a/core/datastore-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/datastore/test/TestDataStoreModule.kt
+++ b/core/datastore-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/datastore/test/TestDataStoreModule.kt
@@ -26,9 +26,9 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
+import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import org.junit.rules.TemporaryFolder
-import javax.inject.Singleton
 
 @Module
 @TestInstallIn(
@@ -43,11 +43,10 @@ internal object TestDataStoreModule {
         @ApplicationScope scope: CoroutineScope,
         userPreferencesSerializer: UserPreferencesSerializer,
         tmpFolder: TemporaryFolder,
-    ): DataStore<UserPreferences> =
-        tmpFolder.testUserPreferencesDataStore(
-            coroutineScope = scope,
-            userPreferencesSerializer = userPreferencesSerializer,
-        )
+    ): DataStore<UserPreferences> = tmpFolder.testUserPreferencesDataStore(
+        coroutineScope = scope,
+        userPreferencesSerializer = userPreferencesSerializer,
+    )
 }
 
 fun TemporaryFolder.testUserPreferencesDataStore(

--- a/core/datastore/src/main/kotlin/com/google/samples/apps/nowinandroid/core/datastore/IntToStringIdsMigration.kt
+++ b/core/datastore/src/main/kotlin/com/google/samples/apps/nowinandroid/core/datastore/IntToStringIdsMigration.kt
@@ -25,25 +25,24 @@ internal object IntToStringIdsMigration : DataMigration<UserPreferences> {
 
     override suspend fun cleanUp() = Unit
 
-    override suspend fun migrate(currentData: UserPreferences): UserPreferences =
-        currentData.copy {
-            // Migrate topic ids
-            deprecatedFollowedTopicIds.clear()
-            deprecatedFollowedTopicIds.addAll(
-                currentData.deprecatedIntFollowedTopicIdsList.map(Int::toString),
-            )
-            deprecatedIntFollowedTopicIds.clear()
+    override suspend fun migrate(currentData: UserPreferences): UserPreferences = currentData.copy {
+        // Migrate topic ids
+        deprecatedFollowedTopicIds.clear()
+        deprecatedFollowedTopicIds.addAll(
+            currentData.deprecatedIntFollowedTopicIdsList.map(Int::toString),
+        )
+        deprecatedIntFollowedTopicIds.clear()
 
-            // Migrate author ids
-            deprecatedFollowedAuthorIds.clear()
-            deprecatedFollowedAuthorIds.addAll(
-                currentData.deprecatedIntFollowedAuthorIdsList.map(Int::toString),
-            )
-            deprecatedIntFollowedAuthorIds.clear()
+        // Migrate author ids
+        deprecatedFollowedAuthorIds.clear()
+        deprecatedFollowedAuthorIds.addAll(
+            currentData.deprecatedIntFollowedAuthorIdsList.map(Int::toString),
+        )
+        deprecatedIntFollowedAuthorIds.clear()
 
-            // Mark migration as complete
-            hasDoneIntToStringIdMigration = true
-        }
+        // Mark migration as complete
+        hasDoneIntToStringIdMigration = true
+    }
 
     override suspend fun shouldMigrate(currentData: UserPreferences): Boolean =
         !currentData.hasDoneIntToStringIdMigration

--- a/core/datastore/src/main/kotlin/com/google/samples/apps/nowinandroid/core/datastore/ListToMapMigration.kt
+++ b/core/datastore/src/main/kotlin/com/google/samples/apps/nowinandroid/core/datastore/ListToMapMigration.kt
@@ -25,32 +25,31 @@ internal object ListToMapMigration : DataMigration<UserPreferences> {
 
     override suspend fun cleanUp() = Unit
 
-    override suspend fun migrate(currentData: UserPreferences): UserPreferences =
-        currentData.copy {
-            // Migrate topic id lists
-            followedTopicIds.clear()
-            followedTopicIds.putAll(
-                currentData.deprecatedFollowedTopicIdsList.associateWith { true },
-            )
-            deprecatedFollowedTopicIds.clear()
+    override suspend fun migrate(currentData: UserPreferences): UserPreferences = currentData.copy {
+        // Migrate topic id lists
+        followedTopicIds.clear()
+        followedTopicIds.putAll(
+            currentData.deprecatedFollowedTopicIdsList.associateWith { true },
+        )
+        deprecatedFollowedTopicIds.clear()
 
-            // Migrate author ids
-            followedAuthorIds.clear()
-            followedAuthorIds.putAll(
-                currentData.deprecatedFollowedAuthorIdsList.associateWith { true },
-            )
-            deprecatedFollowedAuthorIds.clear()
+        // Migrate author ids
+        followedAuthorIds.clear()
+        followedAuthorIds.putAll(
+            currentData.deprecatedFollowedAuthorIdsList.associateWith { true },
+        )
+        deprecatedFollowedAuthorIds.clear()
 
-            // Migrate bookmarks
-            bookmarkedNewsResourceIds.clear()
-            bookmarkedNewsResourceIds.putAll(
-                currentData.deprecatedBookmarkedNewsResourceIdsList.associateWith { true },
-            )
-            deprecatedBookmarkedNewsResourceIds.clear()
+        // Migrate bookmarks
+        bookmarkedNewsResourceIds.clear()
+        bookmarkedNewsResourceIds.putAll(
+            currentData.deprecatedBookmarkedNewsResourceIdsList.associateWith { true },
+        )
+        deprecatedBookmarkedNewsResourceIds.clear()
 
-            // Mark migration as complete
-            hasDoneListToMapMigration = true
-        }
+        // Mark migration as complete
+        hasDoneListToMapMigration = true
+    }
 
     override suspend fun shouldMigrate(currentData: UserPreferences): Boolean =
         !currentData.hasDoneListToMapMigration

--- a/core/datastore/src/main/kotlin/com/google/samples/apps/nowinandroid/core/datastore/NiaPreferencesDataSource.kt
+++ b/core/datastore/src/main/kotlin/com/google/samples/apps/nowinandroid/core/datastore/NiaPreferencesDataSource.kt
@@ -21,10 +21,10 @@ import androidx.datastore.core.DataStore
 import com.google.samples.apps.nowinandroid.core.model.data.DarkThemeConfig
 import com.google.samples.apps.nowinandroid.core.model.data.ThemeBrand
 import com.google.samples.apps.nowinandroid.core.model.data.UserData
-import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.map
 import java.io.IOException
 import javax.inject.Inject
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 
 class NiaPreferencesDataSource @Inject constructor(
     private val userPreferences: DataStore<UserPreferences>,

--- a/core/datastore/src/main/kotlin/com/google/samples/apps/nowinandroid/core/datastore/UserPreferencesSerializer.kt
+++ b/core/datastore/src/main/kotlin/com/google/samples/apps/nowinandroid/core/datastore/UserPreferencesSerializer.kt
@@ -29,13 +29,12 @@ import javax.inject.Inject
 class UserPreferencesSerializer @Inject constructor() : Serializer<UserPreferences> {
     override val defaultValue: UserPreferences = UserPreferences.getDefaultInstance()
 
-    override suspend fun readFrom(input: InputStream): UserPreferences =
-        try {
-            // readFrom is already called on the data store background thread
-            UserPreferences.parseFrom(input)
-        } catch (exception: InvalidProtocolBufferException) {
-            throw CorruptionException("Cannot read proto.", exception)
-        }
+    override suspend fun readFrom(input: InputStream): UserPreferences = try {
+        // readFrom is already called on the data store background thread
+        UserPreferences.parseFrom(input)
+    } catch (exception: InvalidProtocolBufferException) {
+        throw CorruptionException("Cannot read proto.", exception)
+    }
 
     override suspend fun writeTo(t: UserPreferences, output: OutputStream) {
         // writeTo is already called on the data store background thread

--- a/core/datastore/src/main/kotlin/com/google/samples/apps/nowinandroid/core/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/kotlin/com/google/samples/apps/nowinandroid/core/datastore/di/DataStoreModule.kt
@@ -31,9 +31,9 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -46,14 +46,13 @@ object DataStoreModule {
         @Dispatcher(IO) ioDispatcher: CoroutineDispatcher,
         @ApplicationScope scope: CoroutineScope,
         userPreferencesSerializer: UserPreferencesSerializer,
-    ): DataStore<UserPreferences> =
-        DataStoreFactory.create(
-            serializer = userPreferencesSerializer,
-            scope = CoroutineScope(scope.coroutineContext + ioDispatcher),
-            migrations = listOf(
-                IntToStringIdsMigration,
-            ),
-        ) {
-            context.dataStoreFile("user_preferences.pb")
-        }
+    ): DataStore<UserPreferences> = DataStoreFactory.create(
+        serializer = userPreferencesSerializer,
+        scope = CoroutineScope(scope.coroutineContext + ioDispatcher),
+        migrations = listOf(
+            IntToStringIdsMigration,
+        ),
+    ) {
+        context.dataStoreFile("user_preferences.pb")
+    }
 }

--- a/core/datastore/src/test/kotlin/com/google/samples/apps/nowinandroid/core/datastore/IntToStringIdsMigrationTest.kt
+++ b/core/datastore/src/test/kotlin/com/google/samples/apps/nowinandroid/core/datastore/IntToStringIdsMigrationTest.kt
@@ -16,10 +16,10 @@
 
 package com.google.samples.apps.nowinandroid.core.datastore
 
-import kotlinx.coroutines.test.runTest
-import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
 
 /**
  * Unit test for [IntToStringIdsMigration]

--- a/core/datastore/src/test/kotlin/com/google/samples/apps/nowinandroid/core/datastore/ListToMapMigrationTest.kt
+++ b/core/datastore/src/test/kotlin/com/google/samples/apps/nowinandroid/core/datastore/ListToMapMigrationTest.kt
@@ -16,10 +16,10 @@
 
 package com.google.samples.apps.nowinandroid.core.datastore
 
-import kotlinx.coroutines.test.runTest
-import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
 
 class ListToMapMigrationTest {
 

--- a/core/datastore/src/test/kotlin/com/google/samples/apps/nowinandroid/core/datastore/NiaPreferencesDataSourceTest.kt
+++ b/core/datastore/src/test/kotlin/com/google/samples/apps/nowinandroid/core/datastore/NiaPreferencesDataSourceTest.kt
@@ -17,6 +17,8 @@
 package com.google.samples.apps.nowinandroid.core.datastore
 
 import com.google.samples.apps.nowinandroid.core.datastore.test.testUserPreferencesDataStore
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -25,8 +27,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class NiaPreferencesDataSourceTest {
 

--- a/core/datastore/src/test/kotlin/com/google/samples/apps/nowinandroid/core/datastore/UserPreferencesSerializerTest.kt
+++ b/core/datastore/src/test/kotlin/com/google/samples/apps/nowinandroid/core/datastore/UserPreferencesSerializerTest.kt
@@ -17,11 +17,11 @@
 package com.google.samples.apps.nowinandroid.core.datastore
 
 import androidx.datastore.core.CorruptionException
-import kotlinx.coroutines.test.runTest
-import org.junit.Test
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
 
 class UserPreferencesSerializerTest {
     private val userPreferencesSerializer = UserPreferencesSerializer()

--- a/core/designsystem/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/ThemeTest.kt
+++ b/core/designsystem/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/ThemeTest.kt
@@ -42,9 +42,9 @@ import com.google.samples.apps.nowinandroid.core.designsystem.theme.LocalGradien
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.LocalTintTheme
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.TintTheme
+import kotlin.test.assertEquals
 import org.junit.Rule
 import org.junit.Test
-import kotlin.test.assertEquals
 
 /**
  * Tests [NiaTheme] using different combinations of the theme mode parameters:

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/Background.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/Background.kt
@@ -48,10 +48,7 @@ import kotlin.math.tan
  * @param content The background content.
  */
 @Composable
-fun NiaBackground(
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
-) {
+fun NiaBackground(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
     val color = LocalBackgroundTheme.current.color
     val tonalElevation = LocalBackgroundTheme.current.tonalElevation
     Surface(

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/LoadingWheel.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/LoadingWheel.kt
@@ -51,10 +51,7 @@ import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import kotlinx.coroutines.launch
 
 @Composable
-fun NiaLoadingWheel(
-    contentDesc: String,
-    modifier: Modifier = Modifier,
-) {
+fun NiaLoadingWheel(contentDesc: String, modifier: Modifier = Modifier) {
     val infiniteTransition = rememberInfiniteTransition(label = "wheel transition")
 
     // Specifies the float animation for slowly drawing out the lines on entering
@@ -132,10 +129,7 @@ fun NiaLoadingWheel(
 }
 
 @Composable
-fun NiaOverlayLoadingWheel(
-    contentDesc: String,
-    modifier: Modifier = Modifier,
-) {
+fun NiaOverlayLoadingWheel(contentDesc: String, modifier: Modifier = Modifier) {
     Surface(
         shape = RoundedCornerShape(60.dp),
         shadowElevation = 8.dp,

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/Navigation.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/Navigation.kt
@@ -86,10 +86,7 @@ fun RowScope.NiaNavigationBarItem(
  * [NavigationBarItem]s.
  */
 @Composable
-fun NiaNavigationBar(
-    modifier: Modifier = Modifier,
-    content: @Composable RowScope.() -> Unit,
-) {
+fun NiaNavigationBar(modifier: Modifier = Modifier, content: @Composable RowScope.() -> Unit) {
     NavigationBar(
         modifier = modifier,
         contentColor = NiaNavigationDefaults.navigationContentColor(),

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/Tabs.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/Tabs.kt
@@ -80,11 +80,7 @@ fun NiaTab(
  * inside this lambda will be measured and placed evenly across the row, each taking up equal space.
  */
 @Composable
-fun NiaTabRow(
-    selectedTabIndex: Int,
-    modifier: Modifier = Modifier,
-    tabs: @Composable () -> Unit,
-) {
+fun NiaTabRow(selectedTabIndex: Int, modifier: Modifier = Modifier, tabs: @Composable () -> Unit) {
     TabRow(
         selectedTabIndex = selectedTabIndex,
         modifier = modifier,

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
@@ -185,7 +185,8 @@ private data class ScrollThumbElement(val colorProducer: ColorProducer) :
     }
 }
 
-private class ScrollThumbNode(var colorProducer: ColorProducer) : DrawModifierNode, Modifier.Node() {
+private class ScrollThumbNode(var colorProducer: ColorProducer) :
+    DrawModifierNode, Modifier.Node() {
     private val shape = RoundedCornerShape(16.dp)
 
     // naive cache outline calculation if size is the same

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/LazyScrollbarUtilities.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/LazyScrollbarUtilities.kt
@@ -33,6 +33,8 @@ import kotlin.math.abs
  * @return a [Float] in the range [firstItemPosition..nextItemPosition) where nextItemPosition
  * is the index of the consecutive item along the major axis.
  * */
+
+@Suppress("ktlint:standard:max-line-length")
 internal inline fun <LazyState : ScrollableState, LazyStateItem> LazyState.interpolateFirstItemIndex(
     visibleItems: List<LazyStateItem>,
     crossinline itemSize: LazyState.(LazyStateItem) -> Int,

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/Scrollbar.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/Scrollbar.kt
@@ -54,12 +54,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.packFloats
 import androidx.compose.ui.util.unpackFloat1
 import androidx.compose.ui.util.unpackFloat2
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.withTimeout
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
 
 /**
  * The delay between scrolls when a user long presses on the scrollbar track to initiate a scroll
@@ -108,9 +108,7 @@ private val ScrollbarTrack.size
 /**
  * Returns the position of the scrollbar thumb on the track as a percentage
  */
-private fun ScrollbarTrack.thumbPosition(
-    dimension: Float,
-): Float = max(
+private fun ScrollbarTrack.thumbPosition(dimension: Float): Float = max(
     a = min(
         a = dimension / size,
         b = 1f,
@@ -149,10 +147,7 @@ private value class ScrollbarTrack(
  * @param thumbMovedPercent the distance the thumb has traveled as a percentage of total
  * track size.
  */
-fun scrollbarStateValue(
-    thumbSizePercent: Float,
-    thumbMovedPercent: Float,
-) = ScrollbarStateValue(
+fun scrollbarStateValue(thumbSizePercent: Float, thumbMovedPercent: Float) = ScrollbarStateValue(
     packFloats(
         val1 = thumbSizePercent,
         val2 = thumbMovedPercent,

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/ScrollbarExt.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/ScrollbarExt.kt
@@ -27,9 +27,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
+import kotlin.math.min
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
-import kotlin.math.min
 
 /**
  * Calculates a [ScrollbarState] driven by the changes in a [LazyListState].

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/ThumbExt.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/ThumbExt.kt
@@ -33,24 +33,22 @@ import kotlin.math.roundToInt
  * @param itemsAvailable the amount of items in the list.
  */
 @Composable
-fun LazyListState.rememberDraggableScroller(
-    itemsAvailable: Int,
-): (Float) -> Unit = rememberDraggableScroller(
-    itemsAvailable = itemsAvailable,
-    scroll = ::scrollToItem,
-)
+fun LazyListState.rememberDraggableScroller(itemsAvailable: Int): (Float) -> Unit =
+    rememberDraggableScroller(
+        itemsAvailable = itemsAvailable,
+        scroll = ::scrollToItem,
+    )
 
 /**
  * Remembers a function to react to [Scrollbar] thumb position displacements for a [LazyGridState]
  * @param itemsAvailable the amount of items in the grid.
  */
 @Composable
-fun LazyGridState.rememberDraggableScroller(
-    itemsAvailable: Int,
-): (Float) -> Unit = rememberDraggableScroller(
-    itemsAvailable = itemsAvailable,
-    scroll = ::scrollToItem,
-)
+fun LazyGridState.rememberDraggableScroller(itemsAvailable: Int): (Float) -> Unit =
+    rememberDraggableScroller(
+        itemsAvailable = itemsAvailable,
+        scroll = ::scrollToItem,
+    )
 
 /**
  * Remembers a function to react to [Scrollbar] thumb position displacements for a
@@ -58,12 +56,11 @@ fun LazyGridState.rememberDraggableScroller(
  * @param itemsAvailable the amount of items in the staggered grid.
  */
 @Composable
-fun LazyStaggeredGridState.rememberDraggableScroller(
-    itemsAvailable: Int,
-): (Float) -> Unit = rememberDraggableScroller(
-    itemsAvailable = itemsAvailable,
-    scroll = ::scrollToItem,
-)
+fun LazyStaggeredGridState.rememberDraggableScroller(itemsAvailable: Int): (Float) -> Unit =
+    rememberDraggableScroller(
+        itemsAvailable = itemsAvailable,
+        scroll = ::scrollToItem,
+    )
 
 /**
  * Generic function to react to [Scrollbar] thumb displacements in a lazy layout.

--- a/core/domain/src/main/kotlin/com/google/samples/apps/nowinandroid/core/domain/GetFollowableTopicsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/google/samples/apps/nowinandroid/core/domain/GetFollowableTopicsUseCase.kt
@@ -21,9 +21,9 @@ import com.google.samples.apps.nowinandroid.core.data.repository.UserDataReposit
 import com.google.samples.apps.nowinandroid.core.domain.TopicSortField.NAME
 import com.google.samples.apps.nowinandroid.core.domain.TopicSortField.NONE
 import com.google.samples.apps.nowinandroid.core.model.data.FollowableTopic
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import javax.inject.Inject
 
 /**
  * A use case which obtains a list of topics with their followed state.

--- a/core/domain/src/main/kotlin/com/google/samples/apps/nowinandroid/core/domain/GetRecentSearchQueriesUseCase.kt
+++ b/core/domain/src/main/kotlin/com/google/samples/apps/nowinandroid/core/domain/GetRecentSearchQueriesUseCase.kt
@@ -18,8 +18,8 @@ package com.google.samples.apps.nowinandroid.core.domain
 
 import com.google.samples.apps.nowinandroid.core.data.model.RecentSearchQuery
 import com.google.samples.apps.nowinandroid.core.data.repository.RecentSearchRepository
-import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
 
 /**
  * A use case which returns the recent search queries.

--- a/core/domain/src/main/kotlin/com/google/samples/apps/nowinandroid/core/domain/GetSearchContentsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/google/samples/apps/nowinandroid/core/domain/GetSearchContentsUseCase.kt
@@ -23,9 +23,9 @@ import com.google.samples.apps.nowinandroid.core.model.data.SearchResult
 import com.google.samples.apps.nowinandroid.core.model.data.UserData
 import com.google.samples.apps.nowinandroid.core.model.data.UserNewsResource
 import com.google.samples.apps.nowinandroid.core.model.data.UserSearchResult
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import javax.inject.Inject
 
 /**
  * A use case which returns the searched contents matched with the search query.
@@ -35,27 +35,26 @@ class GetSearchContentsUseCase @Inject constructor(
     private val userDataRepository: UserDataRepository,
 ) {
 
-    operator fun invoke(
-        searchQuery: String,
-    ): Flow<UserSearchResult> =
+    operator fun invoke(searchQuery: String): Flow<UserSearchResult> =
         searchContentsRepository.searchContents(searchQuery)
             .mapToUserSearchResult(userDataRepository.userData)
 }
 
-private fun Flow<SearchResult>.mapToUserSearchResult(userDataStream: Flow<UserData>): Flow<UserSearchResult> =
-    combine(userDataStream) { searchResult, userData ->
-        UserSearchResult(
-            topics = searchResult.topics.map { topic ->
-                FollowableTopic(
-                    topic = topic,
-                    isFollowed = topic.id in userData.followedTopics,
-                )
-            },
-            newsResources = searchResult.newsResources.map { news ->
-                UserNewsResource(
-                    newsResource = news,
-                    userData = userData,
-                )
-            },
-        )
-    }
+private fun Flow<SearchResult>.mapToUserSearchResult(
+    userDataStream: Flow<UserData>,
+): Flow<UserSearchResult> = combine(userDataStream) { searchResult, userData ->
+    UserSearchResult(
+        topics = searchResult.topics.map { topic ->
+            FollowableTopic(
+                topic = topic,
+                isFollowed = topic.id in userData.followedTopics,
+            )
+        },
+        newsResources = searchResult.newsResources.map { news ->
+            UserNewsResource(
+                newsResource = news,
+                userData = userData,
+            )
+        },
+    )
+}

--- a/core/domain/src/test/kotlin/com/google/samples/apps/nowinandroid/core/domain/GetFollowableTopicsUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/google/samples/apps/nowinandroid/core/domain/GetFollowableTopicsUseCaseTest.kt
@@ -22,11 +22,11 @@ import com.google.samples.apps.nowinandroid.core.model.data.Topic
 import com.google.samples.apps.nowinandroid.core.testing.repository.TestTopicsRepository
 import com.google.samples.apps.nowinandroid.core.testing.repository.TestUserDataRepository
 import com.google.samples.apps.nowinandroid.core.testing.util.MainDispatcherRule
+import kotlin.test.assertEquals
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
-import kotlin.test.assertEquals
 
 class GetFollowableTopicsUseCaseTest {
 

--- a/core/network/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/demo/DemoNiaNetworkDataSource.kt
+++ b/core/network/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/demo/DemoNiaNetworkDataSource.kt
@@ -23,12 +23,12 @@ import com.google.samples.apps.nowinandroid.core.network.NiaNetworkDataSource
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkChangeList
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkNewsResource
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkTopic
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
-import javax.inject.Inject
 
 /**
  * [NiaNetworkDataSource] implementation that provides static news resources to aid development
@@ -67,9 +67,7 @@ class DemoNiaNetworkDataSource @Inject constructor(
  * Converts a list of [T] to change list of all the items in it where [idGetter] defines the
  * [NetworkChangeList.id]
  */
-private fun <T> List<T>.mapToChangeList(
-    idGetter: (T) -> String,
-) = mapIndexed { index, item ->
+private fun <T> List<T>.mapToChangeList(idGetter: (T) -> String) = mapIndexed { index, item ->
     NetworkChangeList(
         id = idGetter(item),
         changeListVersion = index,

--- a/core/network/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/di/NetworkModule.kt
@@ -28,11 +28,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 import kotlinx.serialization.json.Json
 import okhttp3.Call
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
-import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -46,9 +46,8 @@ internal object NetworkModule {
 
     @Provides
     @Singleton
-    fun providesDemoAssetManager(
-        @ApplicationContext context: Context,
-    ): DemoAssetManager = DemoAssetManager(context.assets::open)
+    fun providesDemoAssetManager(@ApplicationContext context: Context): DemoAssetManager =
+        DemoAssetManager(context.assets::open)
 
     @Provides
     @Singleton

--- a/core/network/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/retrofit/RetrofitNiaNetwork.kt
+++ b/core/network/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/retrofit/RetrofitNiaNetwork.kt
@@ -23,6 +23,8 @@ import com.google.samples.apps.nowinandroid.core.network.model.NetworkChangeList
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkNewsResource
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkTopic
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.Call
@@ -30,17 +32,13 @@ import okhttp3.MediaType.Companion.toMediaType
 import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Query
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * Retrofit API declaration for NIA Network API
  */
 private interface RetrofitNiaNetworkApi {
     @GET(value = "topics")
-    suspend fun getTopics(
-        @Query("id") ids: List<String>?,
-    ): NetworkResponse<List<NetworkTopic>>
+    suspend fun getTopics(@Query("id") ids: List<String>?): NetworkResponse<List<NetworkTopic>>
 
     @GET(value = "newsresources")
     suspend fun getNewsResources(
@@ -48,14 +46,10 @@ private interface RetrofitNiaNetworkApi {
     ): NetworkResponse<List<NetworkNewsResource>>
 
     @GET(value = "changelists/topics")
-    suspend fun getTopicChangeList(
-        @Query("after") after: Int?,
-    ): List<NetworkChangeList>
+    suspend fun getTopicChangeList(@Query("after") after: Int?): List<NetworkChangeList>
 
     @GET(value = "changelists/newsresources")
-    suspend fun getNewsResourcesChangeList(
-        @Query("after") after: Int?,
-    ): List<NetworkChangeList>
+    suspend fun getNewsResourcesChangeList(@Query("after") after: Int?): List<NetworkChangeList>
 }
 
 private const val NIA_BASE_URL = BuildConfig.BACKEND_URL

--- a/core/network/src/test/kotlin/com/google/samples/apps/nowinandroid/core/network/demo/DemoNiaNetworkDataSourceTest.kt
+++ b/core/network/src/test/kotlin/com/google/samples/apps/nowinandroid/core/network/demo/DemoNiaNetworkDataSourceTest.kt
@@ -19,6 +19,7 @@ package com.google.samples.apps.nowinandroid.core.network.demo
 import JvmUnitTestDemoAssetManager
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkNewsResource
 import com.google.samples.apps.nowinandroid.core.network.model.NetworkTopic
+import kotlin.test.assertEquals
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDateTime
@@ -27,7 +28,6 @@ import kotlinx.datetime.toInstant
 import kotlinx.serialization.json.Json
 import org.junit.Before
 import org.junit.Test
-import kotlin.test.assertEquals
 
 class DemoNiaNetworkDataSourceTest {
 

--- a/core/notifications/src/demo/kotlin/com/google/samples/apps/nowinandroid/core/notifications/NotificationsModule.kt
+++ b/core/notifications/src/demo/kotlin/com/google/samples/apps/nowinandroid/core/notifications/NotificationsModule.kt
@@ -25,7 +25,5 @@ import dagger.hilt.components.SingletonComponent
 @InstallIn(SingletonComponent::class)
 internal abstract class NotificationsModule {
     @Binds
-    abstract fun bindNotifier(
-        notifier: NoOpNotifier,
-    ): Notifier
+    abstract fun bindNotifier(notifier: NoOpNotifier): Notifier
 }

--- a/core/notifications/src/main/kotlin/com/google/samples/apps/nowinandroid/core/notifications/SystemTrayNotifier.kt
+++ b/core/notifications/src/main/kotlin/com/google/samples/apps/nowinandroid/core/notifications/SystemTrayNotifier.kt
@@ -65,6 +65,7 @@ internal class SystemTrayNotifier @Inject constructor(
 
         val newsNotifications = truncatedNewsResources.map { newsResource ->
             createNewsNotification {
+
                 setSmallIcon(
                     com.google.samples.apps.nowinandroid.core.common.R.drawable.core_common_ic_nia_notification,
                 )

--- a/core/notifications/src/main/kotlin/com/google/samples/apps/nowinandroid/core/notifications/SystemTrayNotifier.kt
+++ b/core/notifications/src/main/kotlin/com/google/samples/apps/nowinandroid/core/notifications/SystemTrayNotifier.kt
@@ -63,7 +63,7 @@ internal class SystemTrayNotifier @Inject constructor(
 
         val newsNotifications = truncatedNewsResources.map { newsResource ->
             createNewsNotification {
-
+                @Suppress("ktlint:standard:max-line-length")
                 setSmallIcon(
                     com.google.samples.apps.nowinandroid.core.common.R.drawable.core_common_ic_nia_notification,
                 )
@@ -79,6 +79,7 @@ internal class SystemTrayNotifier @Inject constructor(
                 R.string.core_notifications_news_notification_group_summary,
                 truncatedNewsResources.size,
             )
+            @Suppress("ktlint:standard:max-line-length")
             setContentTitle(title)
                 .setContentText(title)
                 .setSmallIcon(

--- a/core/notifications/src/main/kotlin/com/google/samples/apps/nowinandroid/core/notifications/SystemTrayNotifier.kt
+++ b/core/notifications/src/main/kotlin/com/google/samples/apps/nowinandroid/core/notifications/SystemTrayNotifier.kt
@@ -54,9 +54,7 @@ internal class SystemTrayNotifier @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : Notifier {
 
-    override fun postNewsNotifications(
-        newsResources: List<NewsResource>,
-    ) = with(context) {
+    override fun postNewsNotifications(newsResources: List<NewsResource>) = with(context) {
         if (checkSelfPermission(this, permission.POST_NOTIFICATIONS) != PERMISSION_GRANTED) {
             return
         }
@@ -150,20 +148,19 @@ private fun Context.ensureNotificationChannelExists() {
     NotificationManagerCompat.from(this).createNotificationChannel(channel)
 }
 
-private fun Context.newsPendingIntent(
-    newsResource: NewsResource,
-): PendingIntent? = PendingIntent.getActivity(
-    this,
-    NEWS_NOTIFICATION_REQUEST_CODE,
-    Intent().apply {
-        action = Intent.ACTION_VIEW
-        data = newsResource.newsDeepLinkUri()
-        component = ComponentName(
-            packageName,
-            TARGET_ACTIVITY_NAME,
-        )
-    },
-    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-)
+private fun Context.newsPendingIntent(newsResource: NewsResource): PendingIntent? =
+    PendingIntent.getActivity(
+        this,
+        NEWS_NOTIFICATION_REQUEST_CODE,
+        Intent().apply {
+            action = Intent.ACTION_VIEW
+            data = newsResource.newsDeepLinkUri()
+            component = ComponentName(
+                packageName,
+                TARGET_ACTIVITY_NAME,
+            )
+        },
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+    )
 
 private fun NewsResource.newsDeepLinkUri() = "$DEEP_LINK_SCHEME_AND_HOST/$FOR_YOU_PATH/$id".toUri()

--- a/core/notifications/src/prod/kotlin/com/google/samples/apps/nowinandroid/core/notifications/NotificationsModule.kt
+++ b/core/notifications/src/prod/kotlin/com/google/samples/apps/nowinandroid/core/notifications/NotificationsModule.kt
@@ -25,7 +25,5 @@ import dagger.hilt.components.SingletonComponent
 @InstallIn(SingletonComponent::class)
 internal abstract class NotificationsModule {
     @Binds
-    abstract fun bindNotifier(
-        notifier: SystemTrayNotifier,
-    ): Notifier
+    abstract fun bindNotifier(notifier: SystemTrayNotifier): Notifier
 }

--- a/core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/di/TestDispatcherModule.kt
+++ b/core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/di/TestDispatcherModule.kt
@@ -20,9 +20,9 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/di/TestDispatchersModule.kt
+++ b/core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/di/TestDispatchersModule.kt
@@ -39,7 +39,6 @@ internal object TestDispatchersModule {
 
     @Provides
     @Dispatcher(Default)
-    fun providesDefaultDispatcher(
-        testDispatcher: TestDispatcher,
-    ): CoroutineDispatcher = testDispatcher
+    fun providesDefaultDispatcher(testDispatcher: TestDispatcher): CoroutineDispatcher =
+        testDispatcher
 }

--- a/core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/repository/TestSearchContentsRepository.kt
+++ b/core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/repository/TestSearchContentsRepository.kt
@@ -37,15 +37,19 @@ class TestSearchContentsRepository : SearchContentsRepository {
         combine(cachedTopics, cachedNewsResources) { topics, news ->
             SearchResult(
                 topics = topics.filter {
-                    searchQuery in it.name || searchQuery in it.shortDescription || searchQuery in it.longDescription
+                    searchQuery in it.name ||
+                        searchQuery in it.shortDescription ||
+                        searchQuery in it.longDescription
                 },
                 newsResources = news.filter {
-                    searchQuery in it.content || searchQuery in it.title
+                    searchQuery in it.content ||
+                        searchQuery in it.title
                 },
             )
         }
 
-    override fun getSearchContentsCount(): Flow<Int> = combine(cachedTopics, cachedNewsResources) { topics, news -> topics.size + news.size }
+    override fun getSearchContentsCount(): Flow<Int> =
+        combine(cachedTopics, cachedNewsResources) { topics, news -> topics.size + news.size }
 
     @TestOnly
     fun addTopics(topics: List<Topic>) = cachedTopics.update { it + topics }

--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/JankStatsExtensions.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/JankStatsExtensions.kt
@@ -49,10 +49,7 @@ fun rememberMetricsStateHolder(): Holder {
  * @see TrackDisposableJank if you need to work with DisposableEffect to cleanup added state.
  */
 @Composable
-fun TrackJank(
-    vararg keys: Any,
-    reportMetric: suspend CoroutineScope.(state: Holder) -> Unit,
-) {
+fun TrackJank(vararg keys: Any, reportMetric: suspend CoroutineScope.(state: Holder) -> Unit) {
     val metrics = rememberMetricsStateHolder()
     LaunchedEffect(metrics, *keys) {
         reportMetric(metrics)

--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
@@ -73,7 +73,11 @@ fun LazyStaggeredGridScope.newsFeed(
                         analyticsHelper.logNewsResourceOpened(
                             newsResourceId = userNewsResource.id,
                         )
-                        launchCustomChromeTab(context, Uri.parse(userNewsResource.url), backgroundColor)
+                        launchCustomChromeTab(
+                            context,
+                            Uri.parse(userNewsResource.url),
+                            backgroundColor,
+                        )
 
                         onNewsResourceViewed(userNewsResource.id)
                     },

--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
@@ -66,12 +66,12 @@ import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import com.google.samples.apps.nowinandroid.core.model.data.FollowableTopic
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
 import com.google.samples.apps.nowinandroid.core.model.data.UserNewsResource
-import kotlinx.datetime.Instant
-import kotlinx.datetime.toJavaInstant
-import kotlinx.datetime.toJavaZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Locale
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toJavaInstant
+import kotlinx.datetime.toJavaZoneId
 
 /**
  * [NewsResource] card used on the following screens: For You, Saved
@@ -142,9 +142,7 @@ fun NewsResourceCardExpanded(
 }
 
 @Composable
-fun NewsResourceHeaderImage(
-    headerImageUrl: String?,
-) {
+fun NewsResourceHeaderImage(headerImageUrl: String?) {
     var isLoading by remember { mutableStateOf(true) }
     var isError by remember { mutableStateOf(false) }
     val imageLoader = rememberAsyncImagePainter(
@@ -189,19 +187,12 @@ fun NewsResourceHeaderImage(
 }
 
 @Composable
-fun NewsResourceTitle(
-    newsResourceTitle: String,
-    modifier: Modifier = Modifier,
-) {
+fun NewsResourceTitle(newsResourceTitle: String, modifier: Modifier = Modifier) {
     Text(newsResourceTitle, style = MaterialTheme.typography.headlineSmall, modifier = modifier)
 }
 
 @Composable
-fun BookmarkButton(
-    isBookmarked: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
+fun BookmarkButton(isBookmarked: Boolean, onClick: () -> Unit, modifier: Modifier = Modifier) {
     NiaIconToggleButton(
         checked = isBookmarked,
         onCheckedChange = { onClick() },
@@ -222,10 +213,7 @@ fun BookmarkButton(
 }
 
 @Composable
-fun NotificationDot(
-    color: Color,
-    modifier: Modifier = Modifier,
-) {
+fun NotificationDot(color: Color, modifier: Modifier = Modifier) {
     val description = stringResource(R.string.core_ui_unread_resource_dot_content_description)
     Canvas(
         modifier = modifier
@@ -247,10 +235,7 @@ fun dateFormatted(publishDate: Instant): String = DateTimeFormatter
     .format(publishDate.toJavaInstant())
 
 @Composable
-fun NewsResourceMetaData(
-    publishDate: Instant,
-    resourceType: String,
-) {
+fun NewsResourceMetaData(publishDate: Instant, resourceType: String) {
     val formattedDate = dateFormatted(publishDate)
     Text(
         if (resourceType.isNotBlank()) {
@@ -263,9 +248,7 @@ fun NewsResourceMetaData(
 }
 
 @Composable
-fun NewsResourceShortDescription(
-    newsResourceShortDescription: String,
-) {
+fun NewsResourceShortDescription(newsResourceShortDescription: String) {
     Text(newsResourceShortDescription, style = MaterialTheme.typography.bodyLarge)
 }
 

--- a/feature/bookmarks/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreenTest.kt
+++ b/feature/bookmarks/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreenTest.kt
@@ -36,11 +36,11 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import com.google.samples.apps.nowinandroid.core.testing.data.userNewsResourcesTestData
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 /**
  * UI tests for [BookmarksScreen] composable.

--- a/feature/bookmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModel.kt
+++ b/feature/bookmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModel.kt
@@ -27,13 +27,13 @@ import com.google.samples.apps.nowinandroid.core.model.data.UserNewsResource
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState.Loading
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @HiltViewModel
 class BookmarksViewModel @Inject constructor(

--- a/feature/bookmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/navigation/BookmarksNavigation.kt
+++ b/feature/bookmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/navigation/BookmarksNavigation.kt
@@ -24,7 +24,10 @@ import com.google.samples.apps.nowinandroid.feature.bookmarks.BookmarksRoute
 
 const val BOOKMARKS_ROUTE = "bookmarks_route"
 
-fun NavController.navigateToBookmarks(navOptions: NavOptions) = navigate(BOOKMARKS_ROUTE, navOptions)
+fun NavController.navigateToBookmarks(navOptions: NavOptions) = navigate(
+    BOOKMARKS_ROUTE,
+    navOptions,
+)
 
 fun NavGraphBuilder.bookmarksScreen(
     onTopicClick: (String) -> Unit,

--- a/feature/bookmarks/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModelTest.kt
+++ b/feature/bookmarks/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModelTest.kt
@@ -23,6 +23,8 @@ import com.google.samples.apps.nowinandroid.core.testing.repository.TestUserData
 import com.google.samples.apps.nowinandroid.core.testing.util.MainDispatcherRule
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState.Loading
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState.Success
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -30,8 +32,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
 
 /**
  * To learn more about how this test handles Flows created with stateIn, see

--- a/feature/foryou/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -429,10 +429,7 @@ private fun SingleTopicButton(
 }
 
 @Composable
-fun TopicIcon(
-    imageUrl: String,
-    modifier: Modifier = Modifier,
-) {
+fun TopicIcon(imageUrl: String, modifier: Modifier = Modifier) {
     DynamicAsyncImage(
         placeholder = painterResource(R.drawable.feature_foryou_ic_icon_placeholder),
         imageUrl = imageUrl,
@@ -482,10 +479,7 @@ private fun DeepLinkEffect(
     }
 }
 
-private fun feedItemsSize(
-    feedState: NewsFeedUiState,
-    onboardingUiState: OnboardingUiState,
-): Int {
+private fun feedItemsSize(feedState: NewsFeedUiState, onboardingUiState: OnboardingUiState): Int {
     val feedSize = when (feedState) {
         NewsFeedUiState.Loading -> 0
         is NewsFeedUiState.Success -> feedState.feed.size

--- a/feature/foryou/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouViewModel.kt
+++ b/feature/foryou/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouViewModel.kt
@@ -30,6 +30,7 @@ import com.google.samples.apps.nowinandroid.core.domain.GetFollowableTopicsUseCa
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState
 import com.google.samples.apps.nowinandroid.feature.foryou.navigation.LINKED_NEWS_RESOURCE_ID
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -39,7 +40,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @HiltViewModel
 class ForYouViewModel @Inject constructor(
@@ -147,15 +147,14 @@ class ForYouViewModel @Inject constructor(
     }
 }
 
-private fun AnalyticsHelper.logNewsDeepLinkOpen(newsResourceId: String) =
-    logEvent(
-        AnalyticsEvent(
-            type = "news_deep_link_opened",
-            extras = listOf(
-                Param(
-                    key = LINKED_NEWS_RESOURCE_ID,
-                    value = newsResourceId,
-                ),
+private fun AnalyticsHelper.logNewsDeepLinkOpen(newsResourceId: String) = logEvent(
+    AnalyticsEvent(
+        type = "news_deep_link_opened",
+        extras = listOf(
+            Param(
+                key = LINKED_NEWS_RESOURCE_ID,
+                value = newsResourceId,
             ),
         ),
-    )
+    ),
+)

--- a/feature/foryou/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreenScreenshotTests.kt
+++ b/feature/foryou/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreenScreenshotTests.kt
@@ -31,6 +31,7 @@ import com.google.samples.apps.nowinandroid.feature.foryou.OnboardingUiState.Loa
 import com.google.samples.apps.nowinandroid.feature.foryou.OnboardingUiState.NotShown
 import com.google.samples.apps.nowinandroid.feature.foryou.OnboardingUiState.Shown
 import dagger.hilt.android.testing.HiltTestApplication
+import java.util.TimeZone
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -39,7 +40,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 import org.robolectric.annotation.LooperMode
-import java.util.TimeZone
 
 /**
  * Screenshot tests for the [ForYouScreen].

--- a/feature/foryou/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouViewModelTest.kt
+++ b/feature/foryou/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouViewModelTest.kt
@@ -35,6 +35,9 @@ import com.google.samples.apps.nowinandroid.core.testing.util.TestAnalyticsHelpe
 import com.google.samples.apps.nowinandroid.core.testing.util.TestSyncManager
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState
 import com.google.samples.apps.nowinandroid.feature.foryou.navigation.LINKED_NEWS_RESOURCE_ID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -45,9 +48,6 @@ import kotlinx.datetime.Instant
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * To learn more about how this test handles Flows created with stateIn, see

--- a/feature/interests/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/interests/InterestsScreenTest.kt
+++ b/feature/interests/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/interests/InterestsScreenTest.kt
@@ -25,13 +25,13 @@ import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import com.google.samples.apps.nowinandroid.core.testing.data.followableTopicTestData
+import com.google.samples.apps.nowinandroid.core.ui.R as CoreUiR
 import com.google.samples.apps.nowinandroid.feature.interests.InterestsScreen
 import com.google.samples.apps.nowinandroid.feature.interests.InterestsUiState
+import com.google.samples.apps.nowinandroid.feature.interests.R as InterestsR
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import com.google.samples.apps.nowinandroid.core.ui.R as CoreUiR
-import com.google.samples.apps.nowinandroid.feature.interests.R as InterestsR
 
 /**
  * UI test for checking the correct behaviour of the Interests screen;

--- a/feature/interests/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/interests/InterestsViewModel.kt
+++ b/feature/interests/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/interests/InterestsViewModel.kt
@@ -25,12 +25,12 @@ import com.google.samples.apps.nowinandroid.core.domain.TopicSortField
 import com.google.samples.apps.nowinandroid.core.model.data.FollowableTopic
 import com.google.samples.apps.nowinandroid.feature.interests.navigation.TOPIC_ID_ARG
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @HiltViewModel
 class InterestsViewModel @Inject constructor(

--- a/feature/interests/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/interests/navigation/InterestsNavigation.kt
+++ b/feature/interests/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/interests/navigation/InterestsNavigation.kt
@@ -37,9 +37,7 @@ fun NavController.navigateToInterests(topicId: String? = null, navOptions: NavOp
     navigate(route, navOptions)
 }
 
-fun NavGraphBuilder.interestsScreen(
-    onTopicClick: (String) -> Unit,
-) {
+fun NavGraphBuilder.interestsScreen(onTopicClick: (String) -> Unit) {
     composable(
         route = INTERESTS_ROUTE,
         arguments = listOf(

--- a/feature/interests/src/test/kotlin/com/google/samples/apps/nowinandroid/interests/InterestsViewModelTest.kt
+++ b/feature/interests/src/test/kotlin/com/google/samples/apps/nowinandroid/interests/InterestsViewModelTest.kt
@@ -26,6 +26,7 @@ import com.google.samples.apps.nowinandroid.core.testing.util.MainDispatcherRule
 import com.google.samples.apps.nowinandroid.feature.interests.InterestsUiState
 import com.google.samples.apps.nowinandroid.feature.interests.InterestsViewModel
 import com.google.samples.apps.nowinandroid.feature.interests.navigation.TOPIC_ID_ARG
+import kotlin.test.assertEquals
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -33,7 +34,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import kotlin.test.assertEquals
 
 /**
  * To learn more about how this test handles Flows created with stateIn, see

--- a/feature/search/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchScreenTest.kt
+++ b/feature/search/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchScreenTest.kt
@@ -70,8 +70,10 @@ class SearchScreenTest {
     @Before
     fun setup() {
         composeTestRule.activity.apply {
-            clearSearchContentDesc = getString(R.string.feature_search_clear_search_text_content_desc)
-            clearRecentSearchesContentDesc = getString(R.string.feature_search_clear_recent_searches_content_desc)
+            clearSearchContentDesc =
+                getString(R.string.feature_search_clear_search_text_content_desc)
+            clearRecentSearchesContentDesc =
+                getString(R.string.feature_search_clear_recent_searches_content_desc)
             followButtonContentDesc =
                 getString(string.core_ui_interests_card_follow_button_content_desc)
             unfollowButtonContentDesc =
@@ -79,7 +81,8 @@ class SearchScreenTest {
             topicsString = getString(R.string.feature_search_topics)
             updatesString = getString(R.string.feature_search_updates)
             tryAnotherSearchString = getString(R.string.feature_search_try_another_search) +
-                " " + getString(R.string.feature_search_interests) + " " + getString(R.string.feature_search_to_browse_topics)
+                " " + getString(R.string.feature_search_interests) +
+                " " + getString(R.string.feature_search_to_browse_topics)
             searchNotReadyString = getString(R.string.feature_search_not_ready)
         }
     }

--- a/feature/search/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
@@ -102,6 +102,7 @@ internal fun SearchRoute(
     modifier: Modifier = Modifier,
     searchViewModel: SearchViewModel = hiltViewModel(),
 ) {
+    @Suppress("ktlint:standard:max-line-length")
     val recentSearchQueriesUiState by searchViewModel.recentSearchQueriesUiState.collectAsStateWithLifecycle()
     val searchResultUiState by searchViewModel.searchResultUiState.collectAsStateWithLifecycle()
     val searchQuery by searchViewModel.searchQuery.collectAsStateWithLifecycle()

--- a/feature/search/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
@@ -180,7 +180,8 @@ internal fun SearchScreen(
                                 onSearchQueryChanged(it)
                                 onSearchTriggered(it)
                             },
-                            recentSearchQueries = recentSearchesUiState.recentQueries.map { it.query },
+                            recentSearchQueries =
+                            recentSearchesUiState.recentQueries.map { it.query },
                         )
                     }
                 } else {
@@ -202,15 +203,13 @@ internal fun SearchScreen(
 }
 
 @Composable
-fun EmptySearchResultBody(
-    searchQuery: String,
-    onInterestsClick: () -> Unit,
-) {
+fun EmptySearchResultBody(searchQuery: String, onInterestsClick: () -> Unit) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier.padding(horizontal = 48.dp),
     ) {
-        val message = stringResource(id = searchR.string.feature_search_result_not_found, searchQuery)
+        val message =
+            stringResource(id = searchR.string.feature_search_result_not_found, searchQuery)
         val start = message.indexOf(searchQuery)
         Text(
             text = AnnotatedString(

--- a/feature/search/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchViewModel.kt
@@ -29,6 +29,7 @@ import com.google.samples.apps.nowinandroid.core.domain.GetRecentSearchQueriesUs
 import com.google.samples.apps.nowinandroid.core.domain.GetSearchContentsUseCase
 import com.google.samples.apps.nowinandroid.core.model.data.UserSearchResult
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
@@ -37,7 +38,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
@@ -133,13 +133,12 @@ class SearchViewModel @Inject constructor(
     }
 }
 
-private fun AnalyticsHelper.logEventSearchTriggered(query: String) =
-    logEvent(
-        event = AnalyticsEvent(
-            type = SEARCH_QUERY,
-            extras = listOf(element = Param(key = SEARCH_QUERY, value = query)),
-        ),
-    )
+private fun AnalyticsHelper.logEventSearchTriggered(query: String) = logEvent(
+    event = AnalyticsEvent(
+        type = SEARCH_QUERY,
+        extras = listOf(element = Param(key = SEARCH_QUERY, value = query)),
+    ),
+)
 
 /** Minimum length where search query is considered as [SearchResultUiState.EmptyQuery] */
 private const val SEARCH_QUERY_MIN_LENGTH = 2

--- a/feature/search/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/navigation/SearchNavigation.kt
+++ b/feature/search/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/navigation/SearchNavigation.kt
@@ -24,7 +24,10 @@ import com.google.samples.apps.nowinandroid.feature.search.SearchRoute
 
 const val SEARCH_ROUTE = "search_route"
 
-fun NavController.navigateToSearch(navOptions: NavOptions? = null) = navigate(SEARCH_ROUTE, navOptions)
+fun NavController.navigateToSearch(navOptions: NavOptions? = null) = navigate(
+    SEARCH_ROUTE,
+    navOptions,
+)
 
 fun NavGraphBuilder.searchScreen(
     onBackClick: () -> Unit,

--- a/feature/search/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchViewModelTest.kt
+++ b/feature/search/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchViewModelTest.kt
@@ -31,6 +31,8 @@ import com.google.samples.apps.nowinandroid.feature.search.RecentSearchQueriesUi
 import com.google.samples.apps.nowinandroid.feature.search.SearchResultUiState.EmptyQuery
 import com.google.samples.apps.nowinandroid.feature.search.SearchResultUiState.Loading
 import com.google.samples.apps.nowinandroid.feature.search.SearchResultUiState.SearchNotReady
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -39,8 +41,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
 
 /**
  * To learn more about how this test handles Flows created with stateIn, see

--- a/feature/settings/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/feature/settings/SettingsDialogTest.kt
+++ b/feature/settings/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/feature/settings/SettingsDialogTest.kt
@@ -71,17 +71,29 @@ class SettingsDialogTest {
         }
 
         // Check that all the possible settings are displayed.
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_brand_default)).assertExists()
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_brand_android)).assertExists()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_brand_default),
+        ).assertExists()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_brand_android),
+        ).assertExists()
         composeTestRule.onNodeWithText(
             getString(R.string.feature_settings_dark_mode_config_system_default),
         ).assertExists()
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_dark_mode_config_light)).assertExists()
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_dark_mode_config_dark)).assertExists()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_dark_mode_config_light),
+        ).assertExists()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_dark_mode_config_dark),
+        ).assertExists()
 
         // Check that the correct settings are selected.
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_brand_android)).assertIsSelected()
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_dark_mode_config_dark)).assertIsSelected()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_brand_android),
+        ).assertIsSelected()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_dark_mode_config_dark),
+        ).assertIsSelected()
     }
 
     @Test
@@ -103,12 +115,20 @@ class SettingsDialogTest {
             )
         }
 
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_dynamic_color_preference)).assertExists()
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_dynamic_color_yes)).assertExists()
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_dynamic_color_no)).assertExists()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_dynamic_color_preference),
+        ).assertExists()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_dynamic_color_yes),
+        ).assertExists()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_dynamic_color_no),
+        ).assertExists()
 
         // Check that the correct default dynamic color setting is selected.
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_dynamic_color_no)).assertIsSelected()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_dynamic_color_no),
+        ).assertIsSelected()
     }
 
     @Test
@@ -129,10 +149,16 @@ class SettingsDialogTest {
             )
         }
 
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_dynamic_color_preference))
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_dynamic_color_preference),
+        )
             .assertDoesNotExist()
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_dynamic_color_yes)).assertDoesNotExist()
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_dynamic_color_no)).assertDoesNotExist()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_dynamic_color_yes),
+        ).assertDoesNotExist()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_dynamic_color_no),
+        ).assertDoesNotExist()
     }
 
     @Test
@@ -153,10 +179,16 @@ class SettingsDialogTest {
             )
         }
 
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_dynamic_color_preference))
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_dynamic_color_preference),
+        )
             .assertDoesNotExist()
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_dynamic_color_yes)).assertDoesNotExist()
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_dynamic_color_no)).assertDoesNotExist()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_dynamic_color_yes),
+        ).assertDoesNotExist()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_dynamic_color_no),
+        ).assertDoesNotExist()
     }
 
     @Test
@@ -177,9 +209,13 @@ class SettingsDialogTest {
             )
         }
 
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_privacy_policy)).assertExists()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_privacy_policy),
+        ).assertExists()
         composeTestRule.onNodeWithText(getString(R.string.feature_settings_licenses)).assertExists()
-        composeTestRule.onNodeWithText(getString(R.string.feature_settings_brand_guidelines)).assertExists()
+        composeTestRule.onNodeWithText(
+            getString(R.string.feature_settings_brand_guidelines),
+        ).assertExists()
         composeTestRule.onNodeWithText(getString(R.string.feature_settings_feedback)).assertExists()
     }
 }

--- a/feature/settings/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/settings/SettingsDialog.kt
+++ b/feature/settings/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/settings/SettingsDialog.kt
@@ -72,10 +72,7 @@ import com.google.samples.apps.nowinandroid.feature.settings.SettingsUiState.Loa
 import com.google.samples.apps.nowinandroid.feature.settings.SettingsUiState.Success
 
 @Composable
-fun SettingsDialog(
-    onDismiss: () -> Unit,
-    viewModel: SettingsViewModel = hiltViewModel(),
-) {
+fun SettingsDialog(onDismiss: () -> Unit, viewModel: SettingsViewModel = hiltViewModel()) {
     val settingsUiState by viewModel.settingsUiState.collectAsStateWithLifecycle()
     SettingsDialog(
         onDismiss = onDismiss,
@@ -177,7 +174,9 @@ private fun ColumnScope.SettingsPanel(
     }
     AnimatedVisibility(visible = settings.brand == DEFAULT && supportDynamicColor) {
         Column {
-            SettingsDialogSectionTitle(text = stringResource(string.feature_settings_dynamic_color_preference))
+            SettingsDialogSectionTitle(
+                text = stringResource(string.feature_settings_dynamic_color_preference),
+            )
             Column(Modifier.selectableGroup()) {
                 SettingsDialogThemeChooserRow(
                     text = stringResource(string.feature_settings_dynamic_color_yes),
@@ -222,11 +221,7 @@ private fun SettingsDialogSectionTitle(text: String) {
 }
 
 @Composable
-fun SettingsDialogThemeChooserRow(
-    text: String,
-    selected: Boolean,
-    onClick: () -> Unit,
-) {
+fun SettingsDialogThemeChooserRow(text: String, selected: Boolean, onClick: () -> Unit) {
     Row(
         Modifier
             .fillMaxWidth()

--- a/feature/settings/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/settings/SettingsViewModel.kt
@@ -24,13 +24,13 @@ import com.google.samples.apps.nowinandroid.core.model.data.ThemeBrand
 import com.google.samples.apps.nowinandroid.feature.settings.SettingsUiState.Loading
 import com.google.samples.apps.nowinandroid.feature.settings.SettingsUiState.Success
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
-import kotlin.time.Duration.Companion.seconds
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(

--- a/feature/settings/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/settings/SettingsViewModelTest.kt
@@ -22,6 +22,7 @@ import com.google.samples.apps.nowinandroid.core.testing.repository.TestUserData
 import com.google.samples.apps.nowinandroid.core.testing.util.MainDispatcherRule
 import com.google.samples.apps.nowinandroid.feature.settings.SettingsUiState.Loading
 import com.google.samples.apps.nowinandroid.feature.settings.SettingsUiState.Success
+import kotlin.test.assertEquals
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -29,7 +30,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import kotlin.test.assertEquals
 
 class SettingsViewModelTest {
 

--- a/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
@@ -172,18 +172,16 @@ internal fun TopicScreen(
     }
 }
 
-private fun topicItemsSize(
-    topicUiState: TopicUiState,
-    newsUiState: NewsUiState,
-) = when (topicUiState) {
-    TopicUiState.Error -> 0 // Nothing
-    TopicUiState.Loading -> 1 // Loading bar
-    is TopicUiState.Success -> when (newsUiState) {
-        NewsUiState.Error -> 0 // Nothing
-        NewsUiState.Loading -> 1 // Loading bar
-        is NewsUiState.Success -> 2 + newsUiState.news.size // Toolbar, header
+private fun topicItemsSize(topicUiState: TopicUiState, newsUiState: NewsUiState) =
+    when (topicUiState) {
+        TopicUiState.Error -> 0 // Nothing
+        TopicUiState.Loading -> 1 // Loading bar
+        is TopicUiState.Success -> when (newsUiState) {
+            NewsUiState.Error -> 0 // Nothing
+            NewsUiState.Loading -> 1 // Loading bar
+            is NewsUiState.Success -> 2 + newsUiState.news.size // Toolbar, header
+        }
     }
-}
 
 private fun LazyListScope.topicBody(
     name: String,

--- a/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModel.kt
@@ -30,6 +30,7 @@ import com.google.samples.apps.nowinandroid.core.result.Result
 import com.google.samples.apps.nowinandroid.core.result.asResult
 import com.google.samples.apps.nowinandroid.feature.topic.navigation.TopicArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -37,7 +38,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @HiltViewModel
 class TopicViewModel @Inject constructor(

--- a/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/navigation/TopicNavigation.kt
+++ b/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/navigation/TopicNavigation.kt
@@ -37,7 +37,9 @@ const val TOPIC_ROUTE = "topic_route"
 
 internal class TopicArgs(val topicId: String) {
     constructor(savedStateHandle: SavedStateHandle) :
-        this(URLDecoder.decode(checkNotNull(savedStateHandle[TOPIC_ID_ARG]), URL_CHARACTER_ENCODING))
+        this(
+            URLDecoder.decode(checkNotNull(savedStateHandle[TOPIC_ID_ARG]), URL_CHARACTER_ENCODING),
+        )
 }
 
 fun NavController.navigateToTopic(topicId: String, navOptions: NavOptionsBuilder.() -> Unit = {}) {

--- a/feature/topic/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModelTest.kt
@@ -26,6 +26,8 @@ import com.google.samples.apps.nowinandroid.core.testing.repository.TestTopicsRe
 import com.google.samples.apps.nowinandroid.core.testing.repository.TestUserDataRepository
 import com.google.samples.apps.nowinandroid.core.testing.util.MainDispatcherRule
 import com.google.samples.apps.nowinandroid.feature.topic.navigation.TOPIC_ID_ARG
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -36,8 +38,6 @@ import kotlinx.datetime.Instant
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
 
 /**
  * To learn more about how this test handles Flows created with stateIn, see

--- a/gradle/init.gradle.kts
+++ b/gradle/init.gradle.kts
@@ -35,11 +35,7 @@ rootProject {
             kotlin {
                 target("**/*.kt")
                 targetExclude("**/build/**/*.kt")
-                ktlint(ktlintVersion).editorConfigOverride(
-                    mapOf(
-                        "android" to "true",
-                    ),
-                )
+                ktlint(ktlintVersion)
                 licenseHeaderFile(rootProject.file("spotless/copyright.kt"))
             }
             format("kts") {

--- a/lint/src/main/kotlin/com/google/samples/apps/nowinandroid/lint/TestMethodNameDetector.kt
+++ b/lint/src/main/kotlin/com/google/samples/apps/nowinandroid/lint/TestMethodNameDetector.kt
@@ -57,10 +57,7 @@ class TestMethodNameDetector : Detector(), SourceCodeScanner {
 
     private fun JavaContext.isAndroidTest() = Path("androidTest") in file.toPath()
 
-    private fun PsiMethod.detectPrefix(
-        context: JavaContext,
-        usageInfo: AnnotationUsageInfo,
-    ) {
+    private fun PsiMethod.detectPrefix(context: JavaContext, usageInfo: AnnotationUsageInfo) {
         if (!name.startsWith("test")) return
         context.report(
             issue = PREFIX,
@@ -76,10 +73,7 @@ class TestMethodNameDetector : Detector(), SourceCodeScanner {
         )
     }
 
-    private fun PsiMethod.detectFormat(
-        context: JavaContext,
-        usageInfo: AnnotationUsageInfo,
-    ) {
+    private fun PsiMethod.detectFormat(context: JavaContext, usageInfo: AnnotationUsageInfo) {
         if (!context.isAndroidTest()) return
         if ("""[^\W_]+(_[^\W_]+){1,2}""".toRegex().matches(name)) return
         context.report(
@@ -92,22 +86,19 @@ class TestMethodNameDetector : Detector(), SourceCodeScanner {
 
     companion object {
 
-        private fun issue(
-            id: String,
-            briefDescription: String,
-            explanation: String,
-        ): Issue = Issue.create(
-            id = id,
-            briefDescription = briefDescription,
-            explanation = explanation,
-            category = TESTING,
-            priority = 5,
-            severity = WARNING,
-            implementation = Implementation(
-                TestMethodNameDetector::class.java,
-                EnumSet.of(JAVA_FILE, TEST_SOURCES),
-            ),
-        )
+        private fun issue(id: String, briefDescription: String, explanation: String): Issue =
+            Issue.create(
+                id = id,
+                briefDescription = briefDescription,
+                explanation = explanation,
+                category = TESTING,
+                priority = 5,
+                severity = WARNING,
+                implementation = Implementation(
+                    TestMethodNameDetector::class.java,
+                    EnumSet.of(JAVA_FILE, TEST_SOURCES),
+                ),
+            )
 
         @JvmField
         val PREFIX: Issue = issue(
@@ -119,8 +110,10 @@ class TestMethodNameDetector : Detector(), SourceCodeScanner {
         @JvmField
         val FORMAT: Issue = issue(
             id = "TestMethodFormat",
-            briefDescription = "Test method does not follow the `given_when_then` or `when_then` format",
-            explanation = "Test method should follow the `given_when_then` or `when_then` format.",
+            briefDescription = "Test method does not follow " +
+                "the `given_when_then` or `when_then` format",
+            explanation = "Test method should follow " +
+                "the `given_when_then` or `when_then` format.",
         )
     }
 }

--- a/sync/sync-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/sync/test/NeverSyncingSyncManager.kt
+++ b/sync/sync-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/sync/test/NeverSyncingSyncManager.kt
@@ -17,9 +17,9 @@
 package com.google.samples.apps.nowinandroid.core.sync.test
 
 import com.google.samples.apps.nowinandroid.core.data.util.SyncManager
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import javax.inject.Inject
 
 internal class NeverSyncingSyncManager @Inject constructor() : SyncManager {
     override val isSyncing: Flow<Boolean> = flowOf(false)

--- a/sync/sync-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/sync/test/TestSyncModule.kt
+++ b/sync/sync-test/src/main/kotlin/com/google/samples/apps/nowinandroid/core/sync/test/TestSyncModule.kt
@@ -30,7 +30,5 @@ import dagger.hilt.testing.TestInstallIn
 )
 internal interface TestSyncModule {
     @Binds
-    fun bindsSyncStatusMonitor(
-        syncStatusMonitor: NeverSyncingSyncManager,
-    ): SyncManager
+    fun bindsSyncStatusMonitor(syncStatusMonitor: NeverSyncingSyncManager): SyncManager
 }

--- a/sync/work/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/sync/workers/SyncWorkerTest.kt
+++ b/sync/work/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/sync/workers/SyncWorkerTest.kt
@@ -25,10 +25,10 @@ import androidx.work.testing.SynchronousExecutor
 import androidx.work.testing.WorkManagerTestInitHelper
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import kotlin.test.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import kotlin.test.assertEquals
 
 @HiltAndroidTest
 class SyncWorkerTest {

--- a/sync/work/src/demo/kotlin/com/google/samples/apps/nowinandroid/sync/di/SyncModule.kt
+++ b/sync/work/src/demo/kotlin/com/google/samples/apps/nowinandroid/sync/di/SyncModule.kt
@@ -34,7 +34,5 @@ abstract class SyncModule {
     ): SyncManager
 
     @Binds
-    internal abstract fun bindsSyncSubscriber(
-        syncSubscriber: StubSyncSubscriber,
-    ): SyncSubscriber
+    internal abstract fun bindsSyncSubscriber(syncSubscriber: StubSyncSubscriber): SyncSubscriber
 }

--- a/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/initializers/SyncWorkHelpers.kt
+++ b/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/initializers/SyncWorkHelpers.kt
@@ -65,7 +65,7 @@ private fun Context.syncWorkNotification(): Notification {
 
         notificationManager?.createNotificationChannel(channel)
     }
-
+    @Suppress("ktlint:standard:max-line-length")
     return NotificationCompat.Builder(
         this,
         SYNC_NOTIFICATION_CHANNEL_ID,

--- a/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/status/WorkManagerSyncManager.kt
+++ b/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/status/WorkManagerSyncManager.kt
@@ -25,10 +25,10 @@ import com.google.samples.apps.nowinandroid.core.data.util.SyncManager
 import com.google.samples.apps.nowinandroid.sync.initializers.SYNC_WORK_NAME
 import com.google.samples.apps.nowinandroid.sync.workers.SyncWorker
 import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 
 /**
  * [SyncManager] backed by [WorkInfo] from [WorkManager]

--- a/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/workers/AnalyticsExtensions.kt
+++ b/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/workers/AnalyticsExtensions.kt
@@ -19,10 +19,9 @@ package com.google.samples.apps.nowinandroid.sync.workers
 import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsEvent
 import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsHelper
 
-internal fun AnalyticsHelper.logSyncStarted() =
-    logEvent(
-        AnalyticsEvent(type = "network_sync_started"),
-    )
+internal fun AnalyticsHelper.logSyncStarted() = logEvent(
+    AnalyticsEvent(type = "network_sync_started"),
+)
 
 internal fun AnalyticsHelper.logSyncFinished(syncedSuccessfully: Boolean) {
     val eventType = if (syncedSuccessfully) "network_sync_successful" else "network_sync_failed"

--- a/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/workers/DelegatingWorker.kt
+++ b/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/workers/DelegatingWorker.kt
@@ -43,10 +43,9 @@ private const val WORKER_CLASS_NAME = "RouterWorkerDelegateClassName"
  * Adds metadata to a WorkRequest to identify what [CoroutineWorker] the [DelegatingWorker] should
  * delegate to
  */
-internal fun KClass<out CoroutineWorker>.delegatedData() =
-    Data.Builder()
-        .putString(WORKER_CLASS_NAME, qualifiedName)
-        .build()
+internal fun KClass<out CoroutineWorker>.delegatedData() = Data.Builder()
+    .putString(WORKER_CLASS_NAME, qualifiedName)
+    .build()
 
 /**
  * A worker that delegates sync to another [CoroutineWorker] constructed with a [HiltWorkerFactory].
@@ -72,9 +71,7 @@ class DelegatingWorker(
             as? CoroutineWorker
             ?: throw IllegalArgumentException("Unable to find appropriate worker")
 
-    override suspend fun getForegroundInfo(): ForegroundInfo =
-        delegateWorker.getForegroundInfo()
+    override suspend fun getForegroundInfo(): ForegroundInfo = delegateWorker.getForegroundInfo()
 
-    override suspend fun doWork(): Result =
-        delegateWorker.doWork()
+    override suspend fun doWork(): Result = delegateWorker.doWork()
 }

--- a/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/workers/SyncWorker.kt
+++ b/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/workers/SyncWorker.kt
@@ -60,8 +60,7 @@ internal class SyncWorker @AssistedInject constructor(
     private val syncSubscriber: SyncSubscriber,
 ) : CoroutineWorker(appContext, workerParams), Synchronizer {
 
-    override suspend fun getForegroundInfo(): ForegroundInfo =
-        appContext.syncForegroundInfo()
+    override suspend fun getForegroundInfo(): ForegroundInfo = appContext.syncForegroundInfo()
 
     override suspend fun doWork(): Result = withContext(ioDispatcher) {
         traceAsync("Sync", 0) {

--- a/sync/work/src/prod/kotlin/com/google/samples/apps/nowinandroid/sync/status/FirebaseSyncSubscriber.kt
+++ b/sync/work/src/prod/kotlin/com/google/samples/apps/nowinandroid/sync/status/FirebaseSyncSubscriber.kt
@@ -18,8 +18,8 @@ package com.google.samples.apps.nowinandroid.sync.status
 
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.samples.apps.nowinandroid.sync.initializers.SYNC_TOPIC
-import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
+import kotlinx.coroutines.tasks.await
 
 /**
  * Implementation of [SyncSubscriber] that subscribes to the FCM [SYNC_TOPIC]


### PR DESCRIPTION
**What I have done and why**

_Include a summary of what your pull request contains, and why you have made these changes._
Move editorConfigOverride  to editorconfig.
Set ktlint_code_style ```android_studio``` [link](https://pinterest.github.io/ktlint/1.2.1/rules/code-styles/)
Add ```root=true``` in ```.editorconfig```. [link](https://editorconfig.org/)
> root: special property that should be specified at the top of the file outside of any sections. Set to true to stop .editorconfig files search on current file.

Need to discussion about:
- rule: standard:max-line-length
- import alphabetic ordering

Android Studio style ```ktlint``` was set max-line-length(100) and alphabetic ordering imports as default value.
If you don't agree with these two rules.
Kindly leave your comment.

If it is fine, merge it!

**How I'm testing it**

_Choose at least one:_
- Unit tests
- UI tests
- Screenshot tests
- [x]  N/A _(provide justification)_


