### PR TITLE
Refactor chrome tab toolbar dark mode on/off

### DIFF
--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
@@ -18,8 +18,6 @@ package com.google.samples.apps.nowinandroid.core.ui
 
 import android.content.Context
 import android.net.Uri
-import androidx.annotation.ColorInt
-import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.padding
@@ -28,10 +26,8 @@ import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridScope
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
@@ -63,7 +59,6 @@ fun LazyStaggeredGridScope.newsFeed(
             ) { userNewsResource ->
                 val context = LocalContext.current
                 val analyticsHelper = LocalAnalyticsHelper.current
-                val backgroundColor = MaterialTheme.colorScheme.background.toArgb()
 
                 NewsResourceCardExpanded(
                     userNewsResource = userNewsResource,
@@ -73,7 +68,7 @@ fun LazyStaggeredGridScope.newsFeed(
                         analyticsHelper.logNewsResourceOpened(
                             newsResourceId = userNewsResource.id,
                         )
-                        launchCustomChromeTab(context, Uri.parse(userNewsResource.url), backgroundColor)
+                        launchCustomChromeTab(context, Uri.parse(userNewsResource.url))
 
                         onNewsResourceViewed(userNewsResource.id)
                     },
@@ -94,14 +89,11 @@ fun LazyStaggeredGridScope.newsFeed(
     }
 }
 
-fun launchCustomChromeTab(context: Context, uri: Uri, @ColorInt toolbarColor: Int) {
-    val customTabBarColor = CustomTabColorSchemeParams.Builder()
-        .setToolbarColor(toolbarColor).build()
-    val customTabsIntent = CustomTabsIntent.Builder()
-        .setDefaultColorSchemeParams(customTabBarColor)
+fun launchCustomChromeTab(context: Context, uri: Uri) {
+    CustomTabsIntent.Builder()
+        .setColorScheme(CustomTabsIntent.COLOR_SCHEME_SYSTEM)
         .build()
-
-    customTabsIntent.launchUrl(context, uri)
+        .run { launchUrl(context, uri) }
 }
 
 /**

--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCardList.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCardList.kt
@@ -19,9 +19,7 @@ package com.google.samples.apps.nowinandroid.core.ui
 import android.net.Uri
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import com.google.samples.apps.nowinandroid.core.analytics.LocalAnalyticsHelper
 import com.google.samples.apps.nowinandroid.core.model.data.UserNewsResource
@@ -44,7 +42,6 @@ fun LazyListScope.userNewsResourceCardItems(
     key = { it.id },
     itemContent = { userNewsResource ->
         val resourceUrl = Uri.parse(userNewsResource.url)
-        val backgroundColor = MaterialTheme.colorScheme.background.toArgb()
         val context = LocalContext.current
         val analyticsHelper = LocalAnalyticsHelper.current
 
@@ -57,7 +54,7 @@ fun LazyListScope.userNewsResourceCardItems(
                 analyticsHelper.logNewsResourceOpened(
                     newsResourceId = userNewsResource.id,
                 )
-                launchCustomChromeTab(context, resourceUrl, backgroundColor)
+                launchCustomChromeTab(context, resourceUrl)
                 onNewsResourceViewed(userNewsResource.id)
             },
             onTopicClick = onTopicClick,

--- a/feature/foryou/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -67,7 +67,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -468,7 +467,6 @@ private fun DeepLinkEffect(
     onDeepLinkOpened: (String) -> Unit,
 ) {
     val context = LocalContext.current
-    val backgroundColor = MaterialTheme.colorScheme.background.toArgb()
 
     LaunchedEffect(userNewsResource) {
         if (userNewsResource == null) return@LaunchedEffect
@@ -477,7 +475,6 @@ private fun DeepLinkEffect(
         launchCustomChromeTab(
             context = context,
             uri = Uri.parse(userNewsResource.url),
-            toolbarColor = backgroundColor,
         )
     }
 }


### PR DESCRIPTION
Modified to change the Chrome toolbar color according to the system scheme during dark mode transitions. Although specific colors can be applied using [setColorSchemeParams](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsIntent.Builder#setColorSchemeParams(int,androidx.browser.customtabs.CustomTabColorSchemeParams)), using the default values should be sufficient.

https://github.com/android/nowinandroid/assets/38935359/042b8863-f0ca-45f3-bbaf-7f26ad42ef87

[After.webm](https://github.com/android/nowinandroid/assets/38935359/a2f10a8a-c9d5-4ab3-802f-55daba2ff10f)
