### PR TITLE
Remove `isReturnDefaultValues` to debug easy.

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -25,7 +25,6 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
-            isReturnDefaultValues = true
         }
     }
 }

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -25,11 +25,6 @@ android {
         consumerProguardFiles("consumer-proguard-rules.pro")
     }
     namespace = "com.google.samples.apps.nowinandroid.core.datastore"
-    testOptions {
-        unitTests {
-            isReturnDefaultValues = true
-        }
-    }
 }
 
 dependencies {


### PR DESCRIPTION
**What I have done and why**

This project seems doesn't need to use `isReturnDefaultValues`.
All test had been passed as no used `isReturnDefaultValues`.
`isReturnDefaultValues` is not recommended to use, because it made hard to debug. [documentation](https://developer.android.com/training/testing/local-tests#error)
> [!Caution]
>Take care when setting the returnDefaultValues property to true. The null/zero return values can introduce regressions to your tests, which are hard to debug and might allow failing tests to pass. Only use it as a last resort.