### PR TITLE
Remove desugaring from this project

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
@@ -22,7 +22,6 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.provideDelegate
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
@@ -47,15 +46,10 @@ internal fun Project.configureKotlinAndroid(
             // https://developer.android.com/studio/write/java11-minimal-support-table
             sourceCompatibility = JavaVersion.VERSION_11
             targetCompatibility = JavaVersion.VERSION_11
-            isCoreLibraryDesugaringEnabled = true
         }
     }
 
     configureKotlin<KotlinAndroidProjectExtension>()
-
-    dependencies {
-        add("coreLibraryDesugaring", libs.findLibrary("android.desugarJdkLibs").get())
-    }
 }
 
 /**

--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
@@ -67,10 +67,7 @@ import com.google.samples.apps.nowinandroid.core.model.data.FollowableTopic
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
 import com.google.samples.apps.nowinandroid.core.model.data.UserNewsResource
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toJavaInstant
-import kotlinx.datetime.toJavaZoneId
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
+import java.text.DateFormat
 import java.util.Locale
 
 /**
@@ -239,12 +236,10 @@ fun NotificationDot(
     )
 }
 
-@Composable
-fun dateFormatted(publishDate: Instant): String = DateTimeFormatter
-    .ofLocalizedDate(FormatStyle.MEDIUM)
-    .withLocale(Locale.getDefault())
-    .withZone(LocalTimeZone.current.toJavaZoneId())
-    .format(publishDate.toJavaInstant())
+ @Composable
+ fun dateFormatted(publishDate: Instant): String = DateFormat
+     .getDateInstance(DateFormat.MEDIUM, Locale.getDefault())
+     .format(publishDate.toEpochMilliseconds())
 
 @Composable
 fun NewsResourceMetaData(

--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
@@ -236,10 +236,10 @@ fun NotificationDot(
     )
 }
 
- @Composable
- fun dateFormatted(publishDate: Instant): String = DateFormat
-     .getDateInstance(DateFormat.MEDIUM, Locale.getDefault())
-     .format(publishDate.toEpochMilliseconds())
+@Composable
+fun dateFormatted(publishDate: Instant): String = DateFormat
+    .getDateInstance(DateFormat.MEDIUM, Locale.getDefault())
+    .format(publishDate.toEpochMilliseconds())
 
 @Composable
 fun NewsResourceMetaData(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 accompanist = "0.34.0"
-androidDesugarJdkLibs = "2.0.4"
 # AGP and tools should be updated together
 androidGradlePlugin = "8.4.0"
 androidTools = "31.4.0"
@@ -63,7 +62,6 @@ turbine = "1.1.0"
 
 [libraries]
 accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanist" }
-android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
 androidx-benchmark-macro = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "androidxMacroBenchmark" }


### PR DESCRIPTION
**What I have done and why**

We can remove desugaring from this project.
The only usage of desugar API is just here.
https://github.com/android/nowinandroid/blob/85129e4660f7a27c7081f4ac21169d19db89fbb6/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt#L242-L247

When we remove the desugaring, we can remove `androidDesugarJdkLibs` dependency.
Output APK's size is reduced 1MB.
![image](https://github.com/android/nowinandroid/assets/48680511/e9fa227f-17e2-45fa-834e-6d78487efa79)



And there's no need to use JAVA 11 whether even use the desugaring, the JAVA version bumped at  #1392 PR