### PR TITLE
Fix Baseline Profile Generate from GMD

### DIFF
--- a/.run/Generate Demo Baseline Profile.run.xml
+++ b/.run/Generate Demo Baseline Profile.run.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
-     Copyright 2022 The Android Open Source Project
+     Copyright 2024 The Android Open Source Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,14 +15,6 @@
      limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <!--
-  Baseline Profiles improve code execution speed by around 30% from the first launch by avoiding
-  interpretation and just-in-time (JIT) compilation steps for included code paths.
-  More information at http://d.android.com/baseline-profiles.
-
-  In this run configuration we leverage rerun parameter that always reruns the requested task regardless of cache.
-  We also leverage enable-display parameter to be able to verify the generator works as intended.
-  -->
   <configuration default="false" name="Generate Demo Baseline Profile" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
       <option name="executionName" />

--- a/.run/Generate Demo Baseline Profile.run.xml
+++ b/.run/Generate Demo Baseline Profile.run.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
      Copyright 2024 The Android Open Source Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,28 +14,41 @@
      limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Generate Demo Baseline Profile" type="GradleRunConfiguration" factoryName="Gradle">
-    <ExternalSystemSettings>
-      <option name="executionName" />
-      <option name="externalProjectPath" value="$PROJECT_DIR$" />
-      <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile" />
-      <option name="taskDescriptions">
-        <list />
-      </option>
-      <option name="taskNames">
-        <list>
-          <option value=":benchmarks:pixel6Api33DemoBenchmarkReleaseAndroidTest" />
-          <option value="--rerun" />
-          <option value="--enable-display" />
-        </list>
-      </option>
-      <option name="vmOptions" />
-    </ExternalSystemSettings>
-    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
-    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-    <DebugAllEnabled>false</DebugAllEnabled>
-    <RunAsTest>false</RunAsTest>
-    <method v="2" />
-  </configuration>
+    <!--
+   Baseline Profiles improve code execution speed by around 30% from the first launch by avoiding
+   interpretation and just-in-time (JIT) compilation steps for included code paths.
+   More information at http://d.android.com/baseline-profiles.
+   In this run configuration we leverage rerun parameter that always reruns the requested task regardless of cache.
+   We also leverage enable-display parameter to be able to verify the generator works as intended.
+   -->
+    <configuration name="Generate Demo Baseline Profile"
+        default="false"
+        factoryName="Gradle"
+        type="GradleRunConfiguration">
+        <ExternalSystemSettings>
+            <option name="executionName" />
+            <option name="externalProjectPath"
+                value="$PROJECT_DIR$" />
+            <option name="externalSystemIdString"
+                value="GRADLE" />
+            <option name="scriptParameters"
+                value="-Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile" />
+            <option name="taskDescriptions">
+                <list />
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value=":benchmarks:pixel6Api33DemoBenchmarkReleaseAndroidTest" />
+                    <option value="--rerun" />
+                    <option value="--enable-display" />
+                </list>
+            </option>
+            <option name="vmOptions" />
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <RunAsTest>false</RunAsTest>
+        <method v="2" />
+    </configuration>
 </component>

--- a/.run/Generate Demo Baseline Profile.run.xml
+++ b/.run/Generate Demo Baseline Profile.run.xml
@@ -36,7 +36,6 @@
         <list>
           <option value=":app:generateDemoReleaseBaselineProfile" />
           <option value="--rerun" />
-          <option value="--enable-display" />
         </list>
       </option>
       <option name="vmOptions" />

--- a/.run/Generate Demo Baseline Profile.run.xml
+++ b/.run/Generate Demo Baseline Profile.run.xml
@@ -16,12 +16,13 @@
 -->
 <component name="ProjectRunConfigurationManager">
   <!--
- Baseline Profiles improve code execution speed by around 30% from the first launch by avoiding
- interpretation and just-in-time (JIT) compilation steps for included code paths.
- More information at http://d.android.com/baseline-profiles.
- In this run configuration we leverage rerun parameter that always reruns the requested task regardless of cache.
- We also leverage enable-display parameter to be able to verify the generator works as intended.
- -->
+      Baseline Profiles improve code execution speed by around 30% from the first launch by avoiding
+      interpretation and just-in-time (JIT) compilation steps for included code paths.
+      More information at http://d.android.com/baseline-profiles.
+
+      In this run configuration we leverage rerun parameter that always reruns the requested task regardless of cache.
+      We also leverage enable-display parameter to be able to verify the generator works as intended.
+  -->
   <configuration default="false" name="Generate Demo Baseline Profile" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
       <option name="executionName" />

--- a/.run/Generate Demo Baseline Profile.run.xml
+++ b/.run/Generate Demo Baseline Profile.run.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
      Copyright 2022 The Android Open Source Project
 
@@ -34,7 +33,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value=":benchmark:pixel6Api31atdDemoBenchmarkAndroidTest" />
+          <option value=":benchmarks:pixel6Api33DemoBenchmarkReleaseAndroidTest" />
           <option value="--rerun" />
           <option value="--enable-display" />
         </list>
@@ -44,6 +43,7 @@
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
     <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
     <method v="2" />
   </configuration>
 </component>

--- a/.run/Generate Demo Baseline Profile.run.xml
+++ b/.run/Generate Demo Baseline Profile.run.xml
@@ -28,7 +28,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile" />
+      <option name="scriptParameters" value="" />
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/Generate Demo Baseline Profile.run.xml
+++ b/.run/Generate Demo Baseline Profile.run.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
      Copyright 2024 The Android Open Source Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,41 +15,35 @@
      limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-    <!--
-   Baseline Profiles improve code execution speed by around 30% from the first launch by avoiding
-   interpretation and just-in-time (JIT) compilation steps for included code paths.
-   More information at http://d.android.com/baseline-profiles.
-   In this run configuration we leverage rerun parameter that always reruns the requested task regardless of cache.
-   We also leverage enable-display parameter to be able to verify the generator works as intended.
-   -->
-    <configuration name="Generate Demo Baseline Profile"
-        default="false"
-        factoryName="Gradle"
-        type="GradleRunConfiguration">
-        <ExternalSystemSettings>
-            <option name="executionName" />
-            <option name="externalProjectPath"
-                value="$PROJECT_DIR$" />
-            <option name="externalSystemIdString"
-                value="GRADLE" />
-            <option name="scriptParameters"
-                value="-Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile" />
-            <option name="taskDescriptions">
-                <list />
-            </option>
-            <option name="taskNames">
-                <list>
-                    <option value=":benchmarks:pixel6Api33DemoBenchmarkReleaseAndroidTest" />
-                    <option value="--rerun" />
-                    <option value="--enable-display" />
-                </list>
-            </option>
-            <option name="vmOptions" />
-        </ExternalSystemSettings>
-        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
-        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-        <DebugAllEnabled>false</DebugAllEnabled>
-        <RunAsTest>false</RunAsTest>
-        <method v="2" />
-    </configuration>
+  <!--
+ Baseline Profiles improve code execution speed by around 30% from the first launch by avoiding
+ interpretation and just-in-time (JIT) compilation steps for included code paths.
+ More information at http://d.android.com/baseline-profiles.
+ In this run configuration we leverage rerun parameter that always reruns the requested task regardless of cache.
+ We also leverage enable-display parameter to be able to verify the generator works as intended.
+ -->
+  <configuration default="false" name="Generate Demo Baseline Profile" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":benchmarks:pixel6Api33DemoBenchmarkReleaseAndroidTest" />
+          <option value="--rerun" />
+          <option value="--enable-display" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
 </component>

--- a/.run/Generate Demo Baseline Profile.run.xml
+++ b/.run/Generate Demo Baseline Profile.run.xml
@@ -34,7 +34,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value=":benchmarks:pixel6Api33DemoBenchmarkReleaseAndroidTest" />
+          <option value=":app:generateDemoReleaseBaselineProfile" />
           <option value="--rerun" />
           <option value="--enable-display" />
         </list>


### PR DESCRIPTION
**What I have done and why**
Change tasks use `:app:generateDemoReleaseBaselineProfile`.
From Baseline profile [documentation](https://developer.android.com/topic/performance/baselineprofiles/create-baselineprofile#generate-profile)
> Note: To generate and install the Baseline Profile from the command-line interface, run the :app:generateBaselineProfile or :app:generateVariantBaselineProfile Gradle tasks.


Used GMD from here
https://github.com/android/nowinandroid/blob/211654ff16aea732cab8fd6148998c2a7293612f/benchmarks/build.gradle.kts#L48-L54

Output:
<img width="281" alt="image" src="https://github.com/android/nowinandroid/assets/48680511/5f41afb4-0a1b-4cdf-85bf-e8b375223d83">



Fix #1467, fix #859