### PR TITLE
Remove the printModulePaths task and read modules direct from settings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,13 +49,3 @@ plugins {
     alias(libs.plugins.room) apply false
     alias(libs.plugins.module.graph) apply true // Plugin applied to allow module graph generation
 }
-
-// Task to print all the module paths in the project e.g. :core:data
-// Used by module graph generator script
-tasks.register("printModulePaths") {
-    subprojects {
-        if (subprojects.size == 0) {
-            println(this.path)
-        }
-    }
-}

--- a/generateModuleGraphs.sh
+++ b/generateModuleGraphs.sh
@@ -31,6 +31,19 @@ then
     exit 1
 fi
 
+# Check for a version of grep which supports Perl regex.
+# On MacOS the OS installed grep doesn't support Perl regex so check for the existence of the
+# GNU version instead which is prefixed with 'g' to distinguish it from the OS installed version.
+    if grep -P "" /dev/null > /dev/null 2>&1; then
+    GREP_COMMAND=grep
+elif command -v ggrep &> /dev/null; then
+    GREP_COMMAND=ggrep
+else
+    echo "You don't have a version of 'grep' installed which supports Perl regular expressions."
+    echo "On MacOS you can install one using Homebrew with the command: 'brew install grep'"
+    exit 1
+fi
+
 # Initialize an array to store excluded modules
 excluded_modules=()
 
@@ -50,7 +63,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Get the module paths
-module_paths=$(./gradlew -q printModulePaths --no-configuration-cache)
+module_paths=$(${GREP_COMMAND} -oP 'include\("\K[^"]+' settings.gradle.kts)
 
 # Ensure the output directory exists
 mkdir -p docs/images/graphs/


### PR DESCRIPTION
**What I have done and why**
I've updated the `generateModuleGraphs.sh` script to remove the dependency on the `printModulePaths` gradle task. This task was unnecessarily run during the gradle configuration phase and has now been removed. Instead, the bash script just reads the module paths direct from `settings.gradle.kts`. 

Also referenced here: https://github.com/android/nowinandroid/pull/1293
