### PR TITLE
Change `kotlinOptions` to `compilerOptions`

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -29,8 +30,8 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidCompose.kt
@@ -54,10 +54,10 @@ internal fun Project.configureAndroidCompose(
     }
 
     tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            freeCompilerArgs += buildComposeMetricsParameters() 
-            freeCompilerArgs += stabilityConfiguration()
-            freeCompilerArgs += strongSkippingConfiguration()
+        compilerOptions {
+            freeCompilerArgs.addAll(buildComposeMetricsParameters())
+            freeCompilerArgs.addAll(stabilityConfiguration())
+            freeCompilerArgs.addAll(strongSkippingConfiguration())
         }
     }
 }

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
@@ -24,6 +24,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**
@@ -75,17 +76,16 @@ internal fun Project.configureKotlinJvm() {
 private fun Project.configureKotlin() {
     // Use withType to workaround https://youtrack.jetbrains.com/issue/KT-55947
     tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
+        compilerOptions {
             // Set JVM target to 11
-            jvmTarget = JavaVersion.VERSION_11.toString()
+            jvmTarget.set(JVM_11)
             // Treat all Kotlin warnings as errors (disabled by default)
             // Override by setting warningsAsErrors=true in your ~/.gradle/gradle.properties
             val warningsAsErrors: String? by project
-            allWarningsAsErrors = warningsAsErrors.toBoolean()
-            freeCompilerArgs = freeCompilerArgs + listOf(
-                // Enable experimental coroutines APIs, including Flow
-                "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-            )
+            allWarningsAsErrors.set(warningsAsErrors.toBoolean())
+
+            // Enable experimental coroutines APIs, including Flow
+            freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
         }
     }
 }

--- a/lint/build.gradle.kts
+++ b/lint/build.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -30,8 +31,8 @@ java {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+    compilerOptions {
+        jvmTarget.set(JVM_11)
     }
 }
 


### PR DESCRIPTION
**What I have done and why**

`KotlinOptions` shows type as `KotlinJvmOptionsDeprecated`
![image](https://github.com/android/nowinandroid/assets/48680511/8c397934-6cbc-4489-b501-9ed56c85a227)

Then in Kotlin 1.9.0, `compilerOptions` have been added.
- Added Kotlin 1.9.0 [here](https://kotlinlang.org/docs/whatsnew19.html#project-level-compiler-options-for-kotlin-jvm)
> Starting with Kotlin 1.9.0, a new compilerOptions block is available inside the kotlin configuration block:



**How I'm testing it**

_Choose at least one:_
- Unit tests
- UI tests
- Screenshot tests
- N/A _(provide justification)_

