### PR TITLE
Fix state loss with workaround

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -201,13 +201,13 @@ internal fun NiaApp(
                 }
 
                 Box(
-                    modifier = if (shouldShowTopAppBar) {
-                        Modifier.consumeWindowInsets(
-                            WindowInsets.safeDrawing.only(WindowInsetsSides.Top),
-                        )
-                    } else {
-                        Modifier
-                    },
+                    modifier = Modifier.consumeWindowInsets(
+                        if (shouldShowTopAppBar) {
+                            WindowInsets.safeDrawing.only(WindowInsetsSides.Top)
+                        } else {
+                            WindowInsets(0, 0, 0, 0)
+                        },
+                    ),
                 ) {
                     NiaNavHost(
                         appState = appState,

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -201,6 +201,7 @@ internal fun NiaApp(
                 }
 
                 Box(
+                    // Workaround for https://issuetracker.google.com/338478720
                     modifier = Modifier.consumeWindowInsets(
                         if (shouldShowTopAppBar) {
                             WindowInsets.safeDrawing.only(WindowInsetsSides.Top)


### PR DESCRIPTION
This is a continuation of #1383 .

After merging #1380 , the state loss issue appeared again that is due to https://issuetracker.google.com/338478720

This additional workaround doesn't change behavior the direct behavior of consuming insets (and shouldn't have any difference overall) but avoids the state loss issue again.