### PR TITLE
Offload connectivity monitor to a background thread

### DIFF
--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
@@ -26,7 +26,6 @@ import android.net.NetworkRequest.Builder
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import androidx.core.content.getSystemService
-import androidx.tracing.Trace
 import androidx.tracing.trace
 import com.google.samples.apps.nowinandroid.core.network.Dispatcher
 import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.IO
@@ -82,8 +81,6 @@ internal class ConnectivityManagerNetworkMonitor @Inject constructor(
              * Sends the latest connectivity status to the underlying channel.
              */
             channel.trySend(connectivityManager.isCurrentlyConnected())
-
-            Trace.endSection()
 
             awaitClose {
                 connectivityManager.unregisterNetworkCallback(callback)

--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
@@ -26,57 +26,71 @@ import android.net.NetworkRequest.Builder
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import androidx.core.content.getSystemService
+import androidx.tracing.Trace
+import androidx.tracing.trace
+import com.google.samples.apps.nowinandroid.core.network.Dispatcher
+import com.google.samples.apps.nowinandroid.core.network.NiaDispatchers.IO
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 internal class ConnectivityManagerNetworkMonitor @Inject constructor(
     @ApplicationContext private val context: Context,
+    @Dispatcher(IO) private val ioDispatcher: CoroutineDispatcher,
 ) : NetworkMonitor {
     override val isOnline: Flow<Boolean> = callbackFlow {
-        val connectivityManager = context.getSystemService<ConnectivityManager>()
-        if (connectivityManager == null) {
-            channel.trySend(false)
-            channel.close()
-            return@callbackFlow
-        }
-
-        /**
-         * The callback's methods are invoked on changes to *any* network matching the [NetworkRequest],
-         * not just the active network. So we can simply track the presence (or absence) of such [Network].
-         */
-        val callback = object : NetworkCallback() {
-
-            private val networks = mutableSetOf<Network>()
-
-            override fun onAvailable(network: Network) {
-                networks += network
-                channel.trySend(true)
+        trace("NetworkMonitor.callbackFlow") {
+            val connectivityManager = context.getSystemService<ConnectivityManager>()
+            if (connectivityManager == null) {
+                channel.trySend(false)
+                channel.close()
+                return@callbackFlow
             }
 
-            override fun onLost(network: Network) {
-                networks -= network
-                channel.trySend(networks.isNotEmpty())
+            /**
+             * The callback's methods are invoked on changes to *any* network matching the [NetworkRequest],
+             * not just the active network. So we can simply track the presence (or absence) of such [Network].
+             */
+            val callback = object : NetworkCallback() {
+
+                private val networks = mutableSetOf<Network>()
+
+                override fun onAvailable(network: Network) {
+                    networks += network
+                    channel.trySend(true)
+                }
+
+                override fun onLost(network: Network) {
+                    networks -= network
+                    channel.trySend(networks.isNotEmpty())
+                }
             }
-        }
 
-        val request = Builder()
-            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-            .build()
-        connectivityManager.registerNetworkCallback(request, callback)
+            trace("NetworkMonitor.registerNetworkCallback") {
+                val request = Builder()
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .build()
+                connectivityManager.registerNetworkCallback(request, callback)
+            }
 
-        /**
-         * Sends the latest connectivity status to the underlying channel.
-         */
-        channel.trySend(connectivityManager.isCurrentlyConnected())
+            /**
+             * Sends the latest connectivity status to the underlying channel.
+             */
+            channel.trySend(connectivityManager.isCurrentlyConnected())
 
-        awaitClose {
-            connectivityManager.unregisterNetworkCallback(callback)
+            Trace.endSection()
+
+            awaitClose {
+                connectivityManager.unregisterNetworkCallback(callback)
+            }
         }
     }
+        .flowOn(ioDispatcher)
         .conflate()
 
     @Suppress("DEPRECATION")


### PR DESCRIPTION
**What I have done and why**

Moved the `ConnectivityManagerNetworkMonitor` to a background thread to prevent blocking main thread by ~5ms during startup.

![image](https://github.com/android/nowinandroid/assets/3973717/58783f60-57b6-4095-a087-f57993ba8aa9)

**How I'm testing it**

**Do tests pass?**
- [x] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [x] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`