### PR TITLE
Optimize recomposition in NavHost using remember

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/navigation/NiaNavHost.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/navigation/NiaNavHost.kt
@@ -17,6 +17,7 @@
 package com.google.samples.apps.nowinandroid.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import com.google.samples.apps.nowinandroid.feature.bookmarks.navigation.bookmarksScreen
@@ -43,20 +44,24 @@ fun NiaNavHost(
     startDestination: String = FOR_YOU_ROUTE,
 ) {
     val navController = appState.navController
+    val onTopicClick: (String) -> Unit = remember(navController) {
+        return@remember navController::navigateToInterests
+    }
+
     NavHost(
         navController = navController,
         startDestination = startDestination,
         modifier = modifier,
     ) {
-        forYouScreen(onTopicClick = navController::navigateToInterests)
+        forYouScreen(onTopicClick)
         bookmarksScreen(
-            onTopicClick = navController::navigateToInterests,
+            onTopicClick = onTopicClick,
             onShowSnackbar = onShowSnackbar,
         )
         searchScreen(
             onBackClick = navController::popBackStack,
             onInterestsClick = { appState.navigateToTopLevelDestination(INTERESTS) },
-            onTopicClick = navController::navigateToInterests,
+            onTopicClick = onTopicClick,
         )
         interestsListDetailScreen()
     }

--- a/feature/interests/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/interests/navigation/InterestsNavigation.kt
+++ b/feature/interests/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/interests/navigation/InterestsNavigation.kt
@@ -37,6 +37,15 @@ fun NavController.navigateToInterests(topicId: String? = null, navOptions: NavOp
     navigate(route, navOptions)
 }
 
+fun NavController.navigateToInterests(topicId: String? = null) {
+    val route = if (topicId != null) {
+        "${INTERESTS_ROUTE_BASE}?${TOPIC_ID_ARG}=$topicId"
+    } else {
+        INTERESTS_ROUTE_BASE
+    }
+    navigate(route, null)
+}
+
 fun NavGraphBuilder.interestsScreen(
     onTopicClick: (String) -> Unit,
 ) {


### PR DESCRIPTION
_Thanks for submitting a pull request. Please include the following information._

**What I have done and why**
Implemented remember for lambda expressions in NiaNavHost to reduce unnecessary recompositions, addressing issue #1353. This optimization minimizes performance overhead caused by state changes unrelated to navigation.


Fixes #1353 

**How I'm testing it**

_Choose at least one:_
- Unit tests
- UI tests

**Do tests pass?**
- [x] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [x] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`

**Is this your first pull request?**
- [x] [Sign the CLA](https://cla.developers.google.com/)
- [x] Run `./tools/setup.sh`
- [x] Import the code formatting style as explained in [the setup script](/tools/setup.sh#L40).


