### PR TITLE
Fix: keyboard visible even after search screen is dismissed

### DIFF
--- a/feature/search/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchScreen.kt
@@ -443,11 +443,17 @@ private fun SearchToolbar(
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier.fillMaxWidth(),
     ) {
-        IconButton(onClick = { onBackClick() }) {
+        IconButton(
+            onClick = {
+                keyboardController?.hide()
+                onBackClick()
+            },
+        ) {
             Icon(
                 imageVector = NiaIcons.ArrowBack,
                 contentDescription = stringResource(


### PR DESCRIPTION
**What I have done and why**

![image](https://github.com/android/nowinandroid/assets/62199728/6478b50a-5f45-4974-b45a-5d97be4dc98d)


while navigating back to any of main tabs [ for you, saved, interest ] from seach screen
by clicking back icon button on top left, keyboard not hidden even after search screen fade out






[keyboardjump1.webm](https://github.com/android/nowinandroid/assets/62199728/9e4f4408-ef8b-4700-a242-67f4eef92b9c)

[keyboardjumping3.webm](https://github.com/android/nowinandroid/assets/62199728/204c3303-31b9-4492-9f13-f0dcae176d0c)
