### PR TITLE
Add minSdk api 21 in CI

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -153,7 +153,7 @@ jobs:
     timeout-minutes: 55
     strategy:
       matrix:
-        api-level: [26, 30]
+        api-level: [21, 26, 30]
 
     steps:
       - name: Delete unnecessary tools 🔧


### PR DESCRIPTION
**What I have done and why**

Cover capability minSdk version in CI.

Fix #1490