### PR TITLE
improve BookmarksViewModelTest coverage

### DIFF
--- a/feature/bookmarks/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModelTest.kt
+++ b/feature/bookmarks/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModelTest.kt
@@ -113,7 +113,7 @@ class BookmarksViewModelTest {
 
     @Test
     fun feedUiState_undoneBookmarkRemoval_bookmarkIsRestored() = runTest {
-        launch(UnconfinedTestDispatcher()) { viewModel.feedUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.feedUiState.collect() }
 
         // Given
         newsRepository.sendNewsResources(newsResourcesTestData)

--- a/feature/bookmarks/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModelTest.kt
+++ b/feature/bookmarks/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModelTest.kt
@@ -92,15 +92,15 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenResourceViewed_setResourcesViewed() = runTest {
+    fun feedUiState_resourceIsViewed_setResourcesViewed() = runTest {
         val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.feedUiState.collect() }
 
-        // Give
+        // Given
         newsRepository.sendNewsResources(newsResourcesTestData)
         userDataRepository.setNewsResourceBookmarked(newsResourcesTestData[0].id, true)
         val itemBeforeViewed = viewModel.feedUiState.value
-        check(itemBeforeViewed is Success)
-        check(!itemBeforeViewed.feed.first().hasBeenViewed)
+        assertIs<Success>(itemBeforeViewed)
+        assertFalse(itemBeforeViewed.feed.first().hasBeenViewed)
 
         // When
         viewModel.setNewsResourceViewed(newsResourcesTestData[0].id, true)
@@ -114,17 +114,17 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenUndoBookmarkRemoval_thenBookmarkIsRestored() = runTest {
+    fun feedUiState_undoneBookmarkRemoval_bookmarkIsRestored() = runTest {
         val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.feedUiState.collect() }
 
-        // Give
+        // Given
         newsRepository.sendNewsResources(newsResourcesTestData)
         userDataRepository.setNewsResourceBookmarked(newsResourcesTestData[0].id, true)
         viewModel.removeFromSavedResources(newsResourcesTestData[0].id)
-        check(viewModel.shouldDisplayUndoBookmark)
+        assertTrue(viewModel.shouldDisplayUndoBookmark)
         val itemBeforeUndo = viewModel.feedUiState.value
-        check(itemBeforeUndo is Success)
-        check(itemBeforeUndo.feed.isEmpty())
+        assertIs<Success>(itemBeforeUndo)
+        assertEquals(0, itemBeforeUndo.feed.size)
 
         // When
         viewModel.undoBookmarkRemoval()
@@ -133,7 +133,7 @@ class BookmarksViewModelTest {
         assertFalse(viewModel.shouldDisplayUndoBookmark)
         val item = viewModel.feedUiState.value
         assertIs<Success>(item)
-        assertEquals(item.feed.size, 1)
+        assertEquals(1, item.feed.size)
 
         collectJob.cancel()
     }

--- a/feature/bookmarks/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModelTest.kt
+++ b/feature/bookmarks/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModelTest.kt
@@ -93,7 +93,7 @@ class BookmarksViewModelTest {
 
     @Test
     fun feedUiState_resourceIsViewed_setResourcesViewed() = runTest {
-        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.feedUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.feedUiState.collect() }
 
         // Given
         newsRepository.sendNewsResources(newsResourcesTestData)
@@ -109,13 +109,11 @@ class BookmarksViewModelTest {
         val item = viewModel.feedUiState.value
         assertIs<Success>(item)
         assertTrue(item.feed.first().hasBeenViewed)
-
-        collectJob.cancel()
     }
 
     @Test
     fun feedUiState_undoneBookmarkRemoval_bookmarkIsRestored() = runTest {
-        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.feedUiState.collect() }
+        launch(UnconfinedTestDispatcher()) { viewModel.feedUiState.collect() }
 
         // Given
         newsRepository.sendNewsResources(newsResourcesTestData)
@@ -134,7 +132,5 @@ class BookmarksViewModelTest {
         val item = viewModel.feedUiState.value
         assertIs<Success>(item)
         assertEquals(1, item.feed.size)
-
-        collectJob.cancel()
     }
 }

--- a/feature/bookmarks/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModelTest.kt
+++ b/feature/bookmarks/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModelTest.kt
@@ -31,7 +31,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 /**
  * To learn more about how this test handles Flows created with stateIn, see
@@ -86,5 +88,53 @@ class BookmarksViewModelTest {
         val item = viewModel.feedUiState.value
         assertIs<Success>(item)
         assertEquals(item.feed.size, 0)
+        assertTrue(viewModel.shouldDisplayUndoBookmark)
+    }
+
+    @Test
+    fun whenResourceViewed_setResourcesViewed() = runTest {
+        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.feedUiState.collect() }
+
+        // Give
+        newsRepository.sendNewsResources(newsResourcesTestData)
+        userDataRepository.setNewsResourceBookmarked(newsResourcesTestData[0].id, true)
+        val itemBeforeViewed = viewModel.feedUiState.value
+        check(itemBeforeViewed is Success)
+        check(!itemBeforeViewed.feed.first().hasBeenViewed)
+
+        // When
+        viewModel.setNewsResourceViewed(newsResourcesTestData[0].id, true)
+
+        // Then
+        val item = viewModel.feedUiState.value
+        assertIs<Success>(item)
+        assertTrue(item.feed.first().hasBeenViewed)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun whenUndoBookmarkRemoval_thenBookmarkIsRestored() = runTest {
+        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.feedUiState.collect() }
+
+        // Give
+        newsRepository.sendNewsResources(newsResourcesTestData)
+        userDataRepository.setNewsResourceBookmarked(newsResourcesTestData[0].id, true)
+        viewModel.removeFromSavedResources(newsResourcesTestData[0].id)
+        check(viewModel.shouldDisplayUndoBookmark)
+        val itemBeforeUndo = viewModel.feedUiState.value
+        check(itemBeforeUndo is Success)
+        check(itemBeforeUndo.feed.isEmpty())
+
+        // When
+        viewModel.undoBookmarkRemoval()
+
+        // Then
+        assertFalse(viewModel.shouldDisplayUndoBookmark)
+        val item = viewModel.feedUiState.value
+        assertIs<Success>(item)
+        assertEquals(item.feed.size, 1)
+
+        collectJob.cancel()
     }
 }


### PR DESCRIPTION
**What I have done and why**
- Improve coverage of BookmarksViewModel
- Add test for `setNewsResourceViewed` method and `undoBookmarkRemoval` method


Fixes #1333

**How I'm testing it**
- Unit tests

**Do tests pass?**
- [ ] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [x] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`

Screenshot test is failed. But new tests pass.

**Is this your first pull request?**
- [x] [Sign the CLA](https://cla.developers.google.com/)
- [x] Run `./tools/setup.sh`
- [x] Import the code formatting style as explained in [the setup script](/tools/setup.sh#L40).
