### PR TITLE
Navigation to InterestScreen from SearchScreen fixed

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/navigation/NiaNavHost.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/navigation/NiaNavHost.kt
@@ -55,7 +55,10 @@ fun NiaNavHost(
         )
         searchScreen(
             onBackClick = navController::popBackStack,
-            onInterestsClick = { appState.navigateToTopLevelDestination(INTERESTS) },
+            onInterestsClick = {
+                appState.navController.popBackStack()
+                appState.navigateToTopLevelDestination(INTERESTS)
+                               },
             onTopicClick = navController::navigateToInterests,
         )
         interestsListDetailScreen()


### PR DESCRIPTION
When users open the search in the Interest screen and search for a non-existing item, they can navigate back to the Interest screen by clicking on "Interests" in the Search screen

_Thanks for submitting a pull request. Please include the following information._

**What I have done and why**
When users open the search in the Interest screen and search for a non-existing item, they can navigate back to the Interest screen by clicking on "Interests" in the Search screen. Before that Interests was navigating back to the interest screen

I used popBackStack() function in onInterestClick(). This will navigate back by removing the search screen from the back of the stack  and then navigation to the Interest screen.

Fixes #<1372>

**How I'm testing it**

_Choose at least one:_
- UI tests


**Do tests pass?**
- [ ] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [ ] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`

**Is this your first pull request?**
- [ ] [Sign the CLA](https://cla.developers.google.com/)
- [ ] Run `./tools/setup.sh`
- [ ] Import the code formatting style as explained in [the setup script](/tools/setup.sh#L40).


