### PR TITLE
Avoid popUpTo and navigateTo same route

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
@@ -33,11 +33,8 @@ import com.google.samples.apps.nowinandroid.core.data.repository.UserNewsResourc
 import com.google.samples.apps.nowinandroid.core.data.util.NetworkMonitor
 import com.google.samples.apps.nowinandroid.core.data.util.TimeZoneMonitor
 import com.google.samples.apps.nowinandroid.core.ui.TrackDisposableJank
-import com.google.samples.apps.nowinandroid.feature.bookmarks.navigation.BookmarksRoute
 import com.google.samples.apps.nowinandroid.feature.bookmarks.navigation.navigateToBookmarks
-import com.google.samples.apps.nowinandroid.feature.foryou.navigation.ForYouRoute
 import com.google.samples.apps.nowinandroid.feature.foryou.navigation.navigateToForYou
-import com.google.samples.apps.nowinandroid.feature.interests.navigation.InterestsRoute
 import com.google.samples.apps.nowinandroid.feature.interests.navigation.navigateToInterests
 import com.google.samples.apps.nowinandroid.feature.search.navigation.navigateToSearch
 import com.google.samples.apps.nowinandroid.navigation.TopLevelDestination

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
@@ -143,10 +143,10 @@ class NiaAppState(
         trace("Navigation: ${topLevelDestination.name}") {
             val topLevelNavOptions = navOptions {
                 val startDestination = navController.graph.findStartDestination()
+
                 // Avoid popUpTo and navigate to same screen.
-                val shouldNotSavedAndRestored = isStartDestinationSameWithNextDestination(
-                    startDestination, topLevelDestination
-                ) ?: false
+                val shouldNotSavedAndRestored = startDestination.hasRoute(topLevelDestination.route)
+
                 // Pop up to the start destination of the graph to
                 // avoid building up a large stack of destinations
                 // on the back stack as users select items
@@ -167,14 +167,6 @@ class NiaAppState(
             }
         }
     }
-
-    /**
-     * Check if next destination is same with start destination of current graph.
-     */
-    private fun isStartDestinationSameWithNextDestination(
-        startDestination: NavDestination,
-        nextDestination: TopLevelDestination,
-    ): Boolean? = startDestination.hasRoute(nextDestination.route)
 
     fun navigateToSearch() = navController.navigateToSearch()
 }


### PR DESCRIPTION
Fix for #1463, #1465 and #1597

The issue arises when both popUpTo() and navigate() target the same route. This can lead to unexpected behavior in navigation within NIA.

If start destination and target destination are same, we can just set saveState and restoreState to false.

