### PR TITLE
Update `SyncWorker` to show notifications for foreground service

### DIFF
--- a/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/workers/SyncWorker.kt
+++ b/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/workers/SyncWorker.kt
@@ -67,6 +67,7 @@ internal class SyncWorker @AssistedInject constructor(
         traceAsync("Sync", 0) {
             analyticsHelper.logSyncStarted()
 
+            setForeground(getForegroundInfo())
             syncSubscriber.subscribe()
 
             // First sync the repositories in parallel


### PR DESCRIPTION
**What I have done and why**

Fix to ensure notifications are visible for foreground synchronization of Topic and News Data.