### PR TITLE
Apply App startup library

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,17 @@
         <meta-data android:name="firebase_analytics_collection_deactivated" android:value="true" />
         <!-- Disable collection of AD_ID for all build variants -->
         <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
+
+        <!-- App Startup library       -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data android:name="com.google.samples.apps.nowinandroid.initializer.ProfileVerifierLoggerInitializer"
+                android:value="androidx.startup" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,8 +65,6 @@
             tools:node="merge">
             <meta-data android:name="com.google.samples.apps.nowinandroid.initializer.ProfileVerifierLoggerInitializer"
                 android:value="androidx.startup" />
-            <meta-data android:name="com.google.samples.apps.nowinandroid.sync.initializers.SyncInitializer"
-                android:value="androidx.startup" />
         </provider>
 
     </application>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,6 +65,8 @@
             tools:node="merge">
             <meta-data android:name="com.google.samples.apps.nowinandroid.initializer.ProfileVerifierLoggerInitializer"
                 android:value="androidx.startup" />
+            <meta-data android:name="com.google.samples.apps.nowinandroid.sync.initializers.SyncInitializer"
+                android:value="androidx.startup" />
         </provider>
 
     </application>

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaApplication.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaApplication.kt
@@ -28,7 +28,7 @@ import javax.inject.Inject
  * [Application] class for NiA
  */
 @HiltAndroidApp
-class NiaApplication : Application(), ImageLoaderFactory, Configuration.Provider{
+class NiaApplication : Application(), ImageLoaderFactory, Configuration.Provider {
     @Inject
     lateinit var imageLoader: dagger.Lazy<ImageLoader>
 
@@ -39,7 +39,7 @@ class NiaApplication : Application(), ImageLoaderFactory, Configuration.Provider
 
 //    override fun onCreate() {
 //        super.onCreate()
-        // Initialize Sync; the system responsible for keeping data in the app up to date.
+    // Initialize Sync; the system responsible for keeping data in the app up to date.
 //        Sync.initialize()
 //        ProfileVerifierLogger.start()
 //    }

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaApplication.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaApplication.kt
@@ -20,7 +20,6 @@ import android.app.Application
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import com.google.samples.apps.nowinandroid.sync.initializers.Sync
-import com.google.samples.apps.nowinandroid.util.ProfileVerifierLogger
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
@@ -32,14 +31,10 @@ class NiaApplication : Application(), ImageLoaderFactory {
     @Inject
     lateinit var imageLoader: dagger.Lazy<ImageLoader>
 
-    @Inject
-    lateinit var profileVerifierLogger: ProfileVerifierLogger
-
     override fun onCreate() {
         super.onCreate()
         // Initialize Sync; the system responsible for keeping data in the app up to date.
         Sync.initialize(context = this)
-        profileVerifierLogger()
     }
 
     override fun newImageLoader(): ImageLoader = imageLoader.get()

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaApplication.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaApplication.kt
@@ -17,10 +17,10 @@
 package com.google.samples.apps.nowinandroid
 
 import android.app.Application
+import android.util.Log
+import androidx.work.Configuration
 import coil.ImageLoader
 import coil.ImageLoaderFactory
-import com.google.samples.apps.nowinandroid.sync.initializers.Sync
-import com.google.samples.apps.nowinandroid.util.ProfileVerifierLogger
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
@@ -28,16 +28,21 @@ import javax.inject.Inject
  * [Application] class for NiA
  */
 @HiltAndroidApp
-class NiaApplication : Application(), ImageLoaderFactory {
+class NiaApplication : Application(), ImageLoaderFactory, Configuration.Provider{
     @Inject
     lateinit var imageLoader: dagger.Lazy<ImageLoader>
 
-    override fun onCreate() {
-        super.onCreate()
+    override val workManagerConfiguration: Configuration =
+        Configuration.Builder()
+            .setMinimumLoggingLevel(Log.INFO)
+            .build()
+
+//    override fun onCreate() {
+//        super.onCreate()
         // Initialize Sync; the system responsible for keeping data in the app up to date.
-        Sync.initialize(context = this)
-        ProfileVerifierLogger.start()
-    }
+//        Sync.initialize()
+//        ProfileVerifierLogger.start()
+//    }
 
     override fun newImageLoader(): ImageLoader = imageLoader.get()
 }

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaApplication.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaApplication.kt
@@ -20,6 +20,7 @@ import android.app.Application
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import com.google.samples.apps.nowinandroid.sync.initializers.Sync
+import com.google.samples.apps.nowinandroid.util.ProfileVerifierLogger
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
@@ -35,6 +36,7 @@ class NiaApplication : Application(), ImageLoaderFactory {
         super.onCreate()
         // Initialize Sync; the system responsible for keeping data in the app up to date.
         Sync.initialize(context = this)
+        ProfileVerifierLogger.start()
     }
 
     override fun newImageLoader(): ImageLoader = imageLoader.get()

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/initializer/ProfileVerifierLoggerInitializer.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/initializer/ProfileVerifierLoggerInitializer.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.Job
 /**
  * Startup initializer for [ProfileVerifierLogger]
  */
-class ProfileVerifierLoggerInitializer: Initializer<ProfileVerifierLogger> {
+class ProfileVerifierLoggerInitializer : Initializer<ProfileVerifierLogger> {
     override fun create(context: Context): ProfileVerifierLogger {
         ProfileVerifierLogger.setScope(scope = CoroutineScope(Dispatchers.Default + Job()))
         return ProfileVerifierLogger

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/initializer/ProfileVerifierLoggerInitializer.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/initializer/ProfileVerifierLoggerInitializer.kt
@@ -21,14 +21,14 @@ import androidx.startup.Initializer
 import com.google.samples.apps.nowinandroid.util.ProfileVerifierLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 
 /**
  * Startup initializer for [ProfileVerifierLogger]
  */
 class ProfileVerifierLoggerInitializer : Initializer<ProfileVerifierLogger> {
     override fun create(context: Context): ProfileVerifierLogger {
-        ProfileVerifierLogger.setScope(scope = CoroutineScope(Dispatchers.Default + Job()))
+        ProfileVerifierLogger.setScope(scope = CoroutineScope(SupervisorJob() + Dispatchers.Default))
         return ProfileVerifierLogger
     }
 

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/initializer/ProfileVerifierLoggerInitializer.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/initializer/ProfileVerifierLoggerInitializer.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid.initializer
+
+import android.content.Context
+import android.util.Log
+import androidx.startup.Initializer
+import com.google.samples.apps.nowinandroid.util.ProfileVerifierLogger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+
+/**
+ * Startup initializer for [ProfileVerifierLogger]
+ */
+class ProfileVerifierLoggerInitializer: Initializer<ProfileVerifierLogger> {
+    override fun create(context: Context): ProfileVerifierLogger {
+        return ProfileVerifierLogger(scope = CoroutineScope(Dispatchers.Default + Job())).apply {
+            this()
+        }
+    }
+
+    override fun dependencies(): MutableList<Class<out Initializer<*>>> {
+        return mutableListOf()
+    }
+}

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/initializer/ProfileVerifierLoggerInitializer.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/initializer/ProfileVerifierLoggerInitializer.kt
@@ -17,7 +17,6 @@
 package com.google.samples.apps.nowinandroid.initializer
 
 import android.content.Context
-import android.util.Log
 import androidx.startup.Initializer
 import com.google.samples.apps.nowinandroid.util.ProfileVerifierLogger
 import kotlinx.coroutines.CoroutineScope
@@ -29,9 +28,8 @@ import kotlinx.coroutines.Job
  */
 class ProfileVerifierLoggerInitializer: Initializer<ProfileVerifierLogger> {
     override fun create(context: Context): ProfileVerifierLogger {
-        return ProfileVerifierLogger(scope = CoroutineScope(Dispatchers.Default + Job())).apply {
-            this()
-        }
+        ProfileVerifierLogger.setScope(scope = CoroutineScope(Dispatchers.Default + Job()))
+        return ProfileVerifierLogger
     }
 
     override fun dependencies(): MutableList<Class<out Initializer<*>>> {

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/initializer/ProfileVerifierLoggerInitializer.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/initializer/ProfileVerifierLoggerInitializer.kt
@@ -28,8 +28,8 @@ import kotlinx.coroutines.SupervisorJob
  */
 class ProfileVerifierLoggerInitializer : Initializer<ProfileVerifierLogger> {
     override fun create(context: Context): ProfileVerifierLogger {
-        ProfileVerifierLogger.setScope(scope = CoroutineScope(SupervisorJob() + Dispatchers.Default))
-        return ProfileVerifierLogger
+        val applicationScope = SupervisorJob() + Dispatchers.Default
+        return ProfileVerifierLogger.setScope(scope = CoroutineScope(applicationScope))
     }
 
     override fun dependencies(): MutableList<Class<out Initializer<*>>> {

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/util/ProfileVerifierLogger.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/util/ProfileVerifierLogger.kt
@@ -50,11 +50,13 @@ object ProfileVerifierLogger {
     private const val TAG = "ProfileInstaller"
     private var scope: CoroutineScope? = null
 
-    fun setScope(scope: CoroutineScope) {
+    fun setScope(scope: CoroutineScope): ProfileVerifierLogger {
         this.scope = scope
+        this.start()
+        return this
     }
 
-    fun start() = scope?.launch {
+    private fun start() = scope?.launch {
         val status = ProfileVerifier.getCompilationStatusAsync().await()
         Log.d(TAG, "Status code: ${status.profileInstallResultCode}")
         Log.d(

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/util/ProfileVerifierLogger.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/util/ProfileVerifierLogger.kt
@@ -46,14 +46,15 @@ import kotlinx.coroutines.launch
  *
  * @see androidx.profileinstaller.ProfileVerifier.CompilationStatus.ResultCode
  */
-class ProfileVerifierLogger (
-    private val scope: CoroutineScope,
-) {
-    companion object {
-        private const val TAG = "ProfileInstaller"
+object ProfileVerifierLogger {
+    private const val TAG = "ProfileInstaller"
+    private var scope: CoroutineScope? = null
+
+    fun setScope(scope: CoroutineScope) {
+        this.scope = scope
     }
 
-    operator fun invoke() = scope.launch {
+    fun start() = scope?.launch {
         val status = ProfileVerifier.getCompilationStatusAsync().await()
         Log.d(TAG, "Status code: ${status.profileInstallResultCode}")
         Log.d(

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/util/ProfileVerifierLogger.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/util/ProfileVerifierLogger.kt
@@ -18,11 +18,9 @@ package com.google.samples.apps.nowinandroid.util
 
 import android.util.Log
 import androidx.profileinstaller.ProfileVerifier
-import com.google.samples.apps.nowinandroid.core.network.di.ApplicationScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 /**
  * Logs the app's Baseline Profile Compilation Status using [ProfileVerifier].
@@ -48,8 +46,8 @@ import javax.inject.Inject
  *
  * @see androidx.profileinstaller.ProfileVerifier.CompilationStatus.ResultCode
  */
-class ProfileVerifierLogger @Inject constructor(
-    @ApplicationScope private val scope: CoroutineScope,
+class ProfileVerifierLogger (
+    private val scope: CoroutineScope,
 ) {
     companion object {
         private const val TAG = "ProfileInstaller"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ androidGradlePlugin = "8.4.0"
 androidTools = "31.4.0"
 androidxActivity = "1.8.2"
 androidxAppCompat = "1.6.1"
+androidxAppStartup = "1.1.1"
 androidxBrowser = "1.8.0"
 androidxComposeAlpha = "1.7.0-beta01"
 androidxComposeBom = "2024.02.02"
@@ -66,6 +67,7 @@ accompanist-permissions = { group = "com.google.accompanist", name = "accompanis
 android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
+androidx-app-startup = { group = "androidx.startup", name = "startup-runtime", version.ref = "androidxAppStartup"}
 androidx-benchmark-macro = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "androidxMacroBenchmark" }
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "androidxBrowser" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ androidGradlePlugin = "8.4.0"
 androidTools = "31.4.0"
 androidxActivity = "1.8.2"
 androidxAppCompat = "1.6.1"
-androidxAppStartup = "1.1.1"
 androidxBrowser = "1.8.0"
 androidxComposeAlpha = "1.7.0-beta01"
 androidxComposeBom = "2024.02.02"
@@ -67,7 +66,6 @@ accompanist-permissions = { group = "com.google.accompanist", name = "accompanis
 android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
-androidx-app-startup = { group = "androidx.startup", name = "startup-runtime", version.ref = "androidxAppStartup"}
 androidx-benchmark-macro = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "androidxMacroBenchmark" }
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "androidxBrowser" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }

--- a/sync/work/build.gradle.kts
+++ b/sync/work/build.gradle.kts
@@ -29,8 +29,9 @@ android {
 dependencies {
     ksp(libs.hilt.ext.compiler)
 
+    api(libs.androidx.work.ktx)
+
     implementation(libs.androidx.tracing.ktx)
-    implementation(libs.androidx.work.ktx)
     implementation(libs.hilt.ext.work)
     implementation(projects.core.analytics)
     implementation(projects.core.data)

--- a/sync/work/src/main/AndroidManifest.xml
+++ b/sync/work/src/main/AndroidManifest.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright 2024 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <!-- App Startup library       -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data android:name="com.google.samples.apps.nowinandroid.sync.initializers.SyncInitializer"
+                android:value="androidx.startup" />
+        </provider>
+    </application>
+
+</manifest>

--- a/sync/work/src/main/AndroidManifest.xml
+++ b/sync/work/src/main/AndroidManifest.xml
@@ -26,6 +26,10 @@
             tools:node="merge">
             <meta-data android:name="com.google.samples.apps.nowinandroid.sync.initializers.SyncInitializer"
                 android:value="androidx.startup" />
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
         </provider>
     </application>
 

--- a/sync/work/src/main/AndroidManifest.xml
+++ b/sync/work/src/main/AndroidManifest.xml
@@ -1,19 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2024 The Android Open Source Project
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     https://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+     Copyright 2024 The Android Open Source Project
 
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 

--- a/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/initializers/SyncInitializer.kt
+++ b/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/initializers/SyncInitializer.kt
@@ -25,7 +25,7 @@ import com.google.samples.apps.nowinandroid.sync.workers.SyncWorker
 /**
  * App startup initializer for [Sync]
  */
-class SyncInitializer: Initializer<Sync> {
+class SyncInitializer : Initializer<Sync> {
     override fun create(context: Context): Sync {
         return Sync
     }

--- a/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/initializers/SyncInitializer.kt
+++ b/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/initializers/SyncInitializer.kt
@@ -27,7 +27,8 @@ import com.google.samples.apps.nowinandroid.sync.workers.SyncWorker
  */
 class SyncInitializer : Initializer<Sync> {
     override fun create(context: Context): Sync {
-        return Sync
+        val workManager = WorkManager.getInstance(context)
+        return Sync.setWorkManager(workManager)
     }
 
     override fun dependencies(): MutableList<Class<out Initializer<*>>> {
@@ -36,10 +37,21 @@ class SyncInitializer : Initializer<Sync> {
 }
 
 object Sync {
+    private var workManager: WorkManager? = null
+
+    /**
+     * setWorkManager to [Sync]
+     */
+    fun setWorkManager(workManager: WorkManager): Sync {
+        this.workManager = workManager
+        this.initialize()
+        return this
+    }
+
     // This method is initializes sync, the process that keeps the app's data current.
     // It is called from the app module's Application.onCreate() and should be only done once.
-    fun initialize(context: Context) {
-        WorkManager.getInstance(context).apply {
+    private fun initialize() {
+        workManager?.apply {
             // Run sync on app startup and ensure only one sync worker runs at any time
             enqueueUniqueWork(
                 SYNC_WORK_NAME,

--- a/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/initializers/SyncInitializer.kt
+++ b/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/initializers/SyncInitializer.kt
@@ -17,9 +17,23 @@
 package com.google.samples.apps.nowinandroid.sync.initializers
 
 import android.content.Context
+import androidx.startup.Initializer
 import androidx.work.ExistingWorkPolicy
 import androidx.work.WorkManager
 import com.google.samples.apps.nowinandroid.sync.workers.SyncWorker
+
+/**
+ * App startup initializer for [Sync]
+ */
+class SyncInitializer: Initializer<Sync> {
+    override fun create(context: Context): Sync {
+        return Sync
+    }
+
+    override fun dependencies(): MutableList<Class<out Initializer<*>>> {
+        return mutableListOf()
+    }
+}
 
 object Sync {
     // This method is initializes sync, the process that keeps the app's data current.


### PR DESCRIPTION
**What I have done and why**

Apply [App startup library](https://developer.android.com/topic/libraries/app-startup) to optimize startup time.

I think the `StartupBenchmark_startupPrecompiledWithBaselineProfile` is the main factor.
See the `StartupBenchmark_startupPrecompiledWithBaselineProfile`'s median, It reduces 5%(1,769.8 -> 1,680.1) startup time.

### StartupBenchmark_startupPrecompiledWithBaselineProfile
|  Before   | min | median | max|
|----|-----|--------|-----|
|timeToFullDisplayMs| 701.6 | 1,769.8 | 1,924.9|
|timeToInitialDisplayMs| 448.0 | 566.5 | 676.9 |

|  Startup   | min | median | max|
|----|-----|--------|-----|
|timeToFullDisplayMs| 759.7 | 1,680.1 | 1,777.3 |
|timeToInitialDisplayMs| 496.0 | 558.7 | 660.6 |


### StartupBenchmark_startupWithoutPreCompilation
|  Before   | min | median | max|
|----|-----|--------|-----|
|timeToFullDisplayMs| 2,173.6 | 2,255.0 | 2,475.4 |
|timeToInitialDisplayMs| 570.0 | 604.4 | 770.7 |

|  Startup   | min | median | max|
|----|-----|--------|-----|
|timeToFullDisplayMs| 2,120.6 | 2,186.8 | 2,333.1 |
|timeToInitialDisplayMs| 581.5 | 632.0 | 759.7 |


### StartupBenchmark_startupWithPartialCompilationAndDisabledBaselineProfile
|  Before   | min | median | max|
|----|-----|--------|-----|
|timeToFullDisplayMs| 1,613.9 | 1,700.4 | 1,857.5 |
|timeToInitialDisplayMs| 490.2 | 561.3 | 668.8 |

|  Startup   | min | median | max|
|----|-----|--------|-----|
|timeToFullDisplayMs| 1,483.5 | 1,723.0 | 1,919.9 |
|timeToInitialDisplayMs| 439.7 | 576.1 | 669.0 |


### StartupBenchmark_startupFullyPrecompiled
|  Before   | min | median | max|
|----|-----|--------|-----|
|timeToFullDisplayMs| 1,758.4 | 1,924.0 | 2,098.2 |
|timeToInitialDisplayMs| 617.4 | 682.1 | 907.3 |

|  Startup   | min | median | max|
|----|-----|--------|-----|
|timeToFullDisplayMs| 1,692.9 | 1,775.5 | 2,039.0 |
|timeToInitialDisplayMs| 577.1 | 661.8 | 794.9 |
