### PR TITLE
Enable strong skipping

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidCompose.kt
@@ -57,6 +57,7 @@ internal fun Project.configureAndroidCompose(
         kotlinOptions {
             freeCompilerArgs += buildComposeMetricsParameters() 
             freeCompilerArgs += stabilityConfiguration()
+            freeCompilerArgs += strongSkippingConfiguration()
         }
     }
 }
@@ -84,10 +85,16 @@ private fun Project.buildComposeMetricsParameters(): List<String> {
             "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" + reportsFolder.absolutePath
         )
     }
+
     return metricParameters.toList()
 }
 
 private fun Project.stabilityConfiguration() = listOf(
     "-P",
     "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=${project.rootDir.absolutePath}/compose_compiler_config.conf",
+)
+
+private fun Project.strongSkippingConfiguration() = listOf(
+    "-P",
+    "plugin:androidx.compose.compiler.plugins.kotlin:experimentalStrongSkipping=true",
 )

--- a/compose_compiler_config.conf
+++ b/compose_compiler_config.conf
@@ -2,5 +2,10 @@
 // It allows us to define classes that our not part of our codebase without wrapping them in a stable class.
 // For more information, check https://developer.android.com/jetpack/compose/performance/stability/fix#configuration-file
 
+// We always use immutable classes for our data model, to avoid running the Compose compiler
+// in the module we declare it to be stable here.
+com.google.samples.apps.nowinandroid.core.model.data.*
+
+// Java standard library classes
 java.time.ZoneId
 java.time.ZoneOffset


### PR DESCRIPTION
**What I have done and why**

Enabled [strong skipping mode](https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/compiler/design/strong-skipping.md) in the Compose compiler. This mode is no longer experimental (it is renamed in the next release with no changes) and so the timing seemed right to enable it here.

I have also marked the entire data module as stable. An alternative to this would be to run the Compose compiler on the data module. Both options are fine, I decided to go with the stability config because it was already set up in the project. The effect of this is minimal, but it did improve the recomposition behaviour of bookmarking at item on the ForYou screen. Previously this would recompose every item, now only the row that is bookmarked is recomposed.

Fixes #1353

**How I'm testing it**
Unit tests
Performance Benchmarks

_Benchmark 1 - Interest Screen - Toggle Topic_
| No Strong Skipping | P50 | P90 | P95 | P99 |
| ---------------- | ---- | ---- | ---- | ---- |
| frameDurationCpuMs | 3.84 | 10.2 | 11.13 | 13.23 |

| With Strong Skipping | P50 | P90 | P95 | P99 |
| ---------------- | ---- | ---- | ---- | ---- |
| frameDurationCpuMs | 3.8 (+1%) | 7.72 (-24.3%) | 8.89 (-20.1%) | 11.91 (-10%) |

