### PR TITLE
Fixed issue with module graphs not generating on Linux

### DIFF
--- a/generateModuleGraphs.sh
+++ b/generateModuleGraphs.sh
@@ -26,15 +26,15 @@ if ! command -v dot &> /dev/null
 then
     echo "The 'dot' command is not found. This is required to generate SVGs from the Graphviz files."
     echo "Installation instructions:"
-    echo "  - On macOS: You can install Graphviz using Homebrew with the command: 'brew install graphviz'"
     echo "  - On Ubuntu: You can install Graphviz using APT with the command: 'sudo apt-get install graphviz'"
+    echo "  - On macOS: You can install Graphviz using Homebrew with the command: 'brew install graphviz'"
     exit 1
 fi
 
 # Check for a version of grep which supports Perl regex.
 # On MacOS the OS installed grep doesn't support Perl regex so check for the existence of the
 # GNU version instead which is prefixed with 'g' to distinguish it from the OS installed version.
-    if grep -P "" /dev/null > /dev/null 2>&1; then
+if echo "" | grep -P "" > /dev/null 2>&1; then
     GREP_COMMAND=grep
 elif command -v ggrep &> /dev/null; then
     GREP_COMMAND=ggrep
@@ -114,10 +114,10 @@ echo "$module_paths" | while read -r module_path; do
           -Pmodules.graph.of.module="${module_path}" </dev/null
 
         # Convert to SVG using dot, remove unnecessary comments, and reformat
-        dot -Tsvg "/tmp/${file_name}.gv" |
-          sed 's/<!--/\x0<!--/g;s/-->/-->\x0/g' | grep -zv '^<!--' | tr -d '\0' |
-          xmllint --format - \
-          > "docs/images/graphs/${file_name}.svg"
+                dot -Tsvg "/tmp/${file_name}.gv" |
+                  sed 's/<!--/\x0<!--/g;s/-->/-->\x0/g' | grep -zv '^<!--' | tr -d '\0' |
+                  xmllint --format - \
+                  > "docs/images/graphs/${file_name}.svg"
         # Remove the temporary .gv file
         rm "/tmp/${file_name}.gv"
     fi

--- a/generateModuleGraphs.sh
+++ b/generateModuleGraphs.sh
@@ -114,10 +114,10 @@ echo "$module_paths" | while read -r module_path; do
           -Pmodules.graph.of.module="${module_path}" </dev/null
 
         # Convert to SVG using dot, remove unnecessary comments, and reformat
-                dot -Tsvg "/tmp/${file_name}.gv" |
-                  sed 's/<!--/\x0<!--/g;s/-->/-->\x0/g' | grep -zv '^<!--' | tr -d '\0' |
-                  xmllint --format - \
-                  > "docs/images/graphs/${file_name}.svg"
+        dot -Tsvg "/tmp/${file_name}.gv" |
+            sed 's/<!--/\x0<!--/g;s/-->/-->\x0/g' | grep -zv '^<!--' | tr -d '\0' |
+            xmllint --format - \
+            > "docs/images/graphs/${file_name}.svg"
         # Remove the temporary .gv file
         rm "/tmp/${file_name}.gv"
     fi

--- a/generateModuleGraphs.sh
+++ b/generateModuleGraphs.sh
@@ -115,9 +115,9 @@ echo "$module_paths" | while read -r module_path; do
 
         # Convert to SVG using dot, remove unnecessary comments, and reformat
         dot -Tsvg "/tmp/${file_name}.gv" |
-            sed 's/<!--/\x0<!--/g;s/-->/-->\x0/g' | grep -zv '^<!--' | tr -d '\0' |
-            xmllint --format - \
-            > "docs/images/graphs/${file_name}.svg"
+          sed 's/<!--/\x0<!--/g;s/-->/-->\x0/g' | grep -zv '^<!--' | tr -d '\0' |
+          xmllint --format - \
+          > "docs/images/graphs/${file_name}.svg"
         # Remove the temporary .gv file
         rm "/tmp/${file_name}.gv"
     fi


### PR DESCRIPTION
**What I have done and why**

In commit e5008c655ea0373ece8c8dfef6e3aa073991249e a condition was added to check if the grep command supports the -P parameter.

However, from my testing at least, this doesn't seem to work as it uses /dev/null to check for "", probably based on the assumption that grep will return positively even if it doesn't find the matching string (here ""), which isn't true when using /dev/null.

At least that is my understanding of the issue, feel free to correct me if it isn't exactly that <3
What is sure however is that it doesn't work on my setup, even though I do have the grep -P option and it works fine (worked fine before e5008c655ea0373ece8c8dfef6e3aa073991249e, and still works when removing the condition).

Instead of doing a `grep -P "" /dev/null` I changed it to a `echo "" | grep -P ""`, the result will still be positive as grep doesn't return an error when no matches are found, but the string isn't ""null"" as with /dev/null, and so the condition doesn't always return false.