### PR TITLE
add internal keyword to SettingsDialog

### DIFF
--- a/feature/settings/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/settings/SettingsDialog.kt
+++ b/feature/settings/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/settings/SettingsDialog.kt
@@ -87,7 +87,7 @@ fun SettingsDialog(
 }
 
 @Composable
-fun SettingsDialog(
+internal fun SettingsDialog(
     settingsUiState: SettingsUiState,
     supportDynamicColor: Boolean = supportsDynamicTheming(),
     onDismiss: () -> Unit,


### PR DESCRIPTION
_Thanks for submitting a pull request. Please include the following information._

**What I have done and why**

The Internal keyword was added to settingDialog, which is only referenced inside the module.
It seems there is no need to use it externally.

**How I'm testing it**

I simply built and ran it.

**Do tests pass?**
- [x] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [x] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`

**Is this your first pull request?**
- [x] [Sign the CLA](https://cla.developers.google.com/)
- [x] Run `./tools/setup.sh`
- [x] Import the code formatting style as explained in [the setup script](/tools/setup.sh#L40).


