### PR TITLE
Issue #1272 rewrote it.enableAndroidTest to it.androidTest.enable

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidInstrumentedTests.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidInstrumentedTests.kt
@@ -30,6 +30,6 @@ import org.gradle.api.Project
 internal fun LibraryAndroidComponentsExtension.disableUnnecessaryAndroidTests(
     project: Project,
 ) = beforeVariants {
-    it.enableAndroidTest = it.enableAndroidTest
+    it.androidTest.enable = it.androidTest.enable
         && project.projectDir.resolve("src/androidTest").exists()
 }


### PR DESCRIPTION
What I have done and why

Just replace `it.enable.AndroidTest = it.enable.AndroidTest ` to `it.androidTest.enable = it.androidTest.enable` in build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidInstrumentedTests.kt due to recent syntax update in Kotlin.

Related issues/PRs:
#1272 