### PR TITLE
Fix reversed follow/unfollow states in InterestsItem-ToggleButton

### DIFF
--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/InterestsItem.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/InterestsItem.kt
@@ -70,7 +70,7 @@ fun InterestsItem(
                     Icon(
                         imageVector = NiaIcons.Add,
                         contentDescription = stringResource(
-                            id = string.core_ui_interests_card_follow_button_content_desc,
+                            id = string.core_ui_interests_card_unfollow_button_content_desc,
                         ),
                     )
                 },
@@ -78,7 +78,7 @@ fun InterestsItem(
                     Icon(
                         imageVector = NiaIcons.Check,
                         contentDescription = stringResource(
-                            id = string.core_ui_interests_card_unfollow_button_content_desc,
+                            id = string.core_ui_interests_card_follow_button_content_desc,
                         ),
                     )
                 },

--- a/feature/interests/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/interests/InterestsScreenTest.kt
+++ b/feature/interests/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/interests/InterestsScreenTest.kt
@@ -93,7 +93,7 @@ class InterestsScreenTest {
             .assertIsDisplayed()
 
         composeTestRule
-            .onAllNodesWithContentDescription(interestsTopicCardFollowButton)
+            .onAllNodesWithContentDescription(interestsTopicCardUnfollowButton)
             .assertCountEquals(numberOfUnfollowedTopics)
     }
 

--- a/feature/search/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchScreenTest.kt
+++ b/feature/search/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchScreenTest.kt
@@ -157,10 +157,10 @@ class SearchScreenTest {
 
         composeTestRule
             .onAllNodesWithContentDescription(followButtonContentDesc)
-            .assertCountEquals(2)
+            .assertCountEquals(1)
         composeTestRule
             .onAllNodesWithContentDescription(unfollowButtonContentDesc)
-            .assertCountEquals(1)
+            .assertCountEquals(2)
     }
 
     @Test


### PR DESCRIPTION
During the UI test review, I found that the follow and unfollow states in the `contentDescription` of the `InterestsItem-ToggleButton` were reversed, so I corrected them.

