### PR TITLE
refactor: On ui layer analytics injected by entrypoint

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/MainActivity.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/MainActivity.kt
@@ -38,8 +38,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.metrics.performance.JankStats
 import com.google.samples.apps.nowinandroid.MainActivityUiState.Loading
 import com.google.samples.apps.nowinandroid.MainActivityUiState.Success
-import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsHelper
-import com.google.samples.apps.nowinandroid.core.analytics.LocalAnalyticsHelper
 import com.google.samples.apps.nowinandroid.core.data.repository.UserNewsResourceRepository
 import com.google.samples.apps.nowinandroid.core.data.util.NetworkMonitor
 import com.google.samples.apps.nowinandroid.core.data.util.TimeZoneMonitor
@@ -71,9 +69,6 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var timeZoneMonitor: TimeZoneMonitor
-
-    @Inject
-    lateinit var analyticsHelper: AnalyticsHelper
 
     @Inject
     lateinit var userNewsResourceRepository: UserNewsResourceRepository
@@ -140,7 +135,6 @@ class MainActivity : ComponentActivity() {
             val currentTimeZone by appState.currentTimeZone.collectAsStateWithLifecycle()
 
             CompositionLocalProvider(
-                LocalAnalyticsHelper provides analyticsHelper,
                 LocalTimeZone provides currentTimeZone,
             ) {
                 NiaTheme(

--- a/core/analytics/src/main/kotlin/com/google/samples/apps/nowinandroid/core/analytics/AnalyticsEntryPoint.kt
+++ b/core/analytics/src/main/kotlin/com/google/samples/apps/nowinandroid/core/analytics/AnalyticsEntryPoint.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Android Open Source Project
+ * Copyright 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,18 @@
 
 package com.google.samples.apps.nowinandroid.core.analytics
 
-import androidx.compose.runtime.staticCompositionLocalOf
+import android.content.Context
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
 
-/**
- * Global key used to obtain access to the AnalyticsHelper through a CompositionLocal.
- */
-val LocalAnalyticsHelper = staticCompositionLocalOf<AnalyticsHelper> {
-    // Provide a default AnalyticsHelper which does nothing. This is so that tests and previews
-    // do not have to provide one. For real app builds provide a different implementation.
-    NoOpAnalyticsHelper()
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface AnalyticsEntryPoint {
+    fun get(): AnalyticsHelper
+}
+
+fun analyticsInstance(context: Context): AnalyticsHelper {
+    return EntryPointAccessors.fromApplication(context, AnalyticsEntryPoint::class.java).get()
 }

--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/AnalyticsExtensions.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/AnalyticsExtensions.kt
@@ -18,12 +18,13 @@ package com.google.samples.apps.nowinandroid.core.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
 import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsEvent
 import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsEvent.Param
 import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsEvent.ParamKeys
 import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsEvent.Types
 import com.google.samples.apps.nowinandroid.core.analytics.AnalyticsHelper
-import com.google.samples.apps.nowinandroid.core.analytics.LocalAnalyticsHelper
+import com.google.samples.apps.nowinandroid.core.analytics.analyticsInstance
 
 /**
  * Classes and functions associated with analytics events for the UI.
@@ -56,7 +57,7 @@ fun AnalyticsHelper.logNewsResourceOpened(newsResourceId: String) {
 @Composable
 fun TrackScreenViewEvent(
     screenName: String,
-    analyticsHelper: AnalyticsHelper = LocalAnalyticsHelper.current,
+    analyticsHelper: AnalyticsHelper = analyticsInstance(LocalContext.current),
 ) = DisposableEffect(Unit) {
     analyticsHelper.logScreenView(screenName)
     onDispose {}

--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import com.google.samples.apps.nowinandroid.core.analytics.LocalAnalyticsHelper
+import com.google.samples.apps.nowinandroid.core.analytics.analyticsInstance
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import com.google.samples.apps.nowinandroid.core.model.data.UserNewsResource
 
@@ -62,7 +62,7 @@ fun LazyStaggeredGridScope.newsFeed(
                 contentType = { "newsFeedItem" },
             ) { userNewsResource ->
                 val context = LocalContext.current
-                val analyticsHelper = LocalAnalyticsHelper.current
+                val analyticsHelper = analyticsInstance(context)
                 val backgroundColor = MaterialTheme.colorScheme.background.toArgb()
 
                 NewsResourceCardExpanded(

--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCardList.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCardList.kt
@@ -23,7 +23,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
-import com.google.samples.apps.nowinandroid.core.analytics.LocalAnalyticsHelper
+import com.google.samples.apps.nowinandroid.core.analytics.analyticsInstance
 import com.google.samples.apps.nowinandroid.core.model.data.UserNewsResource
 
 /**
@@ -46,7 +46,7 @@ fun LazyListScope.userNewsResourceCardItems(
         val resourceUrl = Uri.parse(userNewsResource.url)
         val backgroundColor = MaterialTheme.colorScheme.background.toArgb()
         val context = LocalContext.current
-        val analyticsHelper = LocalAnalyticsHelper.current
+        val analyticsHelper = analyticsInstance(context)
 
         NewsResourceCardExpanded(
             userNewsResource = userNewsResource,


### PR DESCRIPTION
Issue: #1471

Suggest changing the UI layer injection method of Analytics Instance in Analytics Module. 

Instead of using CompositionLocal, how about using Hilt's EntryPoint?

It has these advantages.
1. It has the advantage of reducing MainActivity injection code.
2. Management outside HiltScope can be reduced.
3. Analytics can eliminate compose dependency.

Additionally, in analytics/AnalyticsModule, how about creating an instance as a singleton?

