### PR TITLE
Build tuning

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,23 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Ensure important default jvmargs aren't overwritten. See https://github.com/gradle/gradle/issues/19750
-org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g
+#
+# For more information about how Gradle memory options were chosen:
+# - Metaspace See https://www.jasonpearson.dev/metaspace-in-jvm-builds/
+# - SoftRefLRUPolicyMSPerMB would default to 1000 which with a 4gb heap translates to ~51 minutes.
+#   A value of 1 means ~4 seconds before SoftRefs can be collected, which means its realistic to
+#   collect them as needed during a build that should take seconds to minutes.
+# - CodeCache normally defaults to a very small size. Increasing it from platform defaults of 32-48m
+#   because of how many classes can be loaded into memory and then cached as native compiled code
+#   for a small speed boost.
+org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx4g -Xms4g
+
+# For more information about how Kotlin Daemon memory options were chosen:
+# - Kotlin JVM args only inherit Xmx, ReservedCodeCache, and MaxMetaspace. Since we are specifying
+#   other args we need to specify all of them here.
+# - We're using the Kotlin Gradle Plugin's default value for ReservedCodeCacheSize, if we do not then
+#   the Gradle JVM arg value for ReservedCodeCacheSize will be used.
+kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=320m -XX:+HeapDumpOnOutOfMemoryError -Xmx4g -Xms4g
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
**What I have done and why**

It was pointed out in a discussion that NowInAndroid uses a 6GB heap size which seemed high. I did a couple perf runs with current settings and no build cache or config cache. I did this at a few heap sizes like [12G](https://scans.gradle.com/s/gheirot2q7w4c), [6G](https://scans.gradle.com/s/zapioauv4zyvy), [4G](https://scans.gradle.com/s/mz3rwimjce7am), and [3G](https://scans.gradle.com/s/vyz3ai24utnk4). Only at 3G do we observe a regression in build speed which is pretty easily explained by the 27 seconds spent in garbage collection - the build process was encountering GC thrashing in attempting to complete the build.

I then changed the JVM arg settings to be what I would use for tuning and while the first build at 3G was only slightly faster the subsequent ones are proving to be just as fast as all the other higher heap size ones.

Settings changed so far is just to this:

```
org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError -XX:+UnlockExperimentalVMOptions -Xmx3g -Xms3g -XX:MetaspaceSize=1g
kotlin.daemon.jvmargs=<same as Gradle>
```

In this PR I also want to add [jemalloc](https://www.linkedin.com/blog/engineering/infrastructure/taming-memory-fragmentation-in-venice-with-jemalloc) to the GitHub CI as that should give roughly 10% memory savings by fixing native memory fragmentation. I did this through a custom action that caches jemalloc.

I also tried out other heap sizes with the new configuration. Anything higher than 3G didn't make a performance difference and anything lower (2G) ran the risk of the build not completing.

I'm happy to alter anything about this contribution, the goal is to help show how its possible to reduce resource usage while increasing performance.
