### PR TITLE
Replace bash commands with proper svgo cli

### DIFF
--- a/docs/images/graphs/dep_graph_app.svg
+++ b/docs/images/graphs/dep_graph_app.svg
@@ -1,383 +1,305 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1212pt" height="404pt" viewBox="0.00 0.00 1212.13 404.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 400)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-400 1208.13,-400 1208.13,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:app</title>
-      <ellipse fill="none" stroke="black" cx="645.13" cy="-378" rx="27.66" ry="18"/>
-      <text text-anchor="middle" x="645.13" y="-373.8" font-family="Times,serif" font-size="14.00">:app</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="1616" height="404pt" viewBox="0 0 1212.13 404">
+    <g class="graph">
+        <path fill="#fff" d="M0 404V0h1212.13v404z"/>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="645.13" cy="-378" fill="none" stroke="#000" rx="27.66" ry="18"/>
+            <text x="645.13" y="-373.8" font-family="Times,serif" font-size="14" text-anchor="middle">:app</text>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="297.13" cy="-306" fill="none" stroke="#000" rx="75.39" ry="18"/>
+            <text x="297.13" y="-301.8" font-family="Times,serif" font-size="14" text-anchor="middle">:feature:interests</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M622.9 28.25C575.45 37.76 472.2 58.45 385.13 76c-5.51 1.11-11.23 2.26-16.96 3.42"/>
+            <path fill="red" d="m370.62 82.5-10.5-1.45 9.11-5.41z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="135.13" cy="-306" fill="none" stroke="#000" rx="68.95" ry="18"/>
+            <text x="135.13" y="-301.8" font-family="Times,serif" font-size="14" text-anchor="middle">:feature:foryou</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M621.71 25.48C553.19 31.85 369.1 50.17 217.13 76c-5.5.93-11.19 1.99-16.88 3.12"/>
+            <path d="m201.33 82.47-10.5-1.43 9.1-5.43z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="812.13" cy="-306" fill="none" stroke="#000" rx="86.12" ry="18"/>
+            <text x="812.13" y="-301.8" font-family="Times,serif" font-size="14" text-anchor="middle">:feature:bookmarks</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M672 32.59c24.72 10.36 64.82 27.17 96.45 40.43"/>
+            <path d="m769.56 69.68 7.87 7.1-10.58-.64z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="645.13" cy="-306" fill="none" stroke="#000" rx="62.51" ry="18"/>
+            <text x="645.13" y="-301.8" font-family="Times,serif" font-size="14" text-anchor="middle">:feature:topic</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M649.13 40.3v24.16"/>
+            <path d="m652.63 64.38-3.5 10-3.5-10z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="458.13" cy="-306" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="458.13" y="-301.8" font-family="Times,serif" font-size="14" text-anchor="middle">:feature:search</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M625.45 31.87C596.73 42.61 547.61 61 510.72 74.81"/>
+            <path d="m512.19 78-10.59.22 8.14-6.78z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="989.13" cy="-306" fill="none" stroke="#000" rx="72.71" ry="18"/>
+            <text x="989.13" y="-301.8" font-family="Times,serif" font-size="14" text-anchor="middle">:feature:settings</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M675.54 28.3c47.27 9.49 149.44 30.06 235.59 47.7 5.47 1.12 11.14 2.29 16.83 3.46"/>
+            <path d="m928.32 75.96 9.08 5.45-10.5 1.4z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="795.13" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="795.13" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M676.95 22.77c93.64-.29 395.91 2.79 476.18 53.23 39.37 24.74 55 42.5 55 89v74c0 44.13-8.03 63.44-44 89-52.76 37.49-225.24 24.92-289 36-5.22.91-10.62 1.93-16.03 3.02"/>
+            <path d="m860.04 370.4-10.51-1.38 9.08-5.47z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="553.13" cy="-234" fill="none" stroke="#000" rx="40.53" ry="18"/>
+            <text x="553.13" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:ui</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M627.54 33.44C611.2 42.46 589.52 57.03 577.13 76c-11.72 17.95-16.64 41.79-18.67 60.29"/>
+            <path d="m561.96 136.38-4.33 9.66-2.64-10.26z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="774.13" cy="-162" fill="none" stroke="#000" rx="85.06" ry="18"/>
+            <text x="774.13" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:designsystem</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M677 24.37c90.47 4.71 371.67 21.68 398.13 51.63 10.59 11.99 8.85 22.67 0 36-14.26 21.47-161.89 76.8-243.49 106.12"/>
+            <path d="m832.85 221.41-10.6.07 8.24-6.66z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="584.13" cy="-162" fill="none" stroke="#000" rx="49.1" ry="18"/>
+            <text x="584.13" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:data</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M621.3 23.36C509.79 25.07 99.33 34.2 61.13 76-73.67 223.49 362.28 237.49 527.4 237.64"/>
+            <path d="m527.29 234.14 10 3.49-10 3.51z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="412.13" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="412.13" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M621.23 23.65C507.4 26.52 81.9 39.63 35.13 76c-33.07 25.71-31 47.11-31 89v74c0 72.85 233.17 116.46 348.68 133.59"/>
+            <path d="m353.06 369.09 9.39 4.9-10.4 2.02z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="1084.13" cy="-90" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="1084.13" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M676.84 24.37c96.52 5 414 23.46 449.29 51.63 38.51 30.74 36.4 60.07 25 108-8.61 36.2-29.46 73.82-44.83 98.2"/>
+            <path d="m1109.29 284.03-8.36 6.5 2.48-10.3z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="1084.13" cy="-234" fill="none" stroke="#000" rx="53.95" ry="18"/>
+            <text x="1084.13" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:sync:work</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M676.8 24.09c94.84 4.04 402.48 19.53 431.33 51.91 15.09 16.94 7.03 42.79-3 62.27"/>
+            <path d="m1108.33 139.73-7.93 7.02 1.82-10.44z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M349.28 108.17c46.73 12.77 117.11 32.02 162.77 44.5"/>
+            <path d="m512.91 149.28 8.73 6.02-10.57.73z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M335.47 110.31c53.99 24.01 154.4 68.34 171.66 73.69 62.31 19.31 134.94 33.06 189.32 41.71"/>
+            <path d="m696.93 222.25 9.34 5-10.42 1.91z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M322.57 111.56c25.82 19.36 71.03 51.41 113.56 72.44 33.02 16.33 72.34 29.89 102.71 39.21"/>
+            <path d="m539.58 219.78 8.56 6.23-10.58.47z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="280.13" cy="-234" fill="none" stroke="#000" rx="61.99" ry="18"/>
+            <text x="280.13" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:domain</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M296.93 112.3c-1.79 7.38-3.93 16.18-5.94 24.45"/>
+            <path fill="red" d="m294.76 136.06-5.76 8.89-1.04-10.54z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M189.81 106.51c9.08 1.93 18.46 3.84 27.32 5.49 102.76 19.19 223.91 36.91 290.28 46.2"/>
+            <path d="m507.84 154.73 9.42 4.84-10.39 2.09z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M189.66 106.67c58.87 13.72 150.08 35.36 165.47 41.33 31.15 12.08 34.32 25.38 66 36 25.5 8.55 177.39 29.47 274.66 42.32"/>
+            <path d="m696.12 222.84 9.45 4.77-10.37 2.17z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M148.05 112.02c11.87 20.76 34.89 55.14 65.08 71.98 52.8 29.45 223.23 43.94 315.06 49.76"/>
+            <path d="m528.25 230.26 9.77 4.11-10.2 2.88z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M170.95 110.36c21.25 10.26 49.41 23.85 72.31 34.91"/>
+            <path d="m244.53 142 7.48 7.5-10.52-1.2z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M764.96 108.83c-47.43 12.82-117.32 31.71-162.71 43.98"/>
+            <path d="m603.29 156.15-10.56-.77 8.74-5.99z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M811.47 112.41c-6.45 24.09-18.15 67.84-25.84 96.56"/>
+            <path d="m789.07 209.67-5.97 8.76-.8-10.57z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M787.58 111.42c-17.78 10.32-41.08 24.02-61.45 36.58-36.53 22.52-77.81 49.32-105.62 67.59"/>
+            <path d="m622.44 218.51-10.27 2.57 6.43-8.42z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M627.79 111.24c-12.51 9.51-28.47 21.66-42.05 31.99"/>
+            <path d="m588.06 145.86-10.07 3.27 5.83-8.84z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M664.43 111.85c22.5 24.76 64.67 71.18 90.84 99.99"/>
+            <path d="m757.69 209.3 4.14 9.75-9.32-5.04z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M641.77 112.13c-10.4 24.2-29.49 68.66-41.87 97.48"/>
+            <path d="m603.27 210.61-7.16 7.81.73-10.57z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M484.16 111.24c12.92 9.51 29.4 21.66 43.43 31.99"/>
+            <path d="m529.64 140.4 5.98 8.75-10.13-3.11z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M503.63 108.57c29.3 9.97 69.29 24.35 103.5 39.43 46.63 20.55 98.27 48.14 132.48 67.12"/>
+            <path d="m741.29 212.05 7.03 7.93-10.44-1.82z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M467.8 112.32c6.93 19.2 20.17 50.26 39.33 71.68 11.92 13.33 27.94 24.74 42.57 33.52"/>
+            <path d="m551.31 214.4 6.93 8.01-10.42-1.94z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M425.25 109.5c-27.48 10.81-65.2 25.64-94.72 37.25"/>
+            <path d="m332.05 149.92-10.59.4 8.03-6.92z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M939.84 106.5c-9.54 1.93-19.41 3.84-28.71 5.5-108 19.26-235.39 37.16-304.07 46.42"/>
+            <path d="m607.62 161.87-10.37-2.13 9.44-4.8z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M968.47 111.29c-38.36 25.33-112.4 74.23-155.97 103.01"/>
+            <path d="m814.7 217.04-10.27 2.59 6.42-8.43z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M952.44 109.27c-76.15 26.7-239.67 84.03-319.13 111.89"/>
+            <path d="m634.7 224.38-10.59.01 8.27-6.62z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="m589.26 177.18 131.95 41.79"/>
+            <path d="m722.19 215.61 8.47 6.36-10.59.31z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M522.04 175.53C471.55 189.9 380.2 224.25 341.13 292c-7.99 13.86-7.36 21.79 0 36 7.13 13.76 19.66 24.72 32.46 33.01"/>
+            <path d="m375.25 357.93 6.8 8.13-10.38-2.12z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M582.63 180.21c18.33 9.97 43.28 24.49 63.5 39.79 18.55 14.04 16.89 26.22 38 36 133.07 61.65 183.33 11.96 328 36 5.23.87 10.63 1.87 16.04 2.94"/>
+            <path d="m1028.66 291.47 9.08 5.45-10.5 1.4z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M626.36 249.67c8.15 2.17 16.73 4.39 24.77 6.33 74.65 18.01 120.68-23.69 169 36 14.16 17.49 6.2 42.9-3.73 62.09"/>
+            <path d="m819.51 355.71-7.95 7 1.85-10.43z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M625.21 250.09c8.46 2.23 17.45 4.36 25.92 5.91 158.59 29.1 201.81 10.35 361 36 5.31.86 10.8 1.86 16.3 2.93"/>
+            <path d="m1029.07 291.49 9.09 5.45-10.5 1.41z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="412.13" cy="-90" fill="none" stroke="#000" rx="66.26" ry="18"/>
+            <text x="412.13" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:database</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="m556.18 252-93.88 38.21"/>
+            <path fill="red" d="m465.15 292.83-10.58.53 7.94-7.02z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="931.13" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="931.13" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M625.98 249.79c8.25 2.19 16.97 4.38 25.15 6.21 88.99 19.9 112.45 18.74 202 36 6.31 1.22 12.89 2.52 19.45 3.84"/>
+            <path d="m872.97 292.35 9.1 5.43-10.49 1.43z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="742.13" cy="-90" fill="none" stroke="#000" rx="64.66" ry="18"/>
+            <text x="742.13" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:network</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M618.59 252.5c23.83 10.55 57.28 25.37 83.94 37.19"/>
+            <path d="m703.65 286.35 7.72 7.25-10.56-.85z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="578.13" cy="-90" fill="none" stroke="#000" rx="81.29" ry="18"/>
+            <text x="578.13" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:notifications</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M586.65 256.3c-.63 7.29-1.37 15.97-2.07 24.16"/>
+            <path d="m588.07 280.72-4.35 9.67-2.63-10.26z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M1037.64 172.89c-76.58 9.09-226.61 27.56-353.51 47.11-13.59 2.09-28.23 4.57-41.87 6.98"/>
+            <path d="m643.02 230.4-10.46-1.69 9.23-5.2z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M1088.13 184.41v96.17"/>
+            <path d="m1091.63 280.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M331.63 177.94c55.58 12.79 147.28 33.91 204.66 47.12"/>
+            <path fill="red" d="m535.38 221.26 8.96 5.66-10.53 1.16z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M281.82 184.44c-3.23 31.81-5.55 99.99 26.31 143.56 13.06 17.87 33.81 30.02 53.65 38.13"/>
+            <path d="m362.8 362.78 8.12 6.81-10.59-.26z"/>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M416.13 328.3v24.16"/>
+            <path fill="red" d="m419.63 350.87-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M904.95 326.54c-19.28 9.92-44.51 22.9-65.5 33.71"/>
+            <path d="m841.07 363.35-10.5 1.47 7.29-7.69z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M877.24 319.75c-18.26 2.7-38.52 5.66-57.11 8.25-120.2 16.77-260.74 34.86-340.37 44.98"/>
+            <path d="m480.33 376.43-10.37-2.21 9.48-4.73z"/>
+        </g>
+        <g class="node" transform="translate(4 400)">
+            <ellipse cx="971.13" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="971.13" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M945.02 328.3c4.45 7.8 9.82 17.19 14.78 25.87"/>
+            <path d="m962.68 352.16 1.92 10.42-8-6.94z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M758.96 327.95c6.18 8.16 13.74 18.14 20.62 27.23"/>
+            <path d="M782.26 352.92 785.5 363l-8.82-5.86z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M697.6 322.31c-8.48 1.93-17.23 3.89-25.47 5.69-67.75 14.79-145.82 30.81-197.76 41.32"/>
+            <path d="m475.36 372.69-10.5-1.45 9.11-5.41z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M626.83 325.42c34.89 11.26 83.44 26.92 120.11 38.75"/>
+            <path d="m747.55 360.68 8.44 6.4-10.59.26z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M545.7 326.36c-25.25 10.65-59 24.88-85.72 36.15"/>
+            <path d="m461.34 365.73-10.57.66 7.85-7.11z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:feature:interests</title>
-      <ellipse fill="none" stroke="black" cx="297.13" cy="-306" rx="75.39" ry="18"/>
-      <text text-anchor="middle" x="297.13" y="-301.8" font-family="Times,serif" font-size="14.00">:feature:interests</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:app-&gt;:feature:interests</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M618.9,-371.75C571.45,-362.24 468.2,-341.55 381.13,-324 375.62,-322.89 369.9,-321.74 364.17,-320.58"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="366.62,-317.5 356.12,-318.95 365.23,-324.36 366.62,-317.5"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:feature:foryou</title>
-      <ellipse fill="none" stroke="black" cx="135.13" cy="-306" rx="68.95" ry="18"/>
-      <text text-anchor="middle" x="135.13" y="-301.8" font-family="Times,serif" font-size="14.00">:feature:foryou</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:app-&gt;:feature:foryou</title>
-      <path fill="none" stroke="black" d="M617.71,-374.52C549.19,-368.15 365.1,-349.83 213.13,-324 207.63,-323.07 201.94,-322.01 196.25,-320.88"/>
-      <polygon fill="black" stroke="black" points="197.33,-317.53 186.83,-318.96 195.93,-324.39 197.33,-317.53"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:feature:bookmarks</title>
-      <ellipse fill="none" stroke="black" cx="812.13" cy="-306" rx="86.12" ry="18"/>
-      <text text-anchor="middle" x="812.13" y="-301.8" font-family="Times,serif" font-size="14.00">:feature:bookmarks</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:app-&gt;:feature:bookmarks</title>
-      <path fill="none" stroke="black" d="M668,-367.41C692.72,-357.05 732.82,-340.24 764.45,-326.98"/>
-      <polygon fill="black" stroke="black" points="765.56,-330.32 773.43,-323.22 762.85,-323.86 765.56,-330.32"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:feature:topic</title>
-      <ellipse fill="none" stroke="black" cx="645.13" cy="-306" rx="62.51" ry="18"/>
-      <text text-anchor="middle" x="645.13" y="-301.8" font-family="Times,serif" font-size="14.00">:feature:topic</text>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:app-&gt;:feature:topic</title>
-      <path fill="none" stroke="black" d="M645.13,-359.7C645.13,-352.41 645.13,-343.73 645.13,-335.54"/>
-      <polygon fill="black" stroke="black" points="648.63,-335.62 645.13,-325.62 641.63,-335.62 648.63,-335.62"/>
-    </g>
-    <g id="node6" class="node">
-      <title>:feature:search</title>
-      <ellipse fill="none" stroke="black" cx="458.13" cy="-306" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="458.13" y="-301.8" font-family="Times,serif" font-size="14.00">:feature:search</text>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:app-&gt;:feature:search</title>
-      <path fill="none" stroke="black" d="M621.45,-368.13C592.73,-357.39 543.61,-339 506.72,-325.19"/>
-      <polygon fill="black" stroke="black" points="508.19,-322 497.6,-321.78 505.74,-328.56 508.19,-322"/>
-    </g>
-    <g id="node7" class="node">
-      <title>:feature:settings</title>
-      <ellipse fill="none" stroke="black" cx="989.13" cy="-306" rx="72.71" ry="18"/>
-      <text text-anchor="middle" x="989.13" y="-301.8" font-family="Times,serif" font-size="14.00">:feature:settings</text>
-    </g>
-    <g id="edge6" class="edge">
-      <title>:app-&gt;:feature:settings</title>
-      <path fill="none" stroke="black" d="M671.54,-371.7C718.81,-362.21 820.98,-341.64 907.13,-324 912.6,-322.88 918.27,-321.71 923.96,-320.54"/>
-      <polygon fill="black" stroke="black" points="924.32,-324.04 933.4,-318.59 922.9,-317.19 924.32,-324.04"/>
-    </g>
-    <g id="node8" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="795.13" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="795.13" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge7" class="edge">
-      <title>:app-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M672.95,-377.23C766.59,-377.52 1068.86,-374.44 1149.13,-324 1188.5,-299.26 1204.13,-281.5 1204.13,-235 1204.13,-235 1204.13,-235 1204.13,-161 1204.13,-116.87 1196.1,-97.56 1160.13,-72 1107.37,-34.51 934.89,-47.08 871.13,-36 865.91,-35.09 860.51,-34.07 855.1,-32.98"/>
-      <polygon fill="black" stroke="black" points="856.04,-29.6 845.53,-30.98 854.61,-36.45 856.04,-29.6"/>
-    </g>
-    <g id="node9" class="node">
-      <title>:core:ui</title>
-      <ellipse fill="none" stroke="black" cx="553.13" cy="-234" rx="40.53" ry="18"/>
-      <text text-anchor="middle" x="553.13" y="-229.8" font-family="Times,serif" font-size="14.00">:core:ui</text>
-    </g>
-    <g id="edge8" class="edge">
-      <title>:app-&gt;:core:ui</title>
-      <path fill="none" stroke="black" d="M623.54,-366.56C607.2,-357.54 585.52,-342.97 573.13,-324 561.41,-306.05 556.49,-282.21 554.46,-263.71"/>
-      <polygon fill="black" stroke="black" points="557.96,-263.62 553.63,-253.96 550.99,-264.22 557.96,-263.62"/>
-    </g>
-    <g id="node10" class="node">
-      <title>:core:designsystem</title>
-      <ellipse fill="none" stroke="black" cx="774.13" cy="-162" rx="85.06" ry="18"/>
-      <text text-anchor="middle" x="774.13" y="-157.8" font-family="Times,serif" font-size="14.00">:core:designsystem</text>
-    </g>
-    <g id="edge9" class="edge">
-      <title>:app-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M673,-375.63C763.47,-370.92 1044.67,-353.95 1071.13,-324 1081.72,-312.01 1079.98,-301.33 1071.13,-288 1056.87,-266.53 909.24,-211.2 827.64,-181.88"/>
-      <polygon fill="black" stroke="black" points="828.85,-178.59 818.25,-178.52 826.49,-185.18 828.85,-178.59"/>
-    </g>
-    <g id="node11" class="node">
-      <title>:core:data</title>
-      <ellipse fill="none" stroke="black" cx="584.13" cy="-162" rx="49.1" ry="18"/>
-      <text text-anchor="middle" x="584.13" y="-157.8" font-family="Times,serif" font-size="14.00">:core:data</text>
-    </g>
-    <g id="edge10" class="edge">
-      <title>:app-&gt;:core:data</title>
-      <path fill="none" stroke="black" d="M617.3,-376.64C505.79,-374.93 95.33,-365.8 57.13,-324 -77.67,-176.51 358.28,-162.51 523.4,-162.36"/>
-      <polygon fill="black" stroke="black" points="523.29,-165.86 533.29,-162.37 523.29,-158.86 523.29,-165.86"/>
-    </g>
-    <g id="node12" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="412.13" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="412.13" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge11" class="edge">
-      <title>:app-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M617.23,-376.35C503.4,-373.48 77.9,-360.37 31.13,-324 -1.94,-298.29 0.13,-276.89 0.13,-235 0.13,-235 0.13,-235 0.13,-161 0.13,-88.15 233.3,-44.54 348.81,-27.41"/>
-      <polygon fill="black" stroke="black" points="349.06,-30.91 358.45,-26.01 348.05,-23.99 349.06,-30.91"/>
-    </g>
-    <g id="node13" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="1084.13" cy="-90" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="1084.13" y="-85.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge12" class="edge">
-      <title>:app-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M672.84,-375.63C769.36,-370.63 1086.84,-352.17 1122.13,-324 1160.64,-293.26 1158.53,-263.93 1147.13,-216 1138.52,-179.8 1117.67,-142.18 1102.3,-117.8"/>
-      <polygon fill="black" stroke="black" points="1105.29,-115.97 1096.93,-109.47 1099.41,-119.77 1105.29,-115.97"/>
-    </g>
-    <g id="node14" class="node">
-      <title>:sync:work</title>
-      <ellipse fill="none" stroke="black" cx="1084.13" cy="-234" rx="53.95" ry="18"/>
-      <text text-anchor="middle" x="1084.13" y="-229.8" font-family="Times,serif" font-size="14.00">:sync:work</text>
-    </g>
-    <g id="edge13" class="edge">
-      <title>:app-&gt;:sync:work</title>
-      <path fill="none" stroke="black" d="M672.8,-375.91C767.64,-371.87 1075.28,-356.38 1104.13,-324 1119.22,-307.06 1111.16,-281.21 1101.13,-261.73"/>
-      <polygon fill="black" stroke="black" points="1104.33,-260.27 1096.4,-253.25 1098.22,-263.69 1104.33,-260.27"/>
-    </g>
-    <g id="edge14" class="edge">
-      <title>:feature:interests-&gt;:core:ui</title>
-      <path fill="none" stroke="black" d="M345.28,-291.83C392.01,-279.06 462.39,-259.81 508.05,-247.33"/>
-      <polygon fill="black" stroke="black" points="508.91,-250.72 517.64,-244.7 507.07,-243.97 508.91,-250.72"/>
-    </g>
-    <g id="edge15" class="edge">
-      <title>:feature:interests-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M331.47,-289.69C385.46,-265.68 485.87,-221.35 503.13,-216 565.44,-196.69 638.07,-182.94 692.45,-174.29"/>
-      <polygon fill="black" stroke="black" points="692.93,-177.75 702.27,-172.75 691.85,-170.84 692.93,-177.75"/>
-    </g>
-    <g id="edge16" class="edge">
-      <title>:feature:interests-&gt;:core:data</title>
-      <path fill="none" stroke="black" d="M318.57,-288.44C344.39,-269.08 389.6,-237.03 432.13,-216 465.15,-199.67 504.47,-186.11 534.84,-176.79"/>
-      <polygon fill="black" stroke="black" points="535.58,-180.22 544.14,-173.99 533.56,-173.52 535.58,-180.22"/>
-    </g>
-    <g id="node15" class="node">
-      <title>:core:domain</title>
-      <ellipse fill="none" stroke="black" cx="280.13" cy="-234" rx="61.99" ry="18"/>
-      <text text-anchor="middle" x="280.13" y="-229.8" font-family="Times,serif" font-size="14.00">:core:domain</text>
-    </g>
-    <g id="edge17" class="edge">
-      <title>:feature:interests-&gt;:core:domain</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M292.93,-287.7C291.14,-280.32 289,-271.52 286.99,-263.25"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="290.76,-263.94 285,-255.05 283.96,-265.59 290.76,-263.94"/>
-    </g>
-    <g id="edge37" class="edge">
-      <title>:feature:foryou-&gt;:core:ui</title>
-      <path fill="none" stroke="black" d="M185.81,-293.49C194.89,-291.56 204.27,-289.65 213.13,-288 315.89,-268.81 437.04,-251.09 503.41,-241.8"/>
-      <polygon fill="black" stroke="black" points="503.84,-245.27 513.26,-240.43 502.87,-238.34 503.84,-245.27"/>
-    </g>
-    <g id="edge38" class="edge">
-      <title>:feature:foryou-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M185.66,-293.33C244.53,-279.61 335.74,-257.97 351.13,-252 382.28,-239.92 385.45,-226.62 417.13,-216 442.63,-207.45 594.52,-186.53 691.79,-173.68"/>
-      <polygon fill="black" stroke="black" points="692.12,-177.16 701.57,-172.39 691.2,-170.22 692.12,-177.16"/>
-    </g>
-    <g id="edge39" class="edge">
-      <title>:feature:foryou-&gt;:core:data</title>
-      <path fill="none" stroke="black" d="M144.05,-287.98C155.92,-267.22 178.94,-232.84 209.13,-216 261.93,-186.55 432.36,-172.06 524.19,-166.24"/>
-      <polygon fill="black" stroke="black" points="524.25,-169.74 534.02,-165.63 523.82,-162.75 524.25,-169.74"/>
-    </g>
-    <g id="edge40" class="edge">
-      <title>:feature:foryou-&gt;:core:domain</title>
-      <path fill="none" stroke="black" d="M166.95,-289.64C188.2,-279.38 216.36,-265.79 239.26,-254.73"/>
-      <polygon fill="black" stroke="black" points="240.53,-258 248.01,-250.5 237.49,-251.7 240.53,-258"/>
-    </g>
-    <g id="edge41" class="edge">
-      <title>:feature:bookmarks-&gt;:core:ui</title>
-      <path fill="none" stroke="black" d="M760.96,-291.17C713.53,-278.35 643.64,-259.46 598.25,-247.19"/>
-      <polygon fill="black" stroke="black" points="599.29,-243.85 588.73,-244.62 597.47,-250.61 599.29,-243.85"/>
-    </g>
-    <g id="edge42" class="edge">
-      <title>:feature:bookmarks-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M807.47,-287.59C801.02,-263.5 789.32,-219.75 781.63,-191.03"/>
-      <polygon fill="black" stroke="black" points="785.07,-190.33 779.1,-181.57 778.3,-192.14 785.07,-190.33"/>
-    </g>
-    <g id="edge43" class="edge">
-      <title>:feature:bookmarks-&gt;:core:data</title>
-      <path fill="none" stroke="black" d="M783.58,-288.58C765.8,-278.26 742.5,-264.56 722.13,-252 685.6,-229.48 644.32,-202.68 616.51,-184.41"/>
-      <polygon fill="black" stroke="black" points="618.44,-181.49 608.17,-178.92 614.6,-187.34 618.44,-181.49"/>
-    </g>
-    <g id="edge44" class="edge">
-      <title>:feature:topic-&gt;:core:ui</title>
-      <path fill="none" stroke="black" d="M623.79,-288.76C611.28,-279.25 595.32,-267.1 581.74,-256.77"/>
-      <polygon fill="black" stroke="black" points="584.06,-254.14 573.99,-250.87 579.82,-259.71 584.06,-254.14"/>
-    </g>
-    <g id="edge45" class="edge">
-      <title>:feature:topic-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M660.43,-288.15C682.93,-263.39 725.1,-216.97 751.27,-188.16"/>
-      <polygon fill="black" stroke="black" points="753.69,-190.7 757.83,-180.95 748.51,-185.99 753.69,-190.7"/>
-    </g>
-    <g id="edge46" class="edge">
-      <title>:feature:topic-&gt;:core:data</title>
-      <path fill="none" stroke="black" d="M637.77,-287.87C627.37,-263.67 608.28,-219.21 595.9,-190.39"/>
-      <polygon fill="black" stroke="black" points="599.27,-189.39 592.11,-181.58 592.84,-192.15 599.27,-189.39"/>
-    </g>
-    <g id="edge47" class="edge">
-      <title>:feature:search-&gt;:core:ui</title>
-      <path fill="none" stroke="black" d="M480.16,-288.76C493.08,-279.25 509.56,-267.1 523.59,-256.77"/>
-      <polygon fill="black" stroke="black" points="525.64,-259.6 531.62,-250.85 521.49,-253.96 525.64,-259.6"/>
-    </g>
-    <g id="edge48" class="edge">
-      <title>:feature:search-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M499.63,-291.43C528.93,-281.46 568.92,-267.08 603.13,-252 649.76,-231.45 701.4,-203.86 735.61,-184.88"/>
-      <polygon fill="black" stroke="black" points="737.29,-187.95 744.32,-180.02 733.88,-181.84 737.29,-187.95"/>
-    </g>
-    <g id="edge49" class="edge">
-      <title>:feature:search-&gt;:core:data</title>
-      <path fill="none" stroke="black" d="M463.8,-287.68C470.73,-268.48 483.97,-237.42 503.13,-216 515.05,-202.67 531.07,-191.26 545.7,-182.48"/>
-      <polygon fill="black" stroke="black" points="547.31,-185.6 554.24,-177.59 543.82,-179.53 547.31,-185.6"/>
-    </g>
-    <g id="edge50" class="edge">
-      <title>:feature:search-&gt;:core:domain</title>
-      <path fill="none" stroke="black" d="M421.25,-290.5C393.77,-279.69 356.05,-264.86 326.53,-253.25"/>
-      <polygon fill="black" stroke="black" points="328.05,-250.08 317.46,-249.68 325.49,-256.6 328.05,-250.08"/>
-    </g>
-    <g id="edge51" class="edge">
-      <title>:feature:settings-&gt;:core:ui</title>
-      <path fill="none" stroke="black" d="M935.84,-293.5C926.3,-291.57 916.43,-289.66 907.13,-288 799.13,-268.74 671.74,-250.84 603.06,-241.58"/>
-      <polygon fill="black" stroke="black" points="603.62,-238.13 593.25,-240.26 602.69,-245.06 603.62,-238.13"/>
-    </g>
-    <g id="edge52" class="edge">
-      <title>:feature:settings-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M964.47,-288.71C926.11,-263.38 852.07,-214.48 808.5,-185.7"/>
-      <polygon fill="black" stroke="black" points="810.7,-182.96 800.43,-180.37 806.85,-188.8 810.7,-182.96"/>
-    </g>
-    <g id="edge53" class="edge">
-      <title>:feature:settings-&gt;:core:data</title>
-      <path fill="none" stroke="black" d="M948.44,-290.73C872.29,-264.03 708.77,-206.7 629.31,-178.84"/>
-      <polygon fill="black" stroke="black" points="630.7,-175.62 620.11,-175.61 628.38,-182.23 630.7,-175.62"/>
-    </g>
-    <g id="edge19" class="edge">
-      <title>:core:ui-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M585.26,-222.82C619.77,-211.89 675.28,-194.31 717.21,-181.03"/>
-      <polygon fill="black" stroke="black" points="718.19,-184.39 726.66,-178.03 716.07,-177.72 718.19,-184.39"/>
-    </g>
-    <g id="edge20" class="edge">
-      <title>:core:ui-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M518.04,-224.47C467.55,-210.1 376.2,-175.75 337.13,-108 329.14,-94.14 329.77,-86.21 337.13,-72 344.26,-58.24 356.79,-47.28 369.59,-38.99"/>
-      <polygon fill="black" stroke="black" points="371.25,-42.07 378.05,-33.94 367.67,-36.06 371.25,-42.07"/>
-    </g>
-    <g id="edge18" class="edge">
-      <title>:core:ui-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M578.63,-219.79C596.96,-209.82 621.91,-195.3 642.13,-180 660.68,-165.96 659.02,-153.78 680.13,-144 813.2,-82.35 863.46,-132.04 1008.13,-108 1013.36,-107.13 1018.76,-106.13 1024.17,-105.06"/>
-      <polygon fill="black" stroke="black" points="1024.66,-108.53 1033.74,-103.08 1023.24,-101.68 1024.66,-108.53"/>
-    </g>
-    <g id="edge21" class="edge">
-      <title>:core:data-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M622.36,-150.33C630.51,-148.16 639.09,-145.94 647.13,-144 721.78,-125.99 767.81,-167.69 816.13,-108 830.29,-90.51 822.33,-65.1 812.4,-45.91"/>
-      <polygon fill="black" stroke="black" points="815.51,-44.29 807.56,-37.29 809.41,-47.72 815.51,-44.29"/>
-    </g>
-    <g id="edge25" class="edge">
-      <title>:core:data-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M621.21,-149.91C629.67,-147.68 638.66,-145.55 647.13,-144 805.72,-114.9 848.94,-133.65 1008.13,-108 1013.44,-107.14 1018.93,-106.14 1024.43,-105.07"/>
-      <polygon fill="black" stroke="black" points="1025.07,-108.51 1034.16,-103.06 1023.66,-101.65 1025.07,-108.51"/>
-    </g>
-    <g id="node16" class="node">
-      <title>:core:database</title>
-      <ellipse fill="none" stroke="black" cx="412.13" cy="-90" rx="66.26" ry="18"/>
-      <text text-anchor="middle" x="412.13" y="-85.8" font-family="Times,serif" font-size="14.00">:core:database</text>
-    </g>
-    <g id="edge22" class="edge">
-      <title>:core:data-&gt;:core:database</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M552.18,-148C525.79,-137.26 487.98,-121.87 458.3,-109.79"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="461.15,-107.17 450.57,-106.64 458.51,-113.66 461.15,-107.17"/>
-    </g>
-    <g id="node17" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="931.13" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="931.13" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
-    </g>
-    <g id="edge23" class="edge">
-      <title>:core:data-&gt;:core:datastore</title>
-      <path fill="none" stroke="black" d="M621.98,-150.21C630.23,-148.02 638.95,-145.83 647.13,-144 736.12,-124.1 759.58,-125.26 849.13,-108 855.44,-106.78 862.02,-105.48 868.58,-104.16"/>
-      <polygon fill="black" stroke="black" points="868.97,-107.65 878.07,-102.22 867.58,-100.79 868.97,-107.65"/>
-    </g>
-    <g id="node18" class="node">
-      <title>:core:network</title>
-      <ellipse fill="none" stroke="black" cx="742.13" cy="-90" rx="64.66" ry="18"/>
-      <text text-anchor="middle" x="742.13" y="-85.8" font-family="Times,serif" font-size="14.00">:core:network</text>
-    </g>
-    <g id="edge24" class="edge">
-      <title>:core:data-&gt;:core:network</title>
-      <path fill="none" stroke="black" d="M614.59,-147.5C638.42,-136.95 671.87,-122.13 698.53,-110.31"/>
-      <polygon fill="black" stroke="black" points="699.65,-113.65 707.37,-106.4 696.81,-107.25 699.65,-113.65"/>
-    </g>
-    <g id="node19" class="node">
-      <title>:core:notifications</title>
-      <ellipse fill="none" stroke="black" cx="578.13" cy="-90" rx="81.29" ry="18"/>
-      <text text-anchor="middle" x="578.13" y="-85.8" font-family="Times,serif" font-size="14.00">:core:notifications</text>
-    </g>
-    <g id="edge26" class="edge">
-      <title>:core:data-&gt;:core:notifications</title>
-      <path fill="none" stroke="black" d="M582.65,-143.7C582.02,-136.41 581.28,-127.73 580.58,-119.54"/>
-      <polygon fill="black" stroke="black" points="584.07,-119.28 579.72,-109.61 577.09,-119.87 584.07,-119.28"/>
-    </g>
-    <g id="edge55" class="edge">
-      <title>:sync:work-&gt;:core:data</title>
-      <path fill="none" stroke="black" d="M1033.64,-227.11C957.06,-218.02 807.03,-199.55 680.13,-180 666.54,-177.91 651.9,-175.43 638.26,-173.02"/>
-      <polygon fill="black" stroke="black" points="639.02,-169.6 628.56,-171.29 637.79,-176.49 639.02,-169.6"/>
-    </g>
-    <g id="edge54" class="edge">
-      <title>:sync:work-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M1084.13,-215.59C1084.13,-191.61 1084.13,-148.14 1084.13,-119.42"/>
-      <polygon fill="black" stroke="black" points="1087.63,-119.62 1084.13,-109.62 1080.63,-119.62 1087.63,-119.62"/>
-    </g>
-    <g id="edge35" class="edge">
-      <title>:core:domain-&gt;:core:data</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M327.63,-222.06C383.21,-209.27 474.91,-188.15 532.29,-174.94"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="531.38,-178.74 540.34,-173.08 529.81,-171.92 531.38,-178.74"/>
-    </g>
-    <g id="edge36" class="edge">
-      <title>:core:domain-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M277.82,-215.56C274.59,-183.75 272.27,-115.57 304.13,-72 317.19,-54.13 337.94,-41.98 357.78,-33.87"/>
-      <polygon fill="black" stroke="black" points="358.8,-37.22 366.92,-30.41 356.33,-30.67 358.8,-37.22"/>
-    </g>
-    <g id="edge27" class="edge">
-      <title>:core:database-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M412.13,-71.7C412.13,-64.41 412.13,-55.73 412.13,-47.54"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="415.63,-49.13 412.13,-39.13 408.63,-49.13 415.63,-49.13"/>
-    </g>
-    <g id="edge30" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M900.95,-73.46C881.67,-63.54 856.44,-50.56 835.45,-39.75"/>
-      <polygon fill="black" stroke="black" points="837.07,-36.65 826.57,-35.18 833.86,-42.87 837.07,-36.65"/>
-    </g>
-    <g id="edge29" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M873.24,-80.25C854.98,-77.55 834.72,-74.59 816.13,-72 695.93,-55.23 555.39,-37.14 475.76,-27.02"/>
-      <polygon fill="black" stroke="black" points="476.33,-23.57 465.96,-25.78 475.44,-30.51 476.33,-23.57"/>
-    </g>
-    <g id="node20" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="971.13" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="971.13" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge28" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="black" d="M941.02,-71.7C945.47,-63.9 950.84,-54.51 955.8,-45.83"/>
-      <polygon fill="black" stroke="black" points="958.68,-47.84 960.6,-37.42 952.6,-44.36 958.68,-47.84"/>
-    </g>
-    <g id="edge31" class="edge">
-      <title>:core:network-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M754.96,-72.05C761.14,-63.89 768.7,-53.91 775.58,-44.82"/>
-      <polygon fill="black" stroke="black" points="778.26,-47.08 781.5,-37 772.68,-42.86 778.26,-47.08"/>
-    </g>
-    <g id="edge32" class="edge">
-      <title>:core:network-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M693.6,-77.69C685.12,-75.76 676.37,-73.8 668.13,-72 600.38,-57.21 522.31,-41.19 470.37,-30.68"/>
-      <polygon fill="black" stroke="black" points="471.36,-27.31 460.86,-28.76 469.97,-34.17 471.36,-27.31"/>
-    </g>
-    <g id="edge34" class="edge">
-      <title>:core:notifications-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M622.83,-74.58C657.72,-63.32 706.27,-47.66 742.94,-35.83"/>
-      <polygon fill="black" stroke="black" points="743.55,-39.32 751.99,-32.92 741.4,-32.66 743.55,-39.32"/>
-    </g>
-    <g id="edge33" class="edge">
-      <title>:core:notifications-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M541.7,-73.64C516.45,-62.99 482.7,-48.76 455.98,-37.49"/>
-      <polygon fill="black" stroke="black" points="457.34,-34.27 446.77,-33.61 454.62,-40.72 457.34,-34.27"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_app_nia_catalog.svg
+++ b/docs/images/graphs/dep_graph_app_nia_catalog.svg
@@ -1,58 +1,45 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="462pt" height="188pt" viewBox="0.00 0.00 462.21 188.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 184)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-184 458.21,-184 458.21,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:app-nia-catalog</title>
-      <ellipse fill="none" stroke="black" cx="169.06" cy="-162" rx="73.77" ry="18"/>
-      <text text-anchor="middle" x="169.06" y="-157.8" font-family="Times,serif" font-size="14.00">:app-nia-catalog</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="616" height="188pt" viewBox="0 0 462.21 188">
+    <g class="graph">
+        <path fill="#fff" d="M0 188V0h462.21v188z"/>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="169.06" cy="-162" fill="none" stroke="#000" rx="73.77" ry="18"/>
+            <text x="169.06" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:app-nia-catalog</text>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="85.06" cy="-18" fill="none" stroke="#000" rx="85.06" ry="18"/>
+            <text x="85.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:designsystem</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M162.93 40.13c-14.38 24.31-40.85 69.05-57.89 97.86"/>
+            <path d="m108.1 139.68-8.1 6.83 2.08-10.39z"/>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="229.06" cy="-90" fill="none" stroke="#000" rx="40.53" ry="18"/>
+            <text x="229.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:ui</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M187.58 39.95c7.26 8.46 16.17 18.86 24.18 28.21"/>
+            <path fill="red" d="m213.26 64.52 3.85 9.87-9.17-5.31z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M206.31 108c-20.76 10.09-49.96 24.29-74.03 35.99"/>
+            <path d="m133.87 147.11-10.53 1.22 7.47-7.52z"/>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="255.06" cy="-18" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="255.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M239.35 111.95c2.8 7.53 6.17 16.61 9.33 25.11"/>
+            <path fill="red" d="m251.39 134.29.2 10.6-6.77-8.16z"/>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="397.06" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="397.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M261.94 107.03c26.15 10.9 65.07 27.11 95.09 39.63"/>
+            <path d="m358.37 143.42 7.89 7.08-10.58-.62z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:designsystem</title>
-      <ellipse fill="none" stroke="black" cx="85.06" cy="-18" rx="85.06" ry="18"/>
-      <text text-anchor="middle" x="85.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:designsystem</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:app-nia-catalog-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M158.93,-143.87C144.55,-119.56 118.08,-74.82 101.04,-46.01"/>
-      <polygon fill="black" stroke="black" points="104.1,-44.32 96,-37.49 98.08,-47.88 104.1,-44.32"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:ui</title>
-      <ellipse fill="none" stroke="black" cx="229.06" cy="-90" rx="40.53" ry="18"/>
-      <text text-anchor="middle" x="229.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:ui</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:app-nia-catalog-&gt;:core:ui</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M183.58,-144.05C190.84,-135.59 199.75,-125.19 207.76,-115.84"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="209.26,-119.48 213.11,-109.61 203.94,-114.92 209.26,-119.48"/>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:core:ui-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M202.31,-76C181.55,-65.91 152.35,-51.71 128.28,-40.01"/>
-      <polygon fill="black" stroke="black" points="129.87,-36.89 119.34,-35.67 126.81,-43.19 129.87,-36.89"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="255.06" cy="-18" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="255.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:core:ui-&gt;:core:analytics</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M235.35,-72.05C238.15,-64.52 241.52,-55.44 244.68,-46.94"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="247.39,-49.71 247.59,-39.11 240.82,-47.27 247.39,-49.71"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="397.06" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="397.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:core:ui-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M257.94,-76.97C284.09,-66.07 323.01,-49.86 353.03,-37.34"/>
-      <polygon fill="black" stroke="black" points="354.37,-40.58 362.26,-33.5 351.68,-34.12 354.37,-40.58"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_analytics.svg
+++ b/docs/images/graphs/dep_graph_core_analytics.svg
@@ -1,13 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="143pt" height="44pt" viewBox="0.00 0.00 142.68 44.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 40)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-40 138.68,-40 138.68,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="67.34" cy="-18" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="67.34" y="-13.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="143pt" height="44pt" viewBox="0 0 142.68 44">
+    <g class="graph">
+        <path fill="#fff" d="M0 44V0h142.68v44z"/>
+        <g class="node" transform="translate(4 40)">
+            <ellipse cx="67.34" cy="-18" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="67.34" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
     </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_common.svg
+++ b/docs/images/graphs/dep_graph_core_common.svg
@@ -1,13 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="142pt" height="44pt" viewBox="0.00 0.00 141.63 44.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 40)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-40 137.63,-40 137.63,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="66.81" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="66.81" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="142pt" height="44pt" viewBox="0 0 141.63 44">
+    <g class="graph">
+        <path fill="#fff" d="M0 44V0h141.63v44z"/>
+        <g class="node" transform="translate(4 40)">
+            <ellipse cx="66.81" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="66.81" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
     </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_data.svg
+++ b/docs/images/graphs/dep_graph_core_data.svg
@@ -1,123 +1,97 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="791pt" height="188pt" viewBox="0.00 0.00 791.30 188.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 184)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-184 787.3,-184 787.3,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:data</title>
-      <ellipse fill="none" stroke="black" cx="327.95" cy="-162" rx="49.1" ry="18"/>
-      <text text-anchor="middle" x="327.95" y="-157.8" font-family="Times,serif" font-size="14.00">:core:data</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="791pt" height="188pt" viewBox="0 0 791.3 188">
+    <g class="graph">
+        <path fill="#fff" d="M0 188V0h791.3v188z"/>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="327.95" cy="-162" fill="none" stroke="#000" rx="49.1" ry="18"/>
+            <text x="327.95" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:data</text>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="91.95" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="91.95" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M282.66 23.68C201.49 25.96 45.21 35.62 10.95 76c-10.35 12.2-7.76 22.01 0 36 8.1 14.58 22.05 25.67 36.34 33.84"/>
+            <path d="m48.61 142.58 7.22 7.76-10.48-1.56z"/>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="563.95" cy="-90" fill="none" stroke="#000" rx="66.26" ry="18"/>
+            <text x="563.95" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:database</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M369.35 34.09c38.82 11.52 99.94 29.64 144.13 42.75"/>
+            <path fill="red" d="m512.83 73 8.59 6.2-10.58.51z"/>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="411.95" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="411.95" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M351.02 38.88c10.72 8.94 24.32 20.27 36.3 30.26"/>
+            <path d="m389.49 66.39 5.44 9.09-9.92-3.71z"/>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="80.95" cy="-90" fill="none" stroke="#000" rx="64.66" ry="18"/>
+            <text x="80.95" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:network</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M293.9 33.78C252.69 45.47 186.56 64.2 139.75 77.47"/>
+            <path d="m140.92 80.78-10.57-.64 8.66-6.1z"/>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="715.95" cy="-90" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="715.95" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M376.63 29.91C437.15 39.44 548.48 57.53 642.95 76c5.19 1.01 10.56 2.11 15.95 3.24"/>
+            <path d="m659.38 75.76 9.05 5.51-10.51 1.34z"/>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="244.95" cy="-90" fill="none" stroke="#000" rx="81.29" ry="18"/>
+            <text x="244.95" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:notifications</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M313.12 38.88c-10.52 8.88-23.84 20.11-35.62 30.04"/>
+            <path d="m279.93 71.46-9.9 3.77 5.39-9.13z"/>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="244.95" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="244.95" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M518.77 106.31c-8.6 1.93-17.46 3.89-25.82 5.69-78.48 16.87-98.73 18.12-177 36-4.28.98-8.71 2.03-13.16 3.1"/>
+            <path fill="red" d="m305.26 154.1-10.55-1.01 8.88-5.79z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M365.01 106.27c-8.69 1.91-17.63 3.88-26.06 5.73-61.62 13.52-132.06 28.88-181.18 39.56"/>
+            <path d="m158.69 154.95-10.52-1.3 9.03-5.54z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M380.95 109.67c-25.67 10.76-60.7 25.44-88.22 36.98"/>
+            <path d="m294.18 149.84-10.57.64 7.87-7.1z"/>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="411.95" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="411.95" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M415.95 112.3v24.16"/>
+            <path d="m419.45 136.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M87.67 112.3c1.16 7.38 2.55 16.18 3.85 24.45"/>
+            <path d="m94.94 135.98-1.91 10.42-5.01-9.33z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M119.33 109.67c25.13 10.73 59.38 25.35 86.37 36.87"/>
+            <path d="m206.8 143.2 7.83 7.15-10.57-.71z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M214.62 110.71c-22.33 10.22-51.64 23.63-75.54 34.56"/>
+            <path d="m140.79 148.34-10.55.97 7.64-7.34z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M248.95 112.3v24.16"/>
+            <path d="m252.45 136.38-3.5 10-3.5-10z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="91.95" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="91.95" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:core:data-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M278.66,-160.32C197.49,-158.04 41.21,-148.38 6.95,-108 -3.4,-95.8 -0.81,-85.99 6.95,-72 15.05,-57.42 29,-46.33 43.29,-38.16"/>
-      <polygon fill="black" stroke="black" points="44.61,-41.42 51.83,-33.66 41.35,-35.22 44.61,-41.42"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:database</title>
-      <ellipse fill="none" stroke="black" cx="563.95" cy="-90" rx="66.26" ry="18"/>
-      <text text-anchor="middle" x="563.95" y="-85.8" font-family="Times,serif" font-size="14.00">:core:database</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:core:data-&gt;:core:database</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M365.35,-149.91C404.17,-138.39 465.29,-120.27 509.48,-107.16"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="508.83,-111 517.42,-104.8 506.84,-104.29 508.83,-111"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="411.95" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="411.95" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:core:data-&gt;:core:datastore</title>
-      <path fill="none" stroke="black" d="M347.02,-145.12C357.74,-136.18 371.34,-124.85 383.32,-114.86"/>
-      <polygon fill="black" stroke="black" points="385.49,-117.61 390.93,-108.52 381.01,-112.23 385.49,-117.61"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:core:network</title>
-      <ellipse fill="none" stroke="black" cx="80.95" cy="-90" rx="64.66" ry="18"/>
-      <text text-anchor="middle" x="80.95" y="-85.8" font-family="Times,serif" font-size="14.00">:core:network</text>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:core:data-&gt;:core:network</title>
-      <path fill="none" stroke="black" d="M289.9,-150.22C248.69,-138.53 182.56,-119.8 135.75,-106.53"/>
-      <polygon fill="black" stroke="black" points="136.92,-103.22 126.35,-103.86 135.01,-109.96 136.92,-103.22"/>
-    </g>
-    <g id="node6" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="715.95" cy="-90" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="715.95" y="-85.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:core:data-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M372.63,-154.09C433.15,-144.56 544.48,-126.47 638.95,-108 644.14,-106.99 649.51,-105.89 654.9,-104.76"/>
-      <polygon fill="black" stroke="black" points="655.38,-108.24 664.43,-102.73 653.92,-101.39 655.38,-108.24"/>
-    </g>
-    <g id="node7" class="node">
-      <title>:core:notifications</title>
-      <ellipse fill="none" stroke="black" cx="244.95" cy="-90" rx="81.29" ry="18"/>
-      <text text-anchor="middle" x="244.95" y="-85.8" font-family="Times,serif" font-size="14.00">:core:notifications</text>
-    </g>
-    <g id="edge6" class="edge">
-      <title>:core:data-&gt;:core:notifications</title>
-      <path fill="none" stroke="black" d="M309.12,-145.12C298.6,-136.24 285.28,-125.01 273.5,-115.08"/>
-      <polygon fill="black" stroke="black" points="275.93,-112.54 266.03,-108.77 271.42,-117.9 275.93,-112.54"/>
-    </g>
-    <g id="node8" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="244.95" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="244.95" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge7" class="edge">
-      <title>:core:database-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M514.77,-77.69C506.17,-75.76 497.31,-73.8 488.95,-72 410.47,-55.13 390.22,-53.88 311.95,-36 307.67,-35.02 303.24,-33.97 298.79,-32.9"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="301.26,-29.9 290.71,-30.91 299.59,-36.7 301.26,-29.9"/>
-    </g>
-    <g id="edge10" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M361.01,-77.73C352.32,-75.82 343.38,-73.85 334.95,-72 273.33,-58.48 202.89,-43.12 153.77,-32.44"/>
-      <polygon fill="black" stroke="black" points="154.69,-29.05 144.17,-30.35 153.2,-35.89 154.69,-29.05"/>
-    </g>
-    <g id="edge9" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M376.95,-74.33C351.28,-63.57 316.25,-48.89 288.73,-37.35"/>
-      <polygon fill="black" stroke="black" points="290.18,-34.16 279.61,-33.52 287.48,-40.62 290.18,-34.16"/>
-    </g>
-    <g id="node9" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="411.95" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="411.95" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge8" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="black" d="M411.95,-71.7C411.95,-64.41 411.95,-55.73 411.95,-47.54"/>
-      <polygon fill="black" stroke="black" points="415.45,-47.62 411.95,-37.62 408.45,-47.62 415.45,-47.62"/>
-    </g>
-    <g id="edge11" class="edge">
-      <title>:core:network-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M83.67,-71.7C84.83,-64.32 86.22,-55.52 87.52,-47.25"/>
-      <polygon fill="black" stroke="black" points="90.94,-48.02 89.03,-37.6 84.02,-46.93 90.94,-48.02"/>
-    </g>
-    <g id="edge12" class="edge">
-      <title>:core:network-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M115.33,-74.33C140.46,-63.6 174.71,-48.98 201.7,-37.46"/>
-      <polygon fill="black" stroke="black" points="202.8,-40.8 210.63,-33.65 200.06,-34.36 202.8,-40.8"/>
-    </g>
-    <g id="edge14" class="edge">
-      <title>:core:notifications-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M210.62,-73.29C188.29,-63.07 158.98,-49.66 135.08,-38.73"/>
-      <polygon fill="black" stroke="black" points="136.79,-35.66 126.24,-34.69 133.88,-42.03 136.79,-35.66"/>
-    </g>
-    <g id="edge13" class="edge">
-      <title>:core:notifications-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M244.95,-71.7C244.95,-64.41 244.95,-55.73 244.95,-47.54"/>
-      <polygon fill="black" stroke="black" points="248.45,-47.62 244.95,-37.62 241.45,-47.62 248.45,-47.62"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_data_test.svg
+++ b/docs/images/graphs/dep_graph_core_data_test.svg
@@ -1,133 +1,105 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="791pt" height="260pt" viewBox="0.00 0.00 791.30 260.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 256)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-256 787.3,-256 787.3,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:data-test</title>
-      <ellipse fill="none" stroke="black" cx="327.95" cy="-234" rx="65.73" ry="18"/>
-      <text text-anchor="middle" x="327.95" y="-229.8" font-family="Times,serif" font-size="14.00">:core:data-test</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="791pt" height="260pt" viewBox="0 0 791.3 260">
+    <g class="graph">
+        <path fill="#fff" d="M0 260V0h791.3v260z"/>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="327.95" cy="-234" fill="none" stroke="#000" rx="65.73" ry="18"/>
+            <text x="327.95" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:data-test</text>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="327.95" cy="-162" fill="none" stroke="#000" rx="49.1" ry="18"/>
+            <text x="327.95" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:data</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M331.95 40.3v24.16"/>
+            <path fill="red" d="m335.45 62.87-3.5 10-3.5-10z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="91.95" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="91.95" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M282.66 95.68C201.49 97.96 45.21 107.62 10.95 148c-10.35 12.2-7.76 22.01 0 36 8.1 14.58 22.05 25.67 36.34 33.84"/>
+            <path d="m48.61 214.58 7.22 7.76-10.48-1.56z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="563.95" cy="-90" fill="none" stroke="#000" rx="66.26" ry="18"/>
+            <text x="563.95" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:database</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M369.35 106.09c38.82 11.52 99.94 29.64 144.13 42.75"/>
+            <path fill="red" d="m512.83 145 8.59 6.2-10.58.51z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="411.95" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="411.95" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M351.02 110.88c10.72 8.94 24.32 20.27 36.3 30.26"/>
+            <path d="m389.49 138.39 5.44 9.09-9.92-3.71z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="80.95" cy="-90" fill="none" stroke="#000" rx="64.66" ry="18"/>
+            <text x="80.95" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:network</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M293.9 105.78c-41.21 11.69-107.34 30.42-154.15 43.69"/>
+            <path d="m140.92 152.78-10.57-.64 8.66-6.1z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="715.95" cy="-90" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="715.95" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M376.63 101.91c60.52 9.53 171.85 27.62 266.32 46.09 5.19 1.01 10.56 2.11 15.95 3.24"/>
+            <path d="m659.38 147.76 9.05 5.51-10.51 1.34z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="244.95" cy="-90" fill="none" stroke="#000" rx="81.29" ry="18"/>
+            <text x="244.95" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:notifications</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M313.12 110.88c-10.52 8.88-23.84 20.11-35.62 30.04"/>
+            <path d="m279.93 143.46-9.9 3.77 5.39-9.13z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="244.95" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="244.95" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M518.77 178.31c-8.6 1.93-17.46 3.89-25.82 5.69-78.48 16.87-98.73 18.12-177 36-4.28.98-8.71 2.03-13.16 3.1"/>
+            <path fill="red" d="m305.26 226.1-10.55-1.01 8.88-5.79z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M365.01 178.27c-8.69 1.91-17.63 3.88-26.06 5.73-61.62 13.52-132.06 28.88-181.18 39.56"/>
+            <path d="m158.69 226.95-10.52-1.3 9.03-5.54z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M380.95 181.67c-25.67 10.76-60.7 25.44-88.22 36.98"/>
+            <path d="m294.18 221.84-10.57.64 7.87-7.1z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="411.95" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="411.95" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M415.95 184.3v24.16"/>
+            <path d="m419.45 208.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M87.67 184.3c1.16 7.38 2.55 16.18 3.85 24.45"/>
+            <path d="m94.94 207.98-1.91 10.42-5.01-9.33z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M119.33 181.67c25.13 10.73 59.38 25.35 86.37 36.87"/>
+            <path d="m206.8 215.2 7.83 7.15-10.57-.71z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M214.62 182.71c-22.33 10.22-51.64 23.63-75.54 34.56"/>
+            <path d="m140.79 220.34-10.55.97 7.64-7.34z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M248.95 184.3v24.16"/>
+            <path d="m252.45 208.38-3.5 10-3.5-10z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:data</title>
-      <ellipse fill="none" stroke="black" cx="327.95" cy="-162" rx="49.1" ry="18"/>
-      <text text-anchor="middle" x="327.95" y="-157.8" font-family="Times,serif" font-size="14.00">:core:data</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:core:data-test-&gt;:core:data</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M327.95,-215.7C327.95,-208.41 327.95,-199.73 327.95,-191.54"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="331.45,-193.13 327.95,-183.13 324.45,-193.13 331.45,-193.13"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="91.95" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="91.95" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:core:data-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M278.66,-160.32C197.49,-158.04 41.21,-148.38 6.95,-108 -3.4,-95.8 -0.81,-85.99 6.95,-72 15.05,-57.42 29,-46.33 43.29,-38.16"/>
-      <polygon fill="black" stroke="black" points="44.61,-41.42 51.83,-33.66 41.35,-35.22 44.61,-41.42"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:database</title>
-      <ellipse fill="none" stroke="black" cx="563.95" cy="-90" rx="66.26" ry="18"/>
-      <text text-anchor="middle" x="563.95" y="-85.8" font-family="Times,serif" font-size="14.00">:core:database</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:core:data-&gt;:core:database</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M365.35,-149.91C404.17,-138.39 465.29,-120.27 509.48,-107.16"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="508.83,-111 517.42,-104.8 506.84,-104.29 508.83,-111"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="411.95" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="411.95" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:core:data-&gt;:core:datastore</title>
-      <path fill="none" stroke="black" d="M347.02,-145.12C357.74,-136.18 371.34,-124.85 383.32,-114.86"/>
-      <polygon fill="black" stroke="black" points="385.49,-117.61 390.93,-108.52 381.01,-112.23 385.49,-117.61"/>
-    </g>
-    <g id="node6" class="node">
-      <title>:core:network</title>
-      <ellipse fill="none" stroke="black" cx="80.95" cy="-90" rx="64.66" ry="18"/>
-      <text text-anchor="middle" x="80.95" y="-85.8" font-family="Times,serif" font-size="14.00">:core:network</text>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:core:data-&gt;:core:network</title>
-      <path fill="none" stroke="black" d="M289.9,-150.22C248.69,-138.53 182.56,-119.8 135.75,-106.53"/>
-      <polygon fill="black" stroke="black" points="136.92,-103.22 126.35,-103.86 135.01,-109.96 136.92,-103.22"/>
-    </g>
-    <g id="node7" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="715.95" cy="-90" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="715.95" y="-85.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge6" class="edge">
-      <title>:core:data-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M372.63,-154.09C433.15,-144.56 544.48,-126.47 638.95,-108 644.14,-106.99 649.51,-105.89 654.9,-104.76"/>
-      <polygon fill="black" stroke="black" points="655.38,-108.24 664.43,-102.73 653.92,-101.39 655.38,-108.24"/>
-    </g>
-    <g id="node8" class="node">
-      <title>:core:notifications</title>
-      <ellipse fill="none" stroke="black" cx="244.95" cy="-90" rx="81.29" ry="18"/>
-      <text text-anchor="middle" x="244.95" y="-85.8" font-family="Times,serif" font-size="14.00">:core:notifications</text>
-    </g>
-    <g id="edge7" class="edge">
-      <title>:core:data-&gt;:core:notifications</title>
-      <path fill="none" stroke="black" d="M309.12,-145.12C298.6,-136.24 285.28,-125.01 273.5,-115.08"/>
-      <polygon fill="black" stroke="black" points="275.93,-112.54 266.03,-108.77 271.42,-117.9 275.93,-112.54"/>
-    </g>
-    <g id="node9" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="244.95" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="244.95" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge8" class="edge">
-      <title>:core:database-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M514.77,-77.69C506.17,-75.76 497.31,-73.8 488.95,-72 410.47,-55.13 390.22,-53.88 311.95,-36 307.67,-35.02 303.24,-33.97 298.79,-32.9"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="301.26,-29.9 290.71,-30.91 299.59,-36.7 301.26,-29.9"/>
-    </g>
-    <g id="edge11" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M361.01,-77.73C352.32,-75.82 343.38,-73.85 334.95,-72 273.33,-58.48 202.89,-43.12 153.77,-32.44"/>
-      <polygon fill="black" stroke="black" points="154.69,-29.05 144.17,-30.35 153.2,-35.89 154.69,-29.05"/>
-    </g>
-    <g id="edge10" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M376.95,-74.33C351.28,-63.57 316.25,-48.89 288.73,-37.35"/>
-      <polygon fill="black" stroke="black" points="290.18,-34.16 279.61,-33.52 287.48,-40.62 290.18,-34.16"/>
-    </g>
-    <g id="node10" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="411.95" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="411.95" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge9" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="black" d="M411.95,-71.7C411.95,-64.41 411.95,-55.73 411.95,-47.54"/>
-      <polygon fill="black" stroke="black" points="415.45,-47.62 411.95,-37.62 408.45,-47.62 415.45,-47.62"/>
-    </g>
-    <g id="edge12" class="edge">
-      <title>:core:network-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M83.67,-71.7C84.83,-64.32 86.22,-55.52 87.52,-47.25"/>
-      <polygon fill="black" stroke="black" points="90.94,-48.02 89.03,-37.6 84.02,-46.93 90.94,-48.02"/>
-    </g>
-    <g id="edge13" class="edge">
-      <title>:core:network-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M115.33,-74.33C140.46,-63.6 174.71,-48.98 201.7,-37.46"/>
-      <polygon fill="black" stroke="black" points="202.8,-40.8 210.63,-33.65 200.06,-34.36 202.8,-40.8"/>
-    </g>
-    <g id="edge15" class="edge">
-      <title>:core:notifications-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M210.62,-73.29C188.29,-63.07 158.98,-49.66 135.08,-38.73"/>
-      <polygon fill="black" stroke="black" points="136.79,-35.66 126.24,-34.69 133.88,-42.03 136.79,-35.66"/>
-    </g>
-    <g id="edge14" class="edge">
-      <title>:core:notifications-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M244.95,-71.7C244.95,-64.41 244.95,-55.73 244.95,-47.54"/>
-      <polygon fill="black" stroke="black" points="248.45,-47.62 244.95,-37.62 241.45,-47.62 248.45,-47.62"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_database.svg
+++ b/docs/images/graphs/dep_graph_core_database.svg
@@ -1,23 +1,17 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="141pt" height="116pt" viewBox="0.00 0.00 140.52 116.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 112)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-112 136.52,-112 136.52,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:database</title>
-      <ellipse fill="none" stroke="black" cx="66.26" cy="-90" rx="66.26" ry="18"/>
-      <text text-anchor="middle" x="66.26" y="-85.8" font-family="Times,serif" font-size="14.00">:core:database</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="188" height="116pt" viewBox="0 0 140.52 116">
+    <g class="graph">
+        <path fill="#fff" d="M0 116V0h140.52v116z"/>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="66.26" cy="-90" fill="none" stroke="#000" rx="66.26" ry="18"/>
+            <text x="66.26" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:database</text>
+        </g>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="66.26" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="66.26" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M70.26 40.3v24.16"/>
+            <path fill="red" d="m73.76 62.87-3.5 10-3.5-10z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="66.26" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="66.26" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:core:database-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M66.26,-71.7C66.26,-64.41 66.26,-55.73 66.26,-47.54"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="69.76,-49.13 66.26,-39.13 62.76,-49.13 69.76,-49.13"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_datastore.svg
+++ b/docs/images/graphs/dep_graph_core_datastore.svg
@@ -1,43 +1,33 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="475pt" height="116pt" viewBox="0.00 0.00 475.29 116.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 112)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-112 471.29,-112 471.29,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="258.47" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="258.47" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="475pt" height="116pt" viewBox="0 0 475.29 116">
+    <g class="graph">
+        <path fill="#fff" d="M0 116V0h475.29v116z"/>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="258.47" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="258.47" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="91.47" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="91.47" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M227.47 37.67c-24.41 10.23-57.26 24.01-84.09 35.25"/>
+            <path fill="red" d="m146.42 75.44-10.58.64 7.87-7.09z"/>
+        </g>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="258.47" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="258.47" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M262.47 40.3v24.16"/>
+            <path d="m265.97 64.38-3.5 10-3.5-10z"/>
+        </g>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="400.47" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="400.47" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M293.64 38.36c20.44 10.08 47.39 23.36 69.6 34.31"/>
+            <path d="m364.61 69.44 7.42 7.56-10.52-1.28z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="91.47" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="91.47" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M223.47,-74.33C199.06,-64.1 166.21,-50.32 139.38,-39.08"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="142.42,-36.56 131.84,-35.92 139.71,-43.01 142.42,-36.56"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="258.47" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="258.47" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M258.47,-71.7C258.47,-64.41 258.47,-55.73 258.47,-47.54"/>
-      <polygon fill="black" stroke="black" points="261.97,-47.62 258.47,-37.62 254.97,-47.62 261.97,-47.62"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="400.47" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="400.47" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M289.64,-73.64C310.08,-63.56 337.03,-50.28 359.24,-39.33"/>
-      <polygon fill="black" stroke="black" points="360.61,-42.56 368.03,-35 357.51,-36.28 360.61,-42.56"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_datastore_proto.svg
+++ b/docs/images/graphs/dep_graph_core_datastore_proto.svg
@@ -1,13 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="191pt" height="44pt" viewBox="0.00 0.00 190.95 44.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 40)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-40 186.95,-40 186.95,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="91.47" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="91.47" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="191pt" height="44pt" viewBox="0 0 190.95 44">
+    <g class="graph">
+        <path fill="#fff" d="M0 44V0h190.95v44z"/>
+        <g class="node" transform="translate(4 40)">
+            <ellipse cx="91.47" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="91.47" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
     </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_datastore_test.svg
+++ b/docs/images/graphs/dep_graph_core_datastore_test.svg
@@ -1,58 +1,45 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="475pt" height="188pt" viewBox="0.00 0.00 474.97 188.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 184)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-184 470.97,-184 470.97,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:datastore-test</title>
-      <ellipse fill="none" stroke="black" cx="154.81" cy="-162" rx="84.5" ry="18"/>
-      <text text-anchor="middle" x="154.81" y="-157.8" font-family="Times,serif" font-size="14.00">:core:datastore-test</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="475pt" height="188pt" viewBox="0 0 474.97 188">
+    <g class="graph">
+        <path fill="#fff" d="M0 188V0h474.97v188z"/>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="154.81" cy="-162" fill="none" stroke="#000" rx="84.5" ry="18"/>
+            <text x="154.81" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-test</text>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="66.81" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="66.81" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M148.2 40.13c-15.13 24.41-43.04 69.44-60.88 98.23"/>
+            <path d="m90.51 139.87-8.25 6.65 2.3-10.34z"/>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="222.81" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="222.81" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M175.27 39.95c8.19 8.42 18.24 18.77 27.29 28.08"/>
+            <path fill="red" d="m203.94 64.43 4.46 9.61-9.48-4.73z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M193.35 110.02c-23.03 10.33-53.85 24.16-78.82 35.37"/>
+            <path d="m116.16 148.49-10.55.9 7.69-7.29z"/>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="242.81" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="242.81" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M231.76 112.3c2.13 7.46 4.68 16.38 7.06 24.73"/>
+            <path fill="red" d="m241.71 134.41-.61 10.58-6.12-8.66z"/>
+        </g>
+        <g class="node" transform="translate(4 184)">
+            <ellipse cx="409.81" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="409.81" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M264.66 109.17c29.59 11.07 70.88 26.53 102.52 38.37"/>
+            <path d="m368.38 144.25 8.13 6.79-10.59-.23z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="66.81" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="66.81" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:core:datastore-test-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M144.2,-143.87C129.07,-119.46 101.16,-74.43 83.32,-45.64"/>
-      <polygon fill="black" stroke="black" points="86.51,-44.13 78.26,-37.48 80.56,-47.82 86.51,-44.13"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="222.81" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="222.81" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:core:datastore-test-&gt;:core:datastore</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M171.27,-144.05C179.46,-135.63 189.51,-125.28 198.56,-115.97"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="199.94,-119.57 204.4,-109.96 194.92,-114.69 199.94,-119.57"/>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M189.35,-73.98C166.32,-63.65 135.5,-49.82 110.53,-38.61"/>
-      <polygon fill="black" stroke="black" points="112.16,-35.51 101.61,-34.61 109.3,-41.9 112.16,-35.51"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="242.81" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="242.81" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M227.76,-71.7C229.89,-64.24 232.44,-55.32 234.82,-46.97"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="237.71,-49.59 237.1,-39.01 230.98,-47.67 237.71,-49.59"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="409.81" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="409.81" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M260.66,-74.83C290.25,-63.76 331.54,-48.3 363.18,-36.46"/>
-      <polygon fill="black" stroke="black" points="364.38,-39.75 372.51,-32.96 361.92,-33.19 364.38,-39.75"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_designsystem.svg
+++ b/docs/images/graphs/dep_graph_core_designsystem.svg
@@ -1,13 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="178pt" height="44pt" viewBox="0.00 0.00 178.11 44.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 40)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-40 174.11,-40 174.11,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:designsystem</title>
-      <ellipse fill="none" stroke="black" cx="85.06" cy="-18" rx="85.06" ry="18"/>
-      <text text-anchor="middle" x="85.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:designsystem</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="178pt" height="44pt" viewBox="0 0 178.11 44">
+    <g class="graph">
+        <path fill="#fff" d="M0 44V0h178.11v44z"/>
+        <g class="node" transform="translate(4 40)">
+            <ellipse cx="85.06" cy="-18" fill="none" stroke="#000" rx="85.06" ry="18"/>
+            <text x="85.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:designsystem</text>
+        </g>
     </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_domain.svg
+++ b/docs/images/graphs/dep_graph_core_domain.svg
@@ -1,138 +1,109 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="857pt" height="260pt" viewBox="0.00 0.00 857.47 260.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 256)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-256 853.47,-256 853.47,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:domain</title>
-      <ellipse fill="none" stroke="black" cx="644.47" cy="-234" rx="61.99" ry="18"/>
-      <text text-anchor="middle" x="644.47" y="-229.8" font-family="Times,serif" font-size="14.00">:core:domain</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="857pt" height="260pt" viewBox="0 0 857.47 260">
+    <g class="graph">
+        <path fill="#fff" d="M0 260V0h857.47v260z"/>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="644.47" cy="-234" fill="none" stroke="#000" rx="61.99" ry="18"/>
+            <text x="644.47" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:domain</text>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="432.47" cy="-162" fill="none" stroke="#000" rx="49.1" ry="18"/>
+            <text x="432.47" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:data</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M608.6 36.17c-35.81 11.82-88.38 29.18-125.99 41.6"/>
+            <path fill="red" d="m485.41 80.53-10.59-.19 8.4-6.46z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="596.47" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="596.47" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M688.75 36.01C759.51 60.94 893.9 118.79 841.47 184c-21.58 26.85-111.18 40.88-174.8 47.61"/>
+            <path d="m667.32 235.06-10.31-2.47 9.6-4.5z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="350.47" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="350.47" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M388.98 99.32c-59.59 6.51-156.66 21.12-178.51 48.68-9.93 12.54-9.15 22.88 0 36 16.41 23.52 44.49 36.64 71.52 43.93"/>
+            <path d="m282.71 224.51 8.89 5.76-10.55 1.04z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="762.47" cy="-90" fill="none" stroke="#000" rx="66.26" ry="18"/>
+            <text x="762.47" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:database</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M478.76 103.63c50.44 10.34 137.3 28.29 211.71 44.37 4.89 1.06 9.96 2.16 15.04 3.28"/>
+            <path fill="red" d="m704.66 147.51 9.01 5.58-10.52 1.25z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="91.47" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="91.47" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M394.3 103.6c-51.27 10.45-140.4 28.66-216.83 44.4-6.2 1.28-12.66 2.61-19.13 3.95"/>
+            <path d="m159.51 155.28-10.5-1.4 9.08-5.45z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="432.47" cy="-90" fill="none" stroke="#000" rx="64.66" ry="18"/>
+            <text x="432.47" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:network</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M436.47 112.3v24.16"/>
+            <path d="m439.97 136.38-3.5 10-3.5-10z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="282.47" cy="-90" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="282.47" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M406.84 108.83c-22.19 10.35-52.86 24.67-77.69 36.26"/>
+            <path d="m330.82 148.17-10.54 1.05 7.58-7.4z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="596.47" cy="-90" fill="none" stroke="#000" rx="81.29" ry="18"/>
+            <text x="596.47" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:notifications</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M467.71 108.33c24.28 10.37 58.36 24.91 85.91 36.67"/>
+            <path d="m555 141.78 7.82 7.15-10.57-.71z"/>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M731.68 181.67c-25.43 10.73-60.1 25.35-87.42 36.87"/>
+            <path fill="red" d="m647.18 221.11-10.58.66 7.86-7.11z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M153.37 175.69c18.26 2.71 38.52 5.67 57.1 8.31 115.27 16.35 249.85 34.41 326.98 44.67"/>
+            <path d="m537.45 225.14 9.45 4.78-10.37 2.15z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M141.78 179.51c43.64 11.8 109.15 29.5 155.92 42.15"/>
+            <path d="m298.37 218.21 8.74 5.99-10.57.77z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="91.47" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="91.47" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M95.47 184.3v24.16"/>
+            <path d="m98.97 208.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M470.85 181.67c25.13 10.73 59.38 25.35 86.37 36.87"/>
+            <path d="m558.32 215.2 7.83 7.15-10.57-.71z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M417.04 183.59c-10.31 8.8-23.17 19.78-34.55 29.49"/>
+            <path d="m384.8 215.72-9.88 3.83 5.33-9.16z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M600.47 184.3v24.16"/>
+            <path d="m603.97 208.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M551.87 180.83c-40.74 11.59-98.94 28.15-141.58 40.29"/>
+            <path d="m411.28 224.47-10.58-.62 8.66-6.11z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:data</title>
-      <ellipse fill="none" stroke="black" cx="432.47" cy="-162" rx="49.1" ry="18"/>
-      <text text-anchor="middle" x="432.47" y="-157.8" font-family="Times,serif" font-size="14.00">:core:data</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:core:domain-&gt;:core:data</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M604.6,-219.83C568.79,-208.01 516.22,-190.65 478.61,-178.23"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="481.41,-175.47 470.82,-175.66 479.22,-182.12 481.41,-175.47"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="596.47" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="596.47" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:core:domain-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M684.75,-219.99C755.51,-195.06 889.9,-137.21 837.47,-72 815.89,-45.15 726.29,-31.12 662.67,-24.39"/>
-      <polygon fill="black" stroke="black" points="663.32,-20.94 653.01,-23.41 662.61,-27.91 663.32,-20.94"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="350.47" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="350.47" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:core:data-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M384.98,-156.68C325.39,-150.17 228.32,-135.56 206.47,-108 196.54,-95.46 197.32,-85.12 206.47,-72 222.88,-48.48 250.96,-35.36 277.99,-28.07"/>
-      <polygon fill="black" stroke="black" points="278.71,-31.49 287.6,-25.73 277.05,-24.69 278.71,-31.49"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:core:database</title>
-      <ellipse fill="none" stroke="black" cx="762.47" cy="-90" rx="66.26" ry="18"/>
-      <text text-anchor="middle" x="762.47" y="-85.8" font-family="Times,serif" font-size="14.00">:core:database</text>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:core:data-&gt;:core:database</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M474.76,-152.37C525.2,-142.03 612.06,-124.08 686.47,-108 691.36,-106.94 696.43,-105.84 701.51,-104.72"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="700.66,-108.49 709.67,-102.91 699.15,-101.66 700.66,-108.49"/>
-    </g>
-    <g id="node6" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="91.47" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="91.47" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:core:data-&gt;:core:datastore</title>
-      <path fill="none" stroke="black" d="M390.3,-152.4C339.03,-141.95 249.9,-123.74 173.47,-108 167.27,-106.72 160.81,-105.39 154.34,-104.05"/>
-      <polygon fill="black" stroke="black" points="155.51,-100.72 145.01,-102.12 154.09,-107.57 155.51,-100.72"/>
-    </g>
-    <g id="node7" class="node">
-      <title>:core:network</title>
-      <ellipse fill="none" stroke="black" cx="432.47" cy="-90" rx="64.66" ry="18"/>
-      <text text-anchor="middle" x="432.47" y="-85.8" font-family="Times,serif" font-size="14.00">:core:network</text>
-    </g>
-    <g id="edge6" class="edge">
-      <title>:core:data-&gt;:core:network</title>
-      <path fill="none" stroke="black" d="M432.47,-143.7C432.47,-136.41 432.47,-127.73 432.47,-119.54"/>
-      <polygon fill="black" stroke="black" points="435.97,-119.62 432.47,-109.62 428.97,-119.62 435.97,-119.62"/>
-    </g>
-    <g id="node8" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="282.47" cy="-90" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="282.47" y="-85.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge7" class="edge">
-      <title>:core:data-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M402.84,-147.17C380.65,-136.82 349.98,-122.5 325.15,-110.91"/>
-      <polygon fill="black" stroke="black" points="326.82,-107.83 316.28,-106.78 323.86,-114.18 326.82,-107.83"/>
-    </g>
-    <g id="node9" class="node">
-      <title>:core:notifications</title>
-      <ellipse fill="none" stroke="black" cx="596.47" cy="-90" rx="81.29" ry="18"/>
-      <text text-anchor="middle" x="596.47" y="-85.8" font-family="Times,serif" font-size="14.00">:core:notifications</text>
-    </g>
-    <g id="edge8" class="edge">
-      <title>:core:data-&gt;:core:notifications</title>
-      <path fill="none" stroke="black" d="M463.71,-147.67C487.99,-137.3 522.07,-122.76 549.62,-111"/>
-      <polygon fill="black" stroke="black" points="551,-114.22 558.82,-107.07 548.25,-107.78 551,-114.22"/>
-    </g>
-    <g id="edge9" class="edge">
-      <title>:core:database-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M727.68,-74.33C702.25,-63.6 667.58,-48.98 640.26,-37.46"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="643.18,-34.89 632.6,-34.23 640.46,-41.34 643.18,-34.89"/>
-    </g>
-    <g id="edge11" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M149.37,-80.31C167.63,-77.6 187.89,-74.64 206.47,-72 321.74,-55.65 456.32,-37.59 533.45,-27.33"/>
-      <polygon fill="black" stroke="black" points="533.45,-30.86 542.9,-26.08 532.53,-23.93 533.45,-30.86"/>
-    </g>
-    <g id="edge12" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M137.78,-76.49C181.42,-64.69 246.93,-46.99 293.7,-34.34"/>
-      <polygon fill="black" stroke="black" points="294.37,-37.79 303.11,-31.8 292.54,-31.03 294.37,-37.79"/>
-    </g>
-    <g id="node10" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="91.47" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="91.47" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge10" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="black" d="M91.47,-71.7C91.47,-64.41 91.47,-55.73 91.47,-47.54"/>
-      <polygon fill="black" stroke="black" points="94.97,-47.62 91.47,-37.62 87.97,-47.62 94.97,-47.62"/>
-    </g>
-    <g id="edge14" class="edge">
-      <title>:core:network-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M466.85,-74.33C491.98,-63.6 526.23,-48.98 553.22,-37.46"/>
-      <polygon fill="black" stroke="black" points="554.32,-40.8 562.15,-33.65 551.58,-34.36 554.32,-40.8"/>
-    </g>
-    <g id="edge13" class="edge">
-      <title>:core:network-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M413.04,-72.41C402.73,-63.61 389.87,-52.63 378.49,-42.92"/>
-      <polygon fill="black" stroke="black" points="380.8,-40.28 370.92,-36.45 376.25,-45.61 380.8,-40.28"/>
-    </g>
-    <g id="edge15" class="edge">
-      <title>:core:notifications-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M596.47,-71.7C596.47,-64.41 596.47,-55.73 596.47,-47.54"/>
-      <polygon fill="black" stroke="black" points="599.97,-47.62 596.47,-37.62 592.97,-47.62 599.97,-47.62"/>
-    </g>
-    <g id="edge16" class="edge">
-      <title>:core:notifications-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M547.87,-75.17C507.13,-63.58 448.93,-47.02 406.29,-34.88"/>
-      <polygon fill="black" stroke="black" points="407.28,-31.53 396.7,-32.15 405.36,-38.26 407.28,-31.53"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_model.svg
+++ b/docs/images/graphs/dep_graph_core_model.svg
@@ -1,13 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="122pt" height="44pt" viewBox="0.00 0.00 122.31 44.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 40)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-40 118.31,-40 118.31,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="57.16" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="57.16" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="122pt" height="44pt" viewBox="0 0 122.31 44">
+    <g class="graph">
+        <path fill="#fff" d="M0 44V0h122.31v44z"/>
+        <g class="node" transform="translate(4 40)">
+            <ellipse cx="57.16" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="57.16" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
     </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_network.svg
+++ b/docs/images/graphs/dep_graph_core_network.svg
@@ -1,33 +1,25 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="274pt" height="116pt" viewBox="0.00 0.00 273.97 116.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 112)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-112 269.97,-112 269.97,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:network</title>
-      <ellipse fill="none" stroke="black" cx="137.81" cy="-90" rx="64.66" ry="18"/>
-      <text text-anchor="middle" x="137.81" y="-85.8" font-family="Times,serif" font-size="14.00">:core:network</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="274pt" height="116pt" viewBox="0 0 273.97 116">
+    <g class="graph">
+        <path fill="#fff" d="M0 116V0h273.97v116z"/>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="137.81" cy="-90" fill="none" stroke="#000" rx="64.66" ry="18"/>
+            <text x="137.81" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:network</text>
+        </g>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="66.81" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="66.81" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M124.99 39.59c-8.76 8.63-19.63 19.35-29.33 28.91"/>
+            <path fill="red" d="m99.25 69.88-9.58 4.52 4.67-9.51z"/>
+        </g>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="208.81" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="208.81" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M158.64 39.59c8.75 8.63 19.63 19.35 29.33 28.91"/>
+            <path d="m190.37 65.95 4.66 9.52-9.58-4.53z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="66.81" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="66.81" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:core:network-&gt;:core:common</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M120.99,-72.41C112.23,-63.78 101.36,-53.06 91.66,-43.5"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="95.25,-42.12 85.67,-37.6 90.34,-47.11 95.25,-42.12"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="208.81" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="208.81" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:core:network-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M154.64,-72.41C163.39,-63.78 174.27,-53.06 183.97,-43.5"/>
-      <polygon fill="black" stroke="black" points="186.37,-46.05 191.03,-36.53 181.45,-41.06 186.37,-46.05"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_notifications.svg
+++ b/docs/images/graphs/dep_graph_core_notifications.svg
@@ -1,33 +1,25 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="274pt" height="116pt" viewBox="0.00 0.00 273.97 116.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 112)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-112 269.97,-112 269.97,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:notifications</title>
-      <ellipse fill="none" stroke="black" cx="128.16" cy="-90" rx="81.29" ry="18"/>
-      <text text-anchor="middle" x="128.16" y="-85.8" font-family="Times,serif" font-size="14.00">:core:notifications</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="274pt" height="116pt" viewBox="0 0 273.97 116">
+    <g class="graph">
+        <path fill="#fff" d="M0 116V0h273.97v116z"/>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="128.16" cy="-90" fill="none" stroke="#000" rx="81.29" ry="18"/>
+            <text x="128.16" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:notifications</text>
+        </g>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="57.16" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="57.16" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M114.97 39.95c-8.76 8.63-19.57 19.29-29.2 28.78"/>
+            <path fill="red" d="m89.43 70.04-9.58 4.53 4.67-9.52z"/>
+        </g>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="199.16" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="199.16" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M149.34 39.95c8.64 8.51 19.26 18.98 28.78 28.37"/>
+            <path d="m180.39 65.64 4.66 9.51-9.58-4.53z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="57.16" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="57.16" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:core:notifications-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M110.97,-72.05C102.21,-63.42 91.4,-52.76 81.77,-43.27"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="85.43,-41.96 75.85,-37.43 80.52,-46.95 85.43,-41.96"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="199.16" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="199.16" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:core:notifications-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M145.34,-72.05C153.98,-63.54 164.6,-53.07 174.12,-43.68"/>
-      <polygon fill="black" stroke="black" points="176.39,-46.36 181.05,-36.85 171.47,-41.38 176.39,-46.36"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_screenshot_testing.svg
+++ b/docs/images/graphs/dep_graph_core_screenshot_testing.svg
@@ -1,33 +1,25 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="330pt" height="116pt" viewBox="0.00 0.00 329.87 116.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 112)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-112 325.87,-112 325.87,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:screenshot-testing</title>
-      <ellipse fill="none" stroke="black" cx="151.81" cy="-90" rx="102.74" ry="18"/>
-      <text text-anchor="middle" x="151.81" y="-85.8" font-family="Times,serif" font-size="14.00">:core:screenshot-testing</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="440" height="116pt" viewBox="0 0 329.87 116">
+    <g class="graph">
+        <path fill="#fff" d="M0 116V0h329.87v116z"/>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="151.81" cy="-90" fill="none" stroke="#000" rx="102.74" ry="18"/>
+            <text x="151.81" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:screenshot-testing</text>
+        </g>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="66.81" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="66.81" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M135.24 39.95c-10.73 8.83-24.02 19.78-35.75 29.43"/>
+            <path fill="red" d="m103.19 70.87-9.95 3.66 5.5-9.06z"/>
+        </g>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="236.81" cy="-18" fill="none" stroke="#000" rx="85.06" ry="18"/>
+            <text x="236.81" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:designsystem</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M176.39 39.95c10.65 8.77 23.83 19.62 35.49 29.22"/>
+            <path d="m213.76 66.19 5.5 9.06-9.95-3.66z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="66.81" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="66.81" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:core:screenshot-testing-&gt;:core:common</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M131.24,-72.05C120.51,-63.22 107.22,-52.27 95.49,-42.62"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="99.19,-41.13 89.24,-37.47 94.74,-46.53 99.19,-41.13"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:designsystem</title>
-      <ellipse fill="none" stroke="black" cx="236.81" cy="-18" rx="85.06" ry="18"/>
-      <text text-anchor="middle" x="236.81" y="-13.8" font-family="Times,serif" font-size="14.00">:core:designsystem</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:core:screenshot-testing-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M172.39,-72.05C183.04,-63.28 196.22,-52.43 207.88,-42.83"/>
-      <polygon fill="black" stroke="black" points="209.76,-45.81 215.26,-36.75 205.31,-40.41 209.76,-45.81"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_testing.svg
+++ b/docs/images/graphs/dep_graph_core_testing.svg
@@ -1,163 +1,129 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1056pt" height="260pt" viewBox="0.00 0.00 1055.83 260.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 256)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-256 1051.83,-256 1051.83,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:testing</title>
-      <ellipse fill="none" stroke="black" cx="639.77" cy="-234" rx="58.77" ry="18"/>
-      <text text-anchor="middle" x="639.77" y="-229.8" font-family="Times,serif" font-size="14.00">:core:testing</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="1408" height="260pt" viewBox="0 0 1055.83 260">
+    <g class="graph">
+        <path fill="#fff" d="M0 260V0h1055.83v260z"/>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="639.77" cy="-234" fill="none" stroke="#000" rx="58.77" ry="18"/>
+            <text x="639.77" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:testing</text>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="83.77" cy="-90" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="83.77" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M599.68 34.26c-99.45 25.4-341.25 87.16-453.22 115.75"/>
+            <path d="m147.41 153.38-10.55-.92 8.82-5.86z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="538.77" cy="-162" fill="none" stroke="#000" rx="49.1" ry="18"/>
+            <text x="538.77" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:data</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M620.85 38.88c-13.75 9.53-31.43 21.79-46.5 32.23"/>
+            <path fill="red" d="m577.6 73.12-10.21 2.82 6.23-8.58z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="438.77" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="438.77" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M585.6 25.19C442.88 31.95 81.96 57.8 11.77 148c-9.83 12.63-10.74 24.14 0 36 54.57 60.24 283.94 21.97 364 36 4.59.8 9.32 1.76 14.06 2.79"/>
+            <path d="m390.38 219.32 8.95 5.67-10.53 1.15z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="740.77" cy="-90" fill="none" stroke="#000" rx="81.29" ry="18"/>
+            <text x="740.77" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:notifications</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M655.75 39.85c17.37 24.42 49.71 69.89 70.26 98.77"/>
+            <path d="m728.67 136.32 2.94 10.18-8.65-6.12z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="631.77" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="631.77" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M683.13 35.78C752.7 60.43 885.51 117.98 834.77 184c-15.85 20.62-77.96 34.92-128.63 43.43"/>
+            <path d="m706.79 230.87-10.43-1.86 9.31-5.05z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="962.77" cy="-162" fill="none" stroke="#000" rx="85.06" ry="18"/>
+            <text x="962.77" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:designsystem</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M690.74 33.18c54.47 11.8 144.75 31.37 207.15 44.89"/>
+            <path d="m898.31 74.58 9.03 5.54-10.52 1.3z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M496.32 100.33c-71.49 8.47-212.69 26.25-331.55 47.67-5.28.95-10.75 2.01-16.22 3.12"/>
+            <path d="m149.35 154.53-10.51-1.38 9.08-5.47z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M577.5 107.03c31.38 10.88 78.05 27.05 114.12 39.55"/>
+            <path d="m692.72 143.26 8.3 6.58-10.59.03z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M571.46 108.81c15.73 9.02 34.23 22.27 45.31 39.19 11.72 17.89 16.35 41.74 18.12 60.25"/>
+            <path d="m638.37 207.79-2.79 10.22-4.19-9.72z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="235.77" cy="-90" fill="none" stroke="#000" rx="66.26" ry="18"/>
+            <text x="235.77" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:database</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M501.91 104.44c-51.9 11.99-141.89 32.78-201.73 46.6"/>
+            <path fill="red" d="m302.49 154.1-10.54-1.16 8.96-5.66z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="387.77" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="387.77" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M513.3 108.66c-22.31 10.34-53.28 24.7-78.37 36.33"/>
+            <path d="m436.49 148.12-10.54 1.04 7.6-7.39z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="538.77" cy="-90" fill="none" stroke="#000" rx="64.66" ry="18"/>
+            <text x="538.77" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:network</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M542.77 112.3v24.16"/>
+            <path d="m546.27 136.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M690.08 179.68c-54.11 12.54-136.55 31.65-191.16 44.31"/>
+            <path d="m499.71 227.39-10.53-1.15 8.95-5.67z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M719.21 183.41c-14.59 9.37-33.08 21.25-48.94 31.43"/>
+            <path d="m672.37 217.66-10.31 2.45 6.53-8.34z"/>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M279.39 180.66c33.05 11.4 80.24 27.67 115.41 39.8"/>
+            <path fill="red" d="m394.13 216.53 8.31 6.56-10.59.05z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M404.12 183.95c5.95 8.16 13.21 18.14 19.84 27.23"/>
+            <path d="m426.59 208.84 3.06 10.15-8.72-6.02z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M436.52 179.84c40.5 11.62 100.3 28.77 143.81 41.26"/>
+            <path d="m581.2 217.7 8.65 6.12-10.58.61z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="271.77" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="271.77" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M365.45 182.88c-15.54 9.38-35.44 21.39-52.55 31.72"/>
+            <path d="m314.86 217.5-10.37 2.17 6.76-8.17z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M519.58 183.24c-13.35 9.34-30.32 21.21-44.9 31.43"/>
+            <path d="m476.93 217.36-10.2 2.87 6.19-8.61z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M564.34 183.24c12.12 9.12 27.45 20.66 40.8 30.7"/>
+            <path d="m606.9 210.89 5.89 8.81-10.1-3.22z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="83.77" cy="-90" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="83.77" y="-85.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:core:testing-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M595.68,-221.74C496.23,-196.34 254.43,-134.58 142.46,-105.99"/>
-      <polygon fill="black" stroke="black" points="143.41,-102.62 132.86,-103.54 141.68,-109.4 143.41,-102.62"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:data</title>
-      <ellipse fill="none" stroke="black" cx="538.77" cy="-162" rx="49.1" ry="18"/>
-      <text text-anchor="middle" x="538.77" y="-157.8" font-family="Times,serif" font-size="14.00">:core:data</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:core:testing-&gt;:core:data</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M616.85,-217.12C603.1,-207.59 585.42,-195.33 570.35,-184.89"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="573.6,-182.88 563.39,-180.06 569.62,-188.64 573.6,-182.88"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="438.77" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="438.77" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:core:testing-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M581.6,-230.81C438.88,-224.05 77.96,-198.2 7.77,-108 -2.06,-95.37 -2.97,-83.86 7.77,-72 62.34,-11.76 291.71,-50.03 371.77,-36 376.36,-35.2 381.09,-34.24 385.83,-33.21"/>
-      <polygon fill="black" stroke="black" points="386.38,-36.68 395.33,-31.01 384.8,-29.86 386.38,-36.68"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:core:notifications</title>
-      <ellipse fill="none" stroke="black" cx="740.77" cy="-90" rx="81.29" ry="18"/>
-      <text text-anchor="middle" x="740.77" y="-85.8" font-family="Times,serif" font-size="14.00">:core:notifications</text>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:core:testing-&gt;:core:notifications</title>
-      <path fill="none" stroke="black" d="M651.75,-216.15C669.12,-191.73 701.46,-146.26 722.01,-117.38"/>
-      <polygon fill="black" stroke="black" points="724.67,-119.68 727.61,-109.5 718.96,-115.62 724.67,-119.68"/>
-    </g>
-    <g id="node6" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="631.77" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="631.77" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:core:testing-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M679.13,-220.22C748.7,-195.57 881.51,-138.02 830.77,-72 814.92,-51.38 752.81,-37.08 702.14,-28.57"/>
-      <polygon fill="black" stroke="black" points="702.79,-25.13 692.36,-26.99 701.67,-32.04 702.79,-25.13"/>
-    </g>
-    <g id="node7" class="node">
-      <title>:core:designsystem</title>
-      <ellipse fill="none" stroke="black" cx="962.77" cy="-162" rx="85.06" ry="18"/>
-      <text text-anchor="middle" x="962.77" y="-157.8" font-family="Times,serif" font-size="14.00">:core:designsystem</text>
-    </g>
-    <g id="edge6" class="edge">
-      <title>:core:testing-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M686.74,-222.82C741.21,-211.02 831.49,-191.45 893.89,-177.93"/>
-      <polygon fill="black" stroke="black" points="894.31,-181.42 903.34,-175.88 892.82,-174.58 894.31,-181.42"/>
-    </g>
-    <g id="edge11" class="edge">
-      <title>:core:data-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M492.32,-155.67C420.83,-147.2 279.63,-129.42 160.77,-108 155.49,-107.05 150.02,-105.99 144.55,-104.88"/>
-      <polygon fill="black" stroke="black" points="145.35,-101.47 134.84,-102.85 143.92,-108.32 145.35,-101.47"/>
-    </g>
-    <g id="edge12" class="edge">
-      <title>:core:data-&gt;:core:notifications</title>
-      <path fill="none" stroke="black" d="M573.5,-148.97C604.88,-138.09 651.55,-121.92 687.62,-109.42"/>
-      <polygon fill="black" stroke="black" points="688.72,-112.74 697.02,-106.16 686.43,-106.13 688.72,-112.74"/>
-    </g>
-    <g id="edge7" class="edge">
-      <title>:core:data-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M567.46,-147.19C583.19,-138.17 601.69,-124.92 612.77,-108 624.49,-90.11 629.12,-66.26 630.89,-47.75"/>
-      <polygon fill="black" stroke="black" points="634.37,-48.21 631.58,-37.99 627.39,-47.71 634.37,-48.21"/>
-    </g>
-    <g id="node8" class="node">
-      <title>:core:database</title>
-      <ellipse fill="none" stroke="black" cx="235.77" cy="-90" rx="66.26" ry="18"/>
-      <text text-anchor="middle" x="235.77" y="-85.8" font-family="Times,serif" font-size="14.00">:core:database</text>
-    </g>
-    <g id="edge8" class="edge">
-      <title>:core:data-&gt;:core:database</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M497.91,-151.56C446.01,-139.57 356.02,-118.78 296.18,-104.96"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="298.49,-101.9 287.95,-103.06 296.91,-108.72 298.49,-101.9"/>
-    </g>
-    <g id="node9" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="387.77" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="387.77" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
-    </g>
-    <g id="edge9" class="edge">
-      <title>:core:data-&gt;:core:datastore</title>
-      <path fill="none" stroke="black" d="M509.3,-147.34C486.99,-137 456.02,-122.64 430.93,-111.01"/>
-      <polygon fill="black" stroke="black" points="432.49,-107.88 421.95,-106.84 429.55,-114.23 432.49,-107.88"/>
-    </g>
-    <g id="node10" class="node">
-      <title>:core:network</title>
-      <ellipse fill="none" stroke="black" cx="538.77" cy="-90" rx="64.66" ry="18"/>
-      <text text-anchor="middle" x="538.77" y="-85.8" font-family="Times,serif" font-size="14.00">:core:network</text>
-    </g>
-    <g id="edge10" class="edge">
-      <title>:core:data-&gt;:core:network</title>
-      <path fill="none" stroke="black" d="M538.77,-143.7C538.77,-136.41 538.77,-127.73 538.77,-119.54"/>
-      <polygon fill="black" stroke="black" points="542.27,-119.62 538.77,-109.62 535.27,-119.62 542.27,-119.62"/>
-    </g>
-    <g id="edge19" class="edge">
-      <title>:core:notifications-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M686.08,-76.32C631.97,-63.78 549.53,-44.67 494.92,-32.01"/>
-      <polygon fill="black" stroke="black" points="495.71,-28.61 485.18,-29.76 494.13,-35.43 495.71,-28.61"/>
-    </g>
-    <g id="edge20" class="edge">
-      <title>:core:notifications-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M715.21,-72.59C700.62,-63.22 682.13,-51.34 666.27,-41.16"/>
-      <polygon fill="black" stroke="black" points="668.37,-38.34 658.06,-35.89 664.59,-44.23 668.37,-38.34"/>
-    </g>
-    <g id="edge13" class="edge">
-      <title>:core:database-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M275.39,-75.34C308.44,-63.94 355.63,-47.67 390.8,-35.54"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="390.13,-39.47 398.44,-32.91 387.85,-32.86 390.13,-39.47"/>
-    </g>
-    <g id="edge15" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M400.12,-72.05C406.07,-63.89 413.33,-53.91 419.96,-44.82"/>
-      <polygon fill="black" stroke="black" points="422.59,-47.16 425.65,-37.01 416.93,-43.03 422.59,-47.16"/>
-    </g>
-    <g id="edge16" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M432.52,-76.16C473.02,-64.54 532.82,-47.39 576.33,-34.9"/>
-      <polygon fill="black" stroke="black" points="577.2,-38.3 585.85,-32.18 575.27,-31.57 577.2,-38.3"/>
-    </g>
-    <g id="node11" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="271.77" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="271.77" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge14" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="black" d="M361.45,-73.12C345.91,-63.74 326.01,-51.73 308.9,-41.4"/>
-      <polygon fill="black" stroke="black" points="310.86,-38.5 300.49,-36.33 307.25,-44.5 310.86,-38.5"/>
-    </g>
-    <g id="edge18" class="edge">
-      <title>:core:network-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M515.58,-72.76C502.23,-63.42 485.26,-51.55 470.68,-41.33"/>
-      <polygon fill="black" stroke="black" points="472.93,-38.64 462.73,-35.77 468.92,-44.38 472.93,-38.64"/>
-    </g>
-    <g id="edge17" class="edge">
-      <title>:core:network-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M560.34,-72.76C572.46,-63.64 587.79,-52.1 601.14,-42.06"/>
-      <polygon fill="black" stroke="black" points="602.9,-45.11 608.79,-36.3 598.69,-39.52 602.9,-45.11"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_core_ui.svg
+++ b/docs/images/graphs/dep_graph_core_ui.svg
@@ -1,43 +1,33 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="462pt" height="116pt" viewBox="0.00 0.00 462.50 116.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 112)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-112 458.5,-112 458.5,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:core:ui</title>
-      <ellipse fill="none" stroke="black" cx="237.34" cy="-90" rx="40.53" ry="18"/>
-      <text text-anchor="middle" x="237.34" y="-85.8" font-family="Times,serif" font-size="14.00">:core:ui</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="616" height="116pt" viewBox="0 0 462.5 116">
+    <g class="graph">
+        <path fill="#fff" d="M0 116V0h462.5v116z"/>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="237.34" cy="-90" fill="none" stroke="#000" rx="40.53" ry="18"/>
+            <text x="237.34" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:ui</text>
+        </g>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="67.34" cy="-18" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="67.34" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M212.5 34.87c-26.1 10.75-64.98 26.76-95.34 39.26"/>
+            <path fill="red" d="m120.2 76.67-10.58.57 7.91-7.04z"/>
+        </g>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="237.34" cy="-18" fill="none" stroke="#000" rx="85.06" ry="18"/>
+            <text x="237.34" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:designsystem</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M241.34 40.3v24.16"/>
+            <path d="m244.84 64.38-3.5 10-3.5-10z"/>
+        </g>
+        <g class="node" transform="translate(4 112)">
+            <ellipse cx="397.34" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="397.34" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M269.58 35.35c24.66 10.79 60.82 26.61 89.02 38.95"/>
+            <path d="m359.84 71.02 7.76 7.22-10.57-.81z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="67.34" cy="-18" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="67.34" y="-13.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:core:ui-&gt;:core:analytics</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M208.5,-77.13C182.4,-66.38 143.52,-50.37 113.16,-37.87"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="116.2,-35.33 105.62,-34.76 113.53,-41.8 116.2,-35.33"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:designsystem</title>
-      <ellipse fill="none" stroke="black" cx="237.34" cy="-18" rx="85.06" ry="18"/>
-      <text text-anchor="middle" x="237.34" y="-13.8" font-family="Times,serif" font-size="14.00">:core:designsystem</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:core:ui-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M237.34,-71.7C237.34,-64.41 237.34,-55.73 237.34,-47.54"/>
-      <polygon fill="black" stroke="black" points="240.84,-47.62 237.34,-37.62 233.84,-47.62 240.84,-47.62"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="397.34" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="397.34" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:core:ui-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M265.58,-76.65C290.24,-65.86 326.4,-50.04 354.6,-37.7"/>
-      <polygon fill="black" stroke="black" points="355.84,-40.98 363.6,-33.76 353.03,-34.57 355.84,-40.98"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_feature_bookmarks.svg
+++ b/docs/images/graphs/dep_graph_feature_bookmarks.svg
@@ -1,168 +1,133 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1064pt" height="260pt" viewBox="0.00 0.00 1063.53 260.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 256)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-256 1059.53,-256 1059.53,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:feature:bookmarks</title>
-      <ellipse fill="none" stroke="black" cx="198.06" cy="-234" rx="86.12" ry="18"/>
-      <text text-anchor="middle" x="198.06" y="-229.8" font-family="Times,serif" font-size="14.00">:feature:bookmarks</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="1064pt" height="260pt" viewBox="0 0 1063.53 260">
+    <g class="graph">
+        <path fill="#fff" d="M0 260V0h1063.53v260z"/>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="198.06" cy="-234" fill="none" stroke="#000" rx="86.12" ry="18"/>
+            <text x="198.06" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:feature:bookmarks</text>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="198.06" cy="-162" fill="none" stroke="#000" rx="40.53" ry="18"/>
+            <text x="198.06" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:ui</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M202.06 40.3v24.16"/>
+            <path d="m205.56 64.38-3.5 10-3.5-10z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="85.06" cy="-90" fill="none" stroke="#000" rx="85.06" ry="18"/>
+            <text x="85.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:designsystem</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M184.75 40.1c-9.93 10.12-22.43 23.37-32.69 35.9-16.5 20.14-33.45 44.33-45.61 62.4"/>
+            <path d="m109.52 140.11-8.46 6.38 2.63-10.26z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="611.06" cy="-162" fill="none" stroke="#000" rx="49.1" ry="18"/>
+            <text x="611.06" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:data</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M267.5 34.09c80.8 13.7 216.81 36.75 292.5 49.58"/>
+            <path fill="red" d="m558.91 79.93 9.27 5.13-10.44 1.77z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M179.19 109.17c-15.56 9.64-36.48 22.59-54.24 33.6"/>
+            <path d="m127.09 145.56-10.35 2.29 6.66-8.24z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="293.06" cy="-90" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="293.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M222.2 109.85c12.69 9.34 29.33 21.61 43.7 32.19"/>
+            <path d="m267.76 139.06 5.97 8.75-10.13-3.11z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="611.06" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="611.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M200.38 112.2c-.94 20.29.97 53.55 20.68 71.8 46.01 42.62 225.28 51.44 325.4 52.97"/>
+            <path d="m546.2 233.46 9.95 3.63-10.04 3.37z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M573.69 104.09c-48.01 10.54-129.56 28.47-199.63 43.91-5.08 1.12-10.35 2.28-15.64 3.45"/>
+            <path d="m359.58 154.77-10.51-1.26 9.01-5.57z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="781.06" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="781.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M662.9 98.73c62.51 5.97 166.79 20.12 190.16 49.27 10.01 12.48 7.02 21.62 0 36-6.16 12.61-16.93 23.09-28.1 31.31"/>
+            <path d="m827.06 218.12-10.24 2.71 6.31-8.51z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="445.06" cy="-90" fill="none" stroke="#000" rx="66.26" ry="18"/>
+            <text x="445.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:database</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M583.83 108.17c-25.23 10.64-61.09 25.76-89.48 37.73"/>
+            <path fill="red" d="m497.23 148.48-10.57.66 7.85-7.11z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="964.06" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="964.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M657.8 103.2c53.43 10.3 147.66 28.56 228.26 44.8 6.21 1.25 12.68 2.57 19.14 3.89"/>
+            <path d="m905.45 148.37 9.09 5.44-10.5 1.42z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="775.06" cy="-90" fill="none" stroke="#000" rx="64.66" ry="18"/>
+            <text x="775.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:network</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M646.29 108.33c24.97 10.66 60.29 25.74 88.23 37.66"/>
+            <path d="m735.61 142.65 7.82 7.15-10.57-.71z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="611.06" cy="-90" fill="none" stroke="#000" rx="81.29" ry="18"/>
+            <text x="611.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:notifications</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M615.06 112.3v24.16"/>
+            <path d="m618.56 136.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M483.86 181.67c25.43 10.73 60.1 25.35 87.41 36.87"/>
+            <path fill="red" d="m571.08 214.66 7.85 7.11-10.57-.66z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M914.83 177.56c-64.82 12.85-173.94 34.49-241.12 47.81"/>
+            <path d="m674.46 228.79-10.49-1.49 9.13-5.38z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M930.58 181.33c-28.25 10.81-67.2 25.71-97.7 37.38"/>
+            <path d="m834.49 221.84-10.59.3 8.08-6.84z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="964.06" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="964.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M968.06 184.3v24.16"/>
+            <path d="m971.56 208.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M744.68 181.67c-25.13 10.73-59.38 25.35-86.36 36.87"/>
+            <path d="m659.96 221.64-10.57.71 7.82-7.15z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M780.54 184.3c.63 7.29 1.37 15.97 2.07 24.16"/>
+            <path d="m786.1 208.13-2.64 10.26-4.34-9.67z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M615.06 184.3v24.16"/>
+            <path d="m618.56 208.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M652.36 182.36c25.54 10.52 59.58 24.53 86.78 35.73"/>
+            <path d="m740.27 214.77 7.91 7.05-10.58-.58z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:ui</title>
-      <ellipse fill="none" stroke="black" cx="198.06" cy="-162" rx="40.53" ry="18"/>
-      <text text-anchor="middle" x="198.06" y="-157.8" font-family="Times,serif" font-size="14.00">:core:ui</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:feature:bookmarks-&gt;:core:ui</title>
-      <path fill="none" stroke="black" d="M198.06,-215.7C198.06,-208.41 198.06,-199.73 198.06,-191.54"/>
-      <polygon fill="black" stroke="black" points="201.56,-191.62 198.06,-181.62 194.56,-191.62 201.56,-191.62"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:designsystem</title>
-      <ellipse fill="none" stroke="black" cx="85.06" cy="-90" rx="85.06" ry="18"/>
-      <text text-anchor="middle" x="85.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:designsystem</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:feature:bookmarks-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M180.75,-215.9C170.82,-205.78 158.32,-192.53 148.06,-180 131.56,-159.86 114.61,-135.67 102.45,-117.6"/>
-      <polygon fill="black" stroke="black" points="105.52,-115.89 97.06,-109.51 99.69,-119.77 105.52,-115.89"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:data</title>
-      <ellipse fill="none" stroke="black" cx="611.06" cy="-162" rx="49.1" ry="18"/>
-      <text text-anchor="middle" x="611.06" y="-157.8" font-family="Times,serif" font-size="14.00">:core:data</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:feature:bookmarks-&gt;:core:data</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M263.5,-221.91C344.3,-208.21 480.31,-185.16 556,-172.33"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="554.91,-176.07 564.18,-170.94 553.74,-169.17 554.91,-176.07"/>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:core:ui-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M175.19,-146.83C159.63,-137.19 138.71,-124.24 120.95,-113.23"/>
-      <polygon fill="black" stroke="black" points="123.09,-110.44 112.74,-108.15 119.4,-116.39 123.09,-110.44"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="293.06" cy="-90" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="293.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:core:ui-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M218.2,-146.15C230.89,-136.81 247.53,-124.54 261.9,-113.96"/>
-      <polygon fill="black" stroke="black" points="263.76,-116.94 269.73,-108.19 259.6,-111.3 263.76,-116.94"/>
-    </g>
-    <g id="node6" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="611.06" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="611.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge6" class="edge">
-      <title>:core:ui-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M196.38,-143.8C195.44,-123.51 197.35,-90.25 217.06,-72 263.07,-29.38 442.34,-20.56 542.46,-19.03"/>
-      <polygon fill="black" stroke="black" points="542.2,-22.54 552.15,-18.91 542.11,-15.54 542.2,-22.54"/>
-    </g>
-    <g id="edge11" class="edge">
-      <title>:core:data-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M569.69,-151.91C521.68,-141.37 440.13,-123.44 370.06,-108 364.98,-106.88 359.71,-105.72 354.42,-104.55"/>
-      <polygon fill="black" stroke="black" points="355.58,-101.23 345.07,-102.49 354.08,-108.06 355.58,-101.23"/>
-    </g>
-    <g id="node7" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="781.06" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="781.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge7" class="edge">
-      <title>:core:data-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M658.9,-157.27C721.41,-151.3 825.69,-137.15 849.06,-108 859.07,-95.52 856.08,-86.38 849.06,-72 842.9,-59.39 832.13,-48.91 820.96,-40.69"/>
-      <polygon fill="black" stroke="black" points="823.06,-37.88 812.82,-35.17 819.13,-43.68 823.06,-37.88"/>
-    </g>
-    <g id="node8" class="node">
-      <title>:core:database</title>
-      <ellipse fill="none" stroke="black" cx="445.06" cy="-90" rx="66.26" ry="18"/>
-      <text text-anchor="middle" x="445.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:database</text>
-    </g>
-    <g id="edge8" class="edge">
-      <title>:core:data-&gt;:core:database</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M579.83,-147.83C554.6,-137.19 518.74,-122.07 490.35,-110.1"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="493.23,-107.52 482.66,-106.86 490.51,-113.97 493.23,-107.52"/>
-    </g>
-    <g id="node9" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="964.06" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="964.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
-    </g>
-    <g id="edge9" class="edge">
-      <title>:core:data-&gt;:core:datastore</title>
-      <path fill="none" stroke="black" d="M653.8,-152.8C707.23,-142.5 801.46,-124.24 882.06,-108 888.27,-106.75 894.74,-105.43 901.2,-104.11"/>
-      <polygon fill="black" stroke="black" points="901.45,-107.63 910.54,-102.19 900.04,-100.77 901.45,-107.63"/>
-    </g>
-    <g id="node10" class="node">
-      <title>:core:network</title>
-      <ellipse fill="none" stroke="black" cx="775.06" cy="-90" rx="64.66" ry="18"/>
-      <text text-anchor="middle" x="775.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:network</text>
-    </g>
-    <g id="edge10" class="edge">
-      <title>:core:data-&gt;:core:network</title>
-      <path fill="none" stroke="black" d="M642.29,-147.67C667.26,-137.01 702.58,-121.93 730.52,-110.01"/>
-      <polygon fill="black" stroke="black" points="731.61,-113.35 739.43,-106.2 728.86,-106.91 731.61,-113.35"/>
-    </g>
-    <g id="node11" class="node">
-      <title>:core:notifications</title>
-      <ellipse fill="none" stroke="black" cx="611.06" cy="-90" rx="81.29" ry="18"/>
-      <text text-anchor="middle" x="611.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:notifications</text>
-    </g>
-    <g id="edge12" class="edge">
-      <title>:core:data-&gt;:core:notifications</title>
-      <path fill="none" stroke="black" d="M611.06,-143.7C611.06,-136.41 611.06,-127.73 611.06,-119.54"/>
-      <polygon fill="black" stroke="black" points="614.56,-119.62 611.06,-109.62 607.56,-119.62 614.56,-119.62"/>
-    </g>
-    <g id="edge13" class="edge">
-      <title>:core:database-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M479.86,-74.33C505.29,-63.6 539.96,-48.98 567.27,-37.46"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="567.08,-41.34 574.93,-34.23 564.36,-34.89 567.08,-41.34"/>
-    </g>
-    <g id="edge15" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M910.83,-78.44C846.01,-65.59 736.89,-43.95 669.71,-30.63"/>
-      <polygon fill="black" stroke="black" points="670.46,-27.21 659.97,-28.7 669.1,-34.08 670.46,-27.21"/>
-    </g>
-    <g id="edge16" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M926.58,-74.67C898.33,-63.86 859.38,-48.96 828.88,-37.29"/>
-      <polygon fill="black" stroke="black" points="830.49,-34.16 819.9,-33.86 827.98,-40.7 830.49,-34.16"/>
-    </g>
-    <g id="node12" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="964.06" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="964.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge14" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="black" d="M964.06,-71.7C964.06,-64.41 964.06,-55.73 964.06,-47.54"/>
-      <polygon fill="black" stroke="black" points="967.56,-47.62 964.06,-37.62 960.56,-47.62 967.56,-47.62"/>
-    </g>
-    <g id="edge18" class="edge">
-      <title>:core:network-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M740.68,-74.33C715.55,-63.6 681.3,-48.98 654.32,-37.46"/>
-      <polygon fill="black" stroke="black" points="655.96,-34.36 645.39,-33.65 653.21,-40.8 655.96,-34.36"/>
-    </g>
-    <g id="edge17" class="edge">
-      <title>:core:network-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M776.54,-71.7C777.17,-64.41 777.91,-55.73 778.61,-47.54"/>
-      <polygon fill="black" stroke="black" points="782.1,-47.87 779.46,-37.61 775.12,-47.28 782.1,-47.87"/>
-    </g>
-    <g id="edge19" class="edge">
-      <title>:core:notifications-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M611.06,-71.7C611.06,-64.41 611.06,-55.73 611.06,-47.54"/>
-      <polygon fill="black" stroke="black" points="614.56,-47.62 611.06,-37.62 607.56,-47.62 614.56,-47.62"/>
-    </g>
-    <g id="edge20" class="edge">
-      <title>:core:notifications-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M648.36,-73.64C673.9,-63.12 707.94,-49.11 735.14,-37.91"/>
-      <polygon fill="black" stroke="black" points="736.27,-41.23 744.18,-34.18 733.6,-34.76 736.27,-41.23"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_feature_foryou.svg
+++ b/docs/images/graphs/dep_graph_feature_foryou.svg
@@ -1,188 +1,149 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1108pt" height="332pt" viewBox="0.00 0.00 1107.53 332.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 328)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-328 1103.53,-328 1103.53,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:feature:foryou</title>
-      <ellipse fill="none" stroke="black" cx="258.06" cy="-306" rx="68.95" ry="18"/>
-      <text text-anchor="middle" x="258.06" y="-301.8" font-family="Times,serif" font-size="14.00">:feature:foryou</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="1108pt" height="332pt" viewBox="0 0 1107.53 332">
+    <g class="graph">
+        <path fill="#fff" d="M0 332V0h1107.53v332z"/>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="258.06" cy="-306" fill="none" stroke="#000" rx="68.95" ry="18"/>
+            <text x="258.06" y="-301.8" font-family="Times,serif" font-size="14" text-anchor="middle">:feature:foryou</text>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="198.06" cy="-234" fill="none" stroke="#000" rx="40.53" ry="18"/>
+            <text x="198.06" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:ui</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M247.53 39.95c-7.25 8.46-16.17 18.86-24.18 28.21"/>
+            <path d="m226.19 70.23-9.17 5.31 3.85-9.87z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="85.06" cy="-162" fill="none" stroke="#000" rx="85.06" ry="18"/>
+            <text x="85.06" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:designsystem</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M221.28 36.89c-22.07 8.86-48.91 21.93-69.22 39.11-20.37 17.22-37.4 42.45-48.6 61.65"/>
+            <path d="m106.55 139.29-7.95 7 1.85-10.43z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="585.06" cy="-162" fill="none" stroke="#000" rx="49.1" ry="18"/>
+            <text x="585.06" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:data</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M299.52 37.51c26.52 10.4 62.87 24.92 94.54 38.49 54.36 23.3 116.38 51.97 155.6 70.37"/>
+            <path d="m550.91 143.09 7.56 7.42-10.53-1.08z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="319.06" cy="-234" fill="none" stroke="#000" rx="61.99" ry="18"/>
+            <text x="319.06" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:domain</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M276.82 39.95c7.27 8.34 16.18 18.56 24.23 27.8"/>
+            <path fill="red" d="m302.51 64.09 3.93 9.84-9.21-5.24z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M179.19 109.17c-15.56 9.64-36.48 22.59-54.24 33.6"/>
+            <path d="m127.09 145.56-10.35 2.29 6.66-8.24z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="350.06" cy="-90" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="350.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M218.9 110.74c26.43 24.68 77.82 72.69 109.06 101.88"/>
+            <path d="m330.17 209.9 4.92 9.38-9.7-4.27z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="585.06" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="585.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M202.92 112.29c2.68 33.45 13.59 106.95 58.14 143.71 38.65 31.9 175.95 44.91 260.17 49.98"/>
+            <path d="m521.2 302.47 9.78 4.07-10.19 2.92z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M551.82 178.09c-38.54 11.48-99.14 29.53-143.11 42.63"/>
+            <path d="m409.95 224-10.58-.5 8.58-6.21z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="832.06" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="832.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M637.67 168.82c115.39 4.82 398.28 19.76 426.39 51.18 10.67 11.92 9.95 23.47 0 36-1.33 1.68-99.82 24.14-166.9 39.28"/>
+            <path d="m898.27 298.61-10.53-1.21 8.99-5.62z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="502.06" cy="-90" fill="none" stroke="#000" rx="66.26" ry="18"/>
+            <text x="502.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:database</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M570.22 182.88c-10.59 8.94-24.03 20.27-35.87 30.26"/>
+            <path fill="red" d="m537.9 214.73-9.9 3.77 5.38-9.13z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="983.06" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="983.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M634.12 173.66c62.22 9.37 177.91 27.44 275.94 46.34 5.19 1 10.56 2.09 15.94 3.21"/>
+            <path d="m926.48 219.73 9.06 5.5-10.51 1.35z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="832.06" cy="-90" fill="none" stroke="#000" rx="64.66" ry="18"/>
+            <text x="832.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:network</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M627.11 177.78c41.22 11.69 107.34 30.42 154.15 43.69"/>
+            <path d="m782 218.04 8.67 6.1-10.58.64z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="668.06" cy="-90" fill="none" stroke="#000" rx="81.29" ry="18"/>
+            <text x="668.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:notifications</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M607.89 182.88c10.52 8.88 23.84 20.11 35.62 30.04"/>
+            <path d="m645.6 210.1 5.38 9.13-9.9-3.77z"/>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M367.88 106.8c47.39 12.47 121.96 32.09 171.22 45.05"/>
+            <path fill="red" d="m538.41 148.05 8.78 5.93-10.56.84z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M309.66 111.68c-23.81 31.74-67.73 101.51-31.6 144.32 30.37 35.99 160.29 47.54 242.3 51.25"/>
+            <path d="m520.49 303.75 9.84 3.92-10.14 3.08z"/>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M525.73 255.59c10.62 8.96 23.9 20.16 35.56 29.99"/>
+            <path fill="red" d="m562.11 281.7 5.39 9.12-9.9-3.77z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M937.02 250.46c-8.96 1.93-18.23 3.86-26.96 5.54-89.6 17.27-193.95 33.85-258.75 43.73"/>
+            <path d="m651.99 303.17-10.42-1.96 9.37-4.96z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M954.29 254.19a369994 369994 0 0 1-75.31 34.91"/>
+            <path d="m880.68 292.17-10.55 1.03 7.6-7.38z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="1008.06" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="1008.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M993.24 256.3c2.69 7.55 5.92 16.58 8.93 25.02"/>
+            <path d="m1005.37 279.88.07 10.59-6.66-8.24z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M791.9 251.51c-42.22 11.97-105.88 30.01-150.59 42.68"/>
+            <path d="m642.4 297.52-10.57-.64 8.66-6.09z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M836.06 256.3v24.16"/>
+            <path d="m839.56 280.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M652.39 255.59c-10.62 8.96-23.91 20.16-35.56 29.99"/>
+            <path d="m619.36 288.02-9.9 3.78 5.38-9.13z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M708.45 254.54c24.39 10.4 56.66 24.18 82.65 35.27"/>
+            <path d="m792.23 286.49 7.82 7.14-10.57-.7z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:ui</title>
-      <ellipse fill="none" stroke="black" cx="198.06" cy="-234" rx="40.53" ry="18"/>
-      <text text-anchor="middle" x="198.06" y="-229.8" font-family="Times,serif" font-size="14.00">:core:ui</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:feature:foryou-&gt;:core:ui</title>
-      <path fill="none" stroke="black" d="M243.53,-288.05C236.28,-279.59 227.36,-269.19 219.35,-259.84"/>
-      <polygon fill="black" stroke="black" points="222.19,-257.77 213.02,-252.46 216.87,-262.33 222.19,-257.77"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:designsystem</title>
-      <ellipse fill="none" stroke="black" cx="85.06" cy="-162" rx="85.06" ry="18"/>
-      <text text-anchor="middle" x="85.06" y="-157.8" font-family="Times,serif" font-size="14.00">:core:designsystem</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:feature:foryou-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M217.28,-291.11C195.21,-282.25 168.37,-269.18 148.06,-252 127.69,-234.78 110.66,-209.55 99.46,-190.35"/>
-      <polygon fill="black" stroke="black" points="102.55,-188.71 94.6,-181.71 96.45,-192.14 102.55,-188.71"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:data</title>
-      <ellipse fill="none" stroke="black" cx="585.06" cy="-162" rx="49.1" ry="18"/>
-      <text text-anchor="middle" x="585.06" y="-157.8" font-family="Times,serif" font-size="14.00">:core:data</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:feature:foryou-&gt;:core:data</title>
-      <path fill="none" stroke="black" d="M295.52,-290.49C322.04,-280.09 358.39,-265.57 390.06,-252 444.42,-228.7 506.44,-200.03 545.66,-181.63"/>
-      <polygon fill="black" stroke="black" points="546.91,-184.91 554.47,-177.49 543.94,-178.57 546.91,-184.91"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:core:domain</title>
-      <ellipse fill="none" stroke="black" cx="319.06" cy="-234" rx="61.99" ry="18"/>
-      <text text-anchor="middle" x="319.06" y="-229.8" font-family="Times,serif" font-size="14.00">:core:domain</text>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:feature:foryou-&gt;:core:domain</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M272.82,-288.05C280.09,-279.71 289,-269.49 297.05,-260.25"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="298.51,-263.91 302.44,-254.07 293.23,-259.31 298.51,-263.91"/>
-    </g>
-    <g id="edge6" class="edge">
-      <title>:core:ui-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M175.19,-218.83C159.63,-209.19 138.71,-196.24 120.95,-185.23"/>
-      <polygon fill="black" stroke="black" points="123.09,-182.44 112.74,-180.15 119.4,-188.39 123.09,-182.44"/>
-    </g>
-    <g id="node6" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="350.06" cy="-90" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="350.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:core:ui-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M214.9,-217.26C241.33,-192.58 292.72,-144.57 323.96,-115.38"/>
-      <polygon fill="black" stroke="black" points="326.17,-118.1 331.09,-108.72 321.39,-112.99 326.17,-118.1"/>
-    </g>
-    <g id="node7" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="585.06" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="585.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge7" class="edge">
-      <title>:core:ui-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M198.92,-215.71C201.6,-182.26 212.51,-108.76 257.06,-72 295.71,-40.1 433.01,-27.09 517.23,-22.02"/>
-      <polygon fill="black" stroke="black" points="517.2,-25.53 526.98,-21.46 516.79,-18.54 517.2,-25.53"/>
-    </g>
-    <g id="edge12" class="edge">
-      <title>:core:data-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M547.82,-149.91C509.28,-138.43 448.68,-120.38 404.71,-107.28"/>
-      <polygon fill="black" stroke="black" points="405.95,-104 395.37,-104.5 403.95,-110.71 405.95,-104"/>
-    </g>
-    <g id="node8" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="832.06" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="832.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge8" class="edge">
-      <title>:core:data-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M633.67,-159.18C749.06,-154.36 1031.95,-139.42 1060.06,-108 1070.73,-96.08 1070.01,-84.53 1060.06,-72 1058.73,-70.32 960.24,-47.86 893.16,-32.72"/>
-      <polygon fill="black" stroke="black" points="894.27,-29.39 883.74,-30.6 892.73,-36.22 894.27,-29.39"/>
-    </g>
-    <g id="node9" class="node">
-      <title>:core:database</title>
-      <ellipse fill="none" stroke="black" cx="502.06" cy="-90" rx="66.26" ry="18"/>
-      <text text-anchor="middle" x="502.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:database</text>
-    </g>
-    <g id="edge9" class="edge">
-      <title>:core:data-&gt;:core:database</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M566.22,-145.12C555.63,-136.18 542.19,-124.85 530.35,-114.86"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="533.9,-113.27 524,-109.5 529.38,-118.63 533.9,-113.27"/>
-    </g>
-    <g id="node10" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="983.06" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="983.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
-    </g>
-    <g id="edge10" class="edge">
-      <title>:core:data-&gt;:core:datastore</title>
-      <path fill="none" stroke="black" d="M630.12,-154.34C692.34,-144.97 808.03,-126.9 906.06,-108 911.25,-107 916.62,-105.91 922,-104.79"/>
-      <polygon fill="black" stroke="black" points="922.48,-108.27 931.54,-102.77 921.03,-101.42 922.48,-108.27"/>
-    </g>
-    <g id="node11" class="node">
-      <title>:core:network</title>
-      <ellipse fill="none" stroke="black" cx="832.06" cy="-90" rx="64.66" ry="18"/>
-      <text text-anchor="middle" x="832.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:network</text>
-    </g>
-    <g id="edge11" class="edge">
-      <title>:core:data-&gt;:core:network</title>
-      <path fill="none" stroke="black" d="M623.11,-150.22C664.33,-138.53 730.45,-119.8 777.26,-106.53"/>
-      <polygon fill="black" stroke="black" points="778,-109.96 786.67,-103.86 776.09,-103.22 778,-109.96"/>
-    </g>
-    <g id="node12" class="node">
-      <title>:core:notifications</title>
-      <ellipse fill="none" stroke="black" cx="668.06" cy="-90" rx="81.29" ry="18"/>
-      <text text-anchor="middle" x="668.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:notifications</text>
-    </g>
-    <g id="edge13" class="edge">
-      <title>:core:data-&gt;:core:notifications</title>
-      <path fill="none" stroke="black" d="M603.89,-145.12C614.41,-136.24 627.73,-125.01 639.51,-115.08"/>
-      <polygon fill="black" stroke="black" points="641.6,-117.9 646.98,-108.77 637.08,-112.54 641.6,-117.9"/>
-    </g>
-    <g id="edge22" class="edge">
-      <title>:core:domain-&gt;:core:data</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M363.88,-221.2C411.27,-208.73 485.84,-189.11 535.1,-176.15"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="534.41,-179.95 543.19,-174.02 532.63,-173.18 534.41,-179.95"/>
-    </g>
-    <g id="edge23" class="edge">
-      <title>:core:domain-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M305.66,-216.32C281.85,-184.58 237.93,-114.81 274.06,-72 304.43,-36.01 434.35,-24.46 516.36,-20.75"/>
-      <polygon fill="black" stroke="black" points="516.49,-24.25 526.33,-20.33 516.19,-17.25 516.49,-24.25"/>
-    </g>
-    <g id="edge14" class="edge">
-      <title>:core:database-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M521.73,-72.41C532.35,-63.45 545.63,-52.25 557.29,-42.42"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="558.11,-46.3 563.5,-37.18 553.6,-40.95 558.11,-46.3"/>
-    </g>
-    <g id="edge16" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M933.02,-77.54C924.06,-75.61 914.79,-73.68 906.06,-72 816.46,-54.73 712.11,-38.15 647.31,-28.27"/>
-      <polygon fill="black" stroke="black" points="647.99,-24.83 637.57,-26.79 646.94,-31.75 647.99,-24.83"/>
-    </g>
-    <g id="edge17" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M950.29,-73.81C928.23,-63.58 898.91,-49.99 874.98,-38.9"/>
-      <polygon fill="black" stroke="black" points="876.68,-35.83 866.13,-34.8 873.73,-42.18 876.68,-35.83"/>
-    </g>
-    <g id="node13" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="1008.06" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="1008.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge15" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="black" d="M989.24,-71.7C991.93,-64.15 995.16,-55.12 998.17,-46.68"/>
-      <polygon fill="black" stroke="black" points="1001.37,-48.12 1001.44,-37.53 994.78,-45.77 1001.37,-48.12"/>
-    </g>
-    <g id="edge19" class="edge">
-      <title>:core:network-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M787.9,-76.49C745.68,-64.52 682.02,-46.48 637.31,-33.81"/>
-      <polygon fill="black" stroke="black" points="638.4,-30.48 627.83,-31.12 636.49,-37.21 638.4,-30.48"/>
-    </g>
-    <g id="edge18" class="edge">
-      <title>:core:network-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M832.06,-71.7C832.06,-64.41 832.06,-55.73 832.06,-47.54"/>
-      <polygon fill="black" stroke="black" points="835.56,-47.62 832.06,-37.62 828.56,-47.62 835.56,-47.62"/>
-    </g>
-    <g id="edge20" class="edge">
-      <title>:core:notifications-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M648.39,-72.41C637.77,-63.45 624.48,-52.25 612.83,-42.42"/>
-      <polygon fill="black" stroke="black" points="615.36,-39.98 605.46,-36.2 610.84,-45.33 615.36,-39.98"/>
-    </g>
-    <g id="edge21" class="edge">
-      <title>:core:notifications-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M704.45,-73.46C728.84,-63.06 761.11,-49.28 787.1,-38.19"/>
-      <polygon fill="black" stroke="black" points="788.23,-41.51 796.05,-34.37 785.48,-35.07 788.23,-41.51"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_feature_interests.svg
+++ b/docs/images/graphs/dep_graph_feature_interests.svg
@@ -1,188 +1,149 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1108pt" height="332pt" viewBox="0.00 0.00 1107.53 332.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 328)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-328 1103.53,-328 1103.53,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:feature:interests</title>
-      <ellipse fill="none" stroke="black" cx="258.06" cy="-306" rx="75.39" ry="18"/>
-      <text text-anchor="middle" x="258.06" y="-301.8" font-family="Times,serif" font-size="14.00">:feature:interests</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="1108pt" height="332pt" viewBox="0 0 1107.53 332">
+    <g class="graph">
+        <path fill="#fff" d="M0 332V0h1107.53v332z"/>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="258.06" cy="-306" fill="none" stroke="#000" rx="75.39" ry="18"/>
+            <text x="258.06" y="-301.8" font-family="Times,serif" font-size="14" text-anchor="middle">:feature:interests</text>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="198.06" cy="-234" fill="none" stroke="#000" rx="40.53" ry="18"/>
+            <text x="198.06" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:ui</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M247.53 39.95c-7.25 8.46-16.17 18.86-24.18 28.21"/>
+            <path d="m226.19 70.23-9.17 5.31 3.85-9.87z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="85.06" cy="-162" fill="none" stroke="#000" rx="85.06" ry="18"/>
+            <text x="85.06" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:designsystem</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M220.22 37.31C198.35 46.17 172.05 59.1 152.06 76c-20.37 17.22-37.4 42.45-48.6 61.65"/>
+            <path d="m106.55 139.29-7.95 7 1.85-10.43z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="585.06" cy="-162" fill="none" stroke="#000" rx="49.1" ry="18"/>
+            <text x="585.06" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:data</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M300.37 37.84c26.45 10.38 62.37 24.73 93.69 38.16 54.36 23.3 116.38 51.97 155.6 70.37"/>
+            <path d="m550.91 143.09 7.56 7.42-10.53-1.08z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="319.06" cy="-234" fill="none" stroke="#000" rx="61.99" ry="18"/>
+            <text x="319.06" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:domain</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M276.82 39.95c7.27 8.34 16.18 18.56 24.23 27.8"/>
+            <path fill="red" d="m302.51 64.09 3.93 9.84-9.21-5.24z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M179.19 109.17c-15.56 9.64-36.48 22.59-54.24 33.6"/>
+            <path d="m127.09 145.56-10.35 2.29 6.66-8.24z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="350.06" cy="-90" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="350.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M218.9 110.74c26.43 24.68 77.82 72.69 109.06 101.88"/>
+            <path d="m330.17 209.9 4.92 9.38-9.7-4.27z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="585.06" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="585.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M202.92 112.29c2.68 33.45 13.59 106.95 58.14 143.71 38.65 31.9 175.95 44.91 260.17 49.98"/>
+            <path d="m521.2 302.47 9.78 4.07-10.19 2.92z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M551.82 178.09c-38.54 11.48-99.14 29.53-143.11 42.63"/>
+            <path d="m409.95 224-10.58-.5 8.58-6.21z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="832.06" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="832.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M637.67 168.82c115.39 4.82 398.28 19.76 426.39 51.18 10.67 11.92 9.95 23.47 0 36-1.33 1.68-99.82 24.14-166.9 39.28"/>
+            <path d="m898.27 298.61-10.53-1.21 8.99-5.62z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="502.06" cy="-90" fill="none" stroke="#000" rx="66.26" ry="18"/>
+            <text x="502.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:database</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M570.22 182.88c-10.59 8.94-24.03 20.27-35.87 30.26"/>
+            <path fill="red" d="m537.9 214.73-9.9 3.77 5.38-9.13z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="983.06" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="983.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M634.12 173.66c62.22 9.37 177.91 27.44 275.94 46.34 5.19 1 10.56 2.09 15.94 3.21"/>
+            <path d="m926.48 219.73 9.06 5.5-10.51 1.35z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="832.06" cy="-90" fill="none" stroke="#000" rx="64.66" ry="18"/>
+            <text x="832.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:network</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M627.11 177.78c41.22 11.69 107.34 30.42 154.15 43.69"/>
+            <path d="m782 218.04 8.67 6.1-10.58.64z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="668.06" cy="-90" fill="none" stroke="#000" rx="81.29" ry="18"/>
+            <text x="668.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:notifications</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M607.89 182.88c10.52 8.88 23.84 20.11 35.62 30.04"/>
+            <path d="m645.6 210.1 5.38 9.13-9.9-3.77z"/>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M367.88 106.8c47.39 12.47 121.96 32.09 171.22 45.05"/>
+            <path fill="red" d="m538.41 148.05 8.78 5.93-10.56.84z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M309.66 111.68c-23.81 31.74-67.73 101.51-31.6 144.32 30.37 35.99 160.29 47.54 242.3 51.25"/>
+            <path d="m520.49 303.75 9.84 3.92-10.14 3.08z"/>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M525.73 255.59c10.62 8.96 23.9 20.16 35.56 29.99"/>
+            <path fill="red" d="m562.11 281.7 5.39 9.12-9.9-3.77z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M937.02 250.46c-8.96 1.93-18.23 3.86-26.96 5.54-89.6 17.27-193.95 33.85-258.75 43.73"/>
+            <path d="m651.99 303.17-10.42-1.96 9.37-4.96z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M954.29 254.19a369994 369994 0 0 1-75.31 34.91"/>
+            <path d="m880.68 292.17-10.55 1.03 7.6-7.38z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="1008.06" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="1008.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M993.24 256.3c2.69 7.55 5.92 16.58 8.93 25.02"/>
+            <path d="m1005.37 279.88.07 10.59-6.66-8.24z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M791.9 251.51c-42.22 11.97-105.88 30.01-150.59 42.68"/>
+            <path d="m642.4 297.52-10.57-.64 8.66-6.09z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M836.06 256.3v24.16"/>
+            <path d="m839.56 280.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M652.39 255.59c-10.62 8.96-23.91 20.16-35.56 29.99"/>
+            <path d="m619.36 288.02-9.9 3.78 5.38-9.13z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M708.45 254.54c24.39 10.4 56.66 24.18 82.65 35.27"/>
+            <path d="m792.23 286.49 7.82 7.14-10.57-.7z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:ui</title>
-      <ellipse fill="none" stroke="black" cx="198.06" cy="-234" rx="40.53" ry="18"/>
-      <text text-anchor="middle" x="198.06" y="-229.8" font-family="Times,serif" font-size="14.00">:core:ui</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:feature:interests-&gt;:core:ui</title>
-      <path fill="none" stroke="black" d="M243.53,-288.05C236.28,-279.59 227.36,-269.19 219.35,-259.84"/>
-      <polygon fill="black" stroke="black" points="222.19,-257.77 213.02,-252.46 216.87,-262.33 222.19,-257.77"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:designsystem</title>
-      <ellipse fill="none" stroke="black" cx="85.06" cy="-162" rx="85.06" ry="18"/>
-      <text text-anchor="middle" x="85.06" y="-157.8" font-family="Times,serif" font-size="14.00">:core:designsystem</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:feature:interests-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M216.22,-290.69C194.35,-281.83 168.05,-268.9 148.06,-252 127.69,-234.78 110.66,-209.55 99.46,-190.35"/>
-      <polygon fill="black" stroke="black" points="102.55,-188.71 94.6,-181.71 96.45,-192.14 102.55,-188.71"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:data</title>
-      <ellipse fill="none" stroke="black" cx="585.06" cy="-162" rx="49.1" ry="18"/>
-      <text text-anchor="middle" x="585.06" y="-157.8" font-family="Times,serif" font-size="14.00">:core:data</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:feature:interests-&gt;:core:data</title>
-      <path fill="none" stroke="black" d="M296.37,-290.16C322.82,-279.78 358.74,-265.43 390.06,-252 444.42,-228.7 506.44,-200.03 545.66,-181.63"/>
-      <polygon fill="black" stroke="black" points="546.91,-184.91 554.47,-177.49 543.94,-178.57 546.91,-184.91"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:core:domain</title>
-      <ellipse fill="none" stroke="black" cx="319.06" cy="-234" rx="61.99" ry="18"/>
-      <text text-anchor="middle" x="319.06" y="-229.8" font-family="Times,serif" font-size="14.00">:core:domain</text>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:feature:interests-&gt;:core:domain</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M272.82,-288.05C280.09,-279.71 289,-269.49 297.05,-260.25"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="298.51,-263.91 302.44,-254.07 293.23,-259.31 298.51,-263.91"/>
-    </g>
-    <g id="edge6" class="edge">
-      <title>:core:ui-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M175.19,-218.83C159.63,-209.19 138.71,-196.24 120.95,-185.23"/>
-      <polygon fill="black" stroke="black" points="123.09,-182.44 112.74,-180.15 119.4,-188.39 123.09,-182.44"/>
-    </g>
-    <g id="node6" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="350.06" cy="-90" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="350.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:core:ui-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M214.9,-217.26C241.33,-192.58 292.72,-144.57 323.96,-115.38"/>
-      <polygon fill="black" stroke="black" points="326.17,-118.1 331.09,-108.72 321.39,-112.99 326.17,-118.1"/>
-    </g>
-    <g id="node7" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="585.06" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="585.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge7" class="edge">
-      <title>:core:ui-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M198.92,-215.71C201.6,-182.26 212.51,-108.76 257.06,-72 295.71,-40.1 433.01,-27.09 517.23,-22.02"/>
-      <polygon fill="black" stroke="black" points="517.2,-25.53 526.98,-21.46 516.79,-18.54 517.2,-25.53"/>
-    </g>
-    <g id="edge12" class="edge">
-      <title>:core:data-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M547.82,-149.91C509.28,-138.43 448.68,-120.38 404.71,-107.28"/>
-      <polygon fill="black" stroke="black" points="405.95,-104 395.37,-104.5 403.95,-110.71 405.95,-104"/>
-    </g>
-    <g id="node8" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="832.06" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="832.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge8" class="edge">
-      <title>:core:data-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M633.67,-159.18C749.06,-154.36 1031.95,-139.42 1060.06,-108 1070.73,-96.08 1070.01,-84.53 1060.06,-72 1058.73,-70.32 960.24,-47.86 893.16,-32.72"/>
-      <polygon fill="black" stroke="black" points="894.27,-29.39 883.74,-30.6 892.73,-36.22 894.27,-29.39"/>
-    </g>
-    <g id="node9" class="node">
-      <title>:core:database</title>
-      <ellipse fill="none" stroke="black" cx="502.06" cy="-90" rx="66.26" ry="18"/>
-      <text text-anchor="middle" x="502.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:database</text>
-    </g>
-    <g id="edge9" class="edge">
-      <title>:core:data-&gt;:core:database</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M566.22,-145.12C555.63,-136.18 542.19,-124.85 530.35,-114.86"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="533.9,-113.27 524,-109.5 529.38,-118.63 533.9,-113.27"/>
-    </g>
-    <g id="node10" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="983.06" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="983.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
-    </g>
-    <g id="edge10" class="edge">
-      <title>:core:data-&gt;:core:datastore</title>
-      <path fill="none" stroke="black" d="M630.12,-154.34C692.34,-144.97 808.03,-126.9 906.06,-108 911.25,-107 916.62,-105.91 922,-104.79"/>
-      <polygon fill="black" stroke="black" points="922.48,-108.27 931.54,-102.77 921.03,-101.42 922.48,-108.27"/>
-    </g>
-    <g id="node11" class="node">
-      <title>:core:network</title>
-      <ellipse fill="none" stroke="black" cx="832.06" cy="-90" rx="64.66" ry="18"/>
-      <text text-anchor="middle" x="832.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:network</text>
-    </g>
-    <g id="edge11" class="edge">
-      <title>:core:data-&gt;:core:network</title>
-      <path fill="none" stroke="black" d="M623.11,-150.22C664.33,-138.53 730.45,-119.8 777.26,-106.53"/>
-      <polygon fill="black" stroke="black" points="778,-109.96 786.67,-103.86 776.09,-103.22 778,-109.96"/>
-    </g>
-    <g id="node12" class="node">
-      <title>:core:notifications</title>
-      <ellipse fill="none" stroke="black" cx="668.06" cy="-90" rx="81.29" ry="18"/>
-      <text text-anchor="middle" x="668.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:notifications</text>
-    </g>
-    <g id="edge13" class="edge">
-      <title>:core:data-&gt;:core:notifications</title>
-      <path fill="none" stroke="black" d="M603.89,-145.12C614.41,-136.24 627.73,-125.01 639.51,-115.08"/>
-      <polygon fill="black" stroke="black" points="641.6,-117.9 646.98,-108.77 637.08,-112.54 641.6,-117.9"/>
-    </g>
-    <g id="edge22" class="edge">
-      <title>:core:domain-&gt;:core:data</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M363.88,-221.2C411.27,-208.73 485.84,-189.11 535.1,-176.15"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="534.41,-179.95 543.19,-174.02 532.63,-173.18 534.41,-179.95"/>
-    </g>
-    <g id="edge23" class="edge">
-      <title>:core:domain-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M305.66,-216.32C281.85,-184.58 237.93,-114.81 274.06,-72 304.43,-36.01 434.35,-24.46 516.36,-20.75"/>
-      <polygon fill="black" stroke="black" points="516.49,-24.25 526.33,-20.33 516.19,-17.25 516.49,-24.25"/>
-    </g>
-    <g id="edge14" class="edge">
-      <title>:core:database-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M521.73,-72.41C532.35,-63.45 545.63,-52.25 557.29,-42.42"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="558.11,-46.3 563.5,-37.18 553.6,-40.95 558.11,-46.3"/>
-    </g>
-    <g id="edge16" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M933.02,-77.54C924.06,-75.61 914.79,-73.68 906.06,-72 816.46,-54.73 712.11,-38.15 647.31,-28.27"/>
-      <polygon fill="black" stroke="black" points="647.99,-24.83 637.57,-26.79 646.94,-31.75 647.99,-24.83"/>
-    </g>
-    <g id="edge17" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M950.29,-73.81C928.23,-63.58 898.91,-49.99 874.98,-38.9"/>
-      <polygon fill="black" stroke="black" points="876.68,-35.83 866.13,-34.8 873.73,-42.18 876.68,-35.83"/>
-    </g>
-    <g id="node13" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="1008.06" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="1008.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge15" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="black" d="M989.24,-71.7C991.93,-64.15 995.16,-55.12 998.17,-46.68"/>
-      <polygon fill="black" stroke="black" points="1001.37,-48.12 1001.44,-37.53 994.78,-45.77 1001.37,-48.12"/>
-    </g>
-    <g id="edge19" class="edge">
-      <title>:core:network-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M787.9,-76.49C745.68,-64.52 682.02,-46.48 637.31,-33.81"/>
-      <polygon fill="black" stroke="black" points="638.4,-30.48 627.83,-31.12 636.49,-37.21 638.4,-30.48"/>
-    </g>
-    <g id="edge18" class="edge">
-      <title>:core:network-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M832.06,-71.7C832.06,-64.41 832.06,-55.73 832.06,-47.54"/>
-      <polygon fill="black" stroke="black" points="835.56,-47.62 832.06,-37.62 828.56,-47.62 835.56,-47.62"/>
-    </g>
-    <g id="edge20" class="edge">
-      <title>:core:notifications-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M648.39,-72.41C637.77,-63.45 624.48,-52.25 612.83,-42.42"/>
-      <polygon fill="black" stroke="black" points="615.36,-39.98 605.46,-36.2 610.84,-45.33 615.36,-39.98"/>
-    </g>
-    <g id="edge21" class="edge">
-      <title>:core:notifications-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M704.45,-73.46C728.84,-63.06 761.11,-49.28 787.1,-38.19"/>
-      <polygon fill="black" stroke="black" points="788.23,-41.51 796.05,-34.37 785.48,-35.07 788.23,-41.51"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_feature_search.svg
+++ b/docs/images/graphs/dep_graph_feature_search.svg
@@ -1,188 +1,149 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1108pt" height="332pt" viewBox="0.00 0.00 1107.53 332.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 328)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-328 1103.53,-328 1103.53,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:feature:search</title>
-      <ellipse fill="none" stroke="black" cx="258.06" cy="-306" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="258.06" y="-301.8" font-family="Times,serif" font-size="14.00">:feature:search</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="1108pt" height="332pt" viewBox="0 0 1107.53 332">
+    <g class="graph">
+        <path fill="#fff" d="M0 332V0h1107.53v332z"/>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="258.06" cy="-306" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="258.06" y="-301.8" font-family="Times,serif" font-size="14" text-anchor="middle">:feature:search</text>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="198.06" cy="-234" fill="none" stroke="#000" rx="40.53" ry="18"/>
+            <text x="198.06" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:ui</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M247.53 39.95c-7.25 8.46-16.17 18.86-24.18 28.21"/>
+            <path d="m226.19 70.23-9.17 5.31 3.85-9.87z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="85.06" cy="-162" fill="none" stroke="#000" rx="85.06" ry="18"/>
+            <text x="85.06" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:designsystem</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M221.55 36.78c-22.13 8.87-49.1 21.97-69.49 39.22-20.37 17.22-37.4 42.45-48.6 61.65"/>
+            <path d="m106.55 139.29-7.95 7 1.85-10.43z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="585.06" cy="-162" fill="none" stroke="#000" rx="49.1" ry="18"/>
+            <text x="585.06" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:data</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M299.23 37.39C325.78 47.8 362.28 62.38 394.06 76c54.36 23.3 116.38 51.97 155.6 70.37"/>
+            <path d="m550.91 143.09 7.56 7.42-10.53-1.08z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="319.06" cy="-234" fill="none" stroke="#000" rx="61.99" ry="18"/>
+            <text x="319.06" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:domain</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M276.82 39.95c7.27 8.34 16.18 18.56 24.23 27.8"/>
+            <path fill="red" d="m302.51 64.09 3.93 9.84-9.21-5.24z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M179.19 109.17c-15.56 9.64-36.48 22.59-54.24 33.6"/>
+            <path d="m127.09 145.56-10.35 2.29 6.66-8.24z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="350.06" cy="-90" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="350.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M218.9 110.74c26.43 24.68 77.82 72.69 109.06 101.88"/>
+            <path d="m330.17 209.9 4.92 9.38-9.7-4.27z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="585.06" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="585.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M202.92 112.29c2.68 33.45 13.59 106.95 58.14 143.71 38.65 31.9 175.95 44.91 260.17 49.98"/>
+            <path d="m521.2 302.47 9.78 4.07-10.19 2.92z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M551.82 178.09c-38.54 11.48-99.14 29.53-143.11 42.63"/>
+            <path d="m409.95 224-10.58-.5 8.58-6.21z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="832.06" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="832.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M637.67 168.82c115.39 4.82 398.28 19.76 426.39 51.18 10.67 11.92 9.95 23.47 0 36-1.33 1.68-99.82 24.14-166.9 39.28"/>
+            <path d="m898.27 298.61-10.53-1.21 8.99-5.62z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="502.06" cy="-90" fill="none" stroke="#000" rx="66.26" ry="18"/>
+            <text x="502.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:database</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M570.22 182.88c-10.59 8.94-24.03 20.27-35.87 30.26"/>
+            <path fill="red" d="m537.9 214.73-9.9 3.77 5.38-9.13z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="983.06" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="983.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M634.12 173.66c62.22 9.37 177.91 27.44 275.94 46.34 5.19 1 10.56 2.09 15.94 3.21"/>
+            <path d="m926.48 219.73 9.06 5.5-10.51 1.35z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="832.06" cy="-90" fill="none" stroke="#000" rx="64.66" ry="18"/>
+            <text x="832.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:network</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M627.11 177.78c41.22 11.69 107.34 30.42 154.15 43.69"/>
+            <path d="m782 218.04 8.67 6.1-10.58.64z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="668.06" cy="-90" fill="none" stroke="#000" rx="81.29" ry="18"/>
+            <text x="668.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:notifications</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M607.89 182.88c10.52 8.88 23.84 20.11 35.62 30.04"/>
+            <path d="m645.6 210.1 5.38 9.13-9.9-3.77z"/>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M367.88 106.8c47.39 12.47 121.96 32.09 171.22 45.05"/>
+            <path fill="red" d="m538.41 148.05 8.78 5.93-10.56.84z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M309.66 111.68c-23.81 31.74-67.73 101.51-31.6 144.32 30.37 35.99 160.29 47.54 242.3 51.25"/>
+            <path d="m520.49 303.75 9.84 3.92-10.14 3.08z"/>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M525.73 255.59c10.62 8.96 23.9 20.16 35.56 29.99"/>
+            <path fill="red" d="m562.11 281.7 5.39 9.12-9.9-3.77z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M937.02 250.46c-8.96 1.93-18.23 3.86-26.96 5.54-89.6 17.27-193.95 33.85-258.75 43.73"/>
+            <path d="m651.99 303.17-10.42-1.96 9.37-4.96z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M954.29 254.19a369994 369994 0 0 1-75.31 34.91"/>
+            <path d="m880.68 292.17-10.55 1.03 7.6-7.38z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="1008.06" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="1008.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M993.24 256.3c2.69 7.55 5.92 16.58 8.93 25.02"/>
+            <path d="m1005.37 279.88.07 10.59-6.66-8.24z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M791.9 251.51c-42.22 11.97-105.88 30.01-150.59 42.68"/>
+            <path d="m642.4 297.52-10.57-.64 8.66-6.09z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M836.06 256.3v24.16"/>
+            <path d="m839.56 280.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M652.39 255.59c-10.62 8.96-23.91 20.16-35.56 29.99"/>
+            <path d="m619.36 288.02-9.9 3.78 5.38-9.13z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M708.45 254.54c24.39 10.4 56.66 24.18 82.65 35.27"/>
+            <path d="m792.23 286.49 7.82 7.14-10.57-.7z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:ui</title>
-      <ellipse fill="none" stroke="black" cx="198.06" cy="-234" rx="40.53" ry="18"/>
-      <text text-anchor="middle" x="198.06" y="-229.8" font-family="Times,serif" font-size="14.00">:core:ui</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:feature:search-&gt;:core:ui</title>
-      <path fill="none" stroke="black" d="M243.53,-288.05C236.28,-279.59 227.36,-269.19 219.35,-259.84"/>
-      <polygon fill="black" stroke="black" points="222.19,-257.77 213.02,-252.46 216.87,-262.33 222.19,-257.77"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:designsystem</title>
-      <ellipse fill="none" stroke="black" cx="85.06" cy="-162" rx="85.06" ry="18"/>
-      <text text-anchor="middle" x="85.06" y="-157.8" font-family="Times,serif" font-size="14.00">:core:designsystem</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:feature:search-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M217.55,-291.22C195.42,-282.35 168.45,-269.25 148.06,-252 127.69,-234.78 110.66,-209.55 99.46,-190.35"/>
-      <polygon fill="black" stroke="black" points="102.55,-188.71 94.6,-181.71 96.45,-192.14 102.55,-188.71"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:data</title>
-      <ellipse fill="none" stroke="black" cx="585.06" cy="-162" rx="49.1" ry="18"/>
-      <text text-anchor="middle" x="585.06" y="-157.8" font-family="Times,serif" font-size="14.00">:core:data</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:feature:search-&gt;:core:data</title>
-      <path fill="none" stroke="black" d="M295.23,-290.61C321.78,-280.2 358.28,-265.62 390.06,-252 444.42,-228.7 506.44,-200.03 545.66,-181.63"/>
-      <polygon fill="black" stroke="black" points="546.91,-184.91 554.47,-177.49 543.94,-178.57 546.91,-184.91"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:core:domain</title>
-      <ellipse fill="none" stroke="black" cx="319.06" cy="-234" rx="61.99" ry="18"/>
-      <text text-anchor="middle" x="319.06" y="-229.8" font-family="Times,serif" font-size="14.00">:core:domain</text>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:feature:search-&gt;:core:domain</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M272.82,-288.05C280.09,-279.71 289,-269.49 297.05,-260.25"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="298.51,-263.91 302.44,-254.07 293.23,-259.31 298.51,-263.91"/>
-    </g>
-    <g id="edge6" class="edge">
-      <title>:core:ui-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M175.19,-218.83C159.63,-209.19 138.71,-196.24 120.95,-185.23"/>
-      <polygon fill="black" stroke="black" points="123.09,-182.44 112.74,-180.15 119.4,-188.39 123.09,-182.44"/>
-    </g>
-    <g id="node6" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="350.06" cy="-90" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="350.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:core:ui-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M214.9,-217.26C241.33,-192.58 292.72,-144.57 323.96,-115.38"/>
-      <polygon fill="black" stroke="black" points="326.17,-118.1 331.09,-108.72 321.39,-112.99 326.17,-118.1"/>
-    </g>
-    <g id="node7" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="585.06" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="585.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge7" class="edge">
-      <title>:core:ui-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M198.92,-215.71C201.6,-182.26 212.51,-108.76 257.06,-72 295.71,-40.1 433.01,-27.09 517.23,-22.02"/>
-      <polygon fill="black" stroke="black" points="517.2,-25.53 526.98,-21.46 516.79,-18.54 517.2,-25.53"/>
-    </g>
-    <g id="edge12" class="edge">
-      <title>:core:data-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M547.82,-149.91C509.28,-138.43 448.68,-120.38 404.71,-107.28"/>
-      <polygon fill="black" stroke="black" points="405.95,-104 395.37,-104.5 403.95,-110.71 405.95,-104"/>
-    </g>
-    <g id="node8" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="832.06" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="832.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge8" class="edge">
-      <title>:core:data-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M633.67,-159.18C749.06,-154.36 1031.95,-139.42 1060.06,-108 1070.73,-96.08 1070.01,-84.53 1060.06,-72 1058.73,-70.32 960.24,-47.86 893.16,-32.72"/>
-      <polygon fill="black" stroke="black" points="894.27,-29.39 883.74,-30.6 892.73,-36.22 894.27,-29.39"/>
-    </g>
-    <g id="node9" class="node">
-      <title>:core:database</title>
-      <ellipse fill="none" stroke="black" cx="502.06" cy="-90" rx="66.26" ry="18"/>
-      <text text-anchor="middle" x="502.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:database</text>
-    </g>
-    <g id="edge9" class="edge">
-      <title>:core:data-&gt;:core:database</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M566.22,-145.12C555.63,-136.18 542.19,-124.85 530.35,-114.86"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="533.9,-113.27 524,-109.5 529.38,-118.63 533.9,-113.27"/>
-    </g>
-    <g id="node10" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="983.06" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="983.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
-    </g>
-    <g id="edge10" class="edge">
-      <title>:core:data-&gt;:core:datastore</title>
-      <path fill="none" stroke="black" d="M630.12,-154.34C692.34,-144.97 808.03,-126.9 906.06,-108 911.25,-107 916.62,-105.91 922,-104.79"/>
-      <polygon fill="black" stroke="black" points="922.48,-108.27 931.54,-102.77 921.03,-101.42 922.48,-108.27"/>
-    </g>
-    <g id="node11" class="node">
-      <title>:core:network</title>
-      <ellipse fill="none" stroke="black" cx="832.06" cy="-90" rx="64.66" ry="18"/>
-      <text text-anchor="middle" x="832.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:network</text>
-    </g>
-    <g id="edge11" class="edge">
-      <title>:core:data-&gt;:core:network</title>
-      <path fill="none" stroke="black" d="M623.11,-150.22C664.33,-138.53 730.45,-119.8 777.26,-106.53"/>
-      <polygon fill="black" stroke="black" points="778,-109.96 786.67,-103.86 776.09,-103.22 778,-109.96"/>
-    </g>
-    <g id="node12" class="node">
-      <title>:core:notifications</title>
-      <ellipse fill="none" stroke="black" cx="668.06" cy="-90" rx="81.29" ry="18"/>
-      <text text-anchor="middle" x="668.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:notifications</text>
-    </g>
-    <g id="edge13" class="edge">
-      <title>:core:data-&gt;:core:notifications</title>
-      <path fill="none" stroke="black" d="M603.89,-145.12C614.41,-136.24 627.73,-125.01 639.51,-115.08"/>
-      <polygon fill="black" stroke="black" points="641.6,-117.9 646.98,-108.77 637.08,-112.54 641.6,-117.9"/>
-    </g>
-    <g id="edge22" class="edge">
-      <title>:core:domain-&gt;:core:data</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M363.88,-221.2C411.27,-208.73 485.84,-189.11 535.1,-176.15"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="534.41,-179.95 543.19,-174.02 532.63,-173.18 534.41,-179.95"/>
-    </g>
-    <g id="edge23" class="edge">
-      <title>:core:domain-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M305.66,-216.32C281.85,-184.58 237.93,-114.81 274.06,-72 304.43,-36.01 434.35,-24.46 516.36,-20.75"/>
-      <polygon fill="black" stroke="black" points="516.49,-24.25 526.33,-20.33 516.19,-17.25 516.49,-24.25"/>
-    </g>
-    <g id="edge14" class="edge">
-      <title>:core:database-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M521.73,-72.41C532.35,-63.45 545.63,-52.25 557.29,-42.42"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="558.11,-46.3 563.5,-37.18 553.6,-40.95 558.11,-46.3"/>
-    </g>
-    <g id="edge16" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M933.02,-77.54C924.06,-75.61 914.79,-73.68 906.06,-72 816.46,-54.73 712.11,-38.15 647.31,-28.27"/>
-      <polygon fill="black" stroke="black" points="647.99,-24.83 637.57,-26.79 646.94,-31.75 647.99,-24.83"/>
-    </g>
-    <g id="edge17" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M950.29,-73.81C928.23,-63.58 898.91,-49.99 874.98,-38.9"/>
-      <polygon fill="black" stroke="black" points="876.68,-35.83 866.13,-34.8 873.73,-42.18 876.68,-35.83"/>
-    </g>
-    <g id="node13" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="1008.06" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="1008.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge15" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="black" d="M989.24,-71.7C991.93,-64.15 995.16,-55.12 998.17,-46.68"/>
-      <polygon fill="black" stroke="black" points="1001.37,-48.12 1001.44,-37.53 994.78,-45.77 1001.37,-48.12"/>
-    </g>
-    <g id="edge19" class="edge">
-      <title>:core:network-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M787.9,-76.49C745.68,-64.52 682.02,-46.48 637.31,-33.81"/>
-      <polygon fill="black" stroke="black" points="638.4,-30.48 627.83,-31.12 636.49,-37.21 638.4,-30.48"/>
-    </g>
-    <g id="edge18" class="edge">
-      <title>:core:network-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M832.06,-71.7C832.06,-64.41 832.06,-55.73 832.06,-47.54"/>
-      <polygon fill="black" stroke="black" points="835.56,-47.62 832.06,-37.62 828.56,-47.62 835.56,-47.62"/>
-    </g>
-    <g id="edge20" class="edge">
-      <title>:core:notifications-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M648.39,-72.41C637.77,-63.45 624.48,-52.25 612.83,-42.42"/>
-      <polygon fill="black" stroke="black" points="615.36,-39.98 605.46,-36.2 610.84,-45.33 615.36,-39.98"/>
-    </g>
-    <g id="edge21" class="edge">
-      <title>:core:notifications-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M704.45,-73.46C728.84,-63.06 761.11,-49.28 787.1,-38.19"/>
-      <polygon fill="black" stroke="black" points="788.23,-41.51 796.05,-34.37 785.48,-35.07 788.23,-41.51"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_feature_settings.svg
+++ b/docs/images/graphs/dep_graph_feature_settings.svg
@@ -1,168 +1,133 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1064pt" height="260pt" viewBox="0.00 0.00 1063.53 260.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 256)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-256 1059.53,-256 1059.53,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:feature:settings</title>
-      <ellipse fill="none" stroke="black" cx="198.06" cy="-234" rx="72.71" ry="18"/>
-      <text text-anchor="middle" x="198.06" y="-229.8" font-family="Times,serif" font-size="14.00">:feature:settings</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="1064pt" height="260pt" viewBox="0 0 1063.53 260">
+    <g class="graph">
+        <path fill="#fff" d="M0 260V0h1063.53v260z"/>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="198.06" cy="-234" fill="none" stroke="#000" rx="72.71" ry="18"/>
+            <text x="198.06" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:feature:settings</text>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="198.06" cy="-162" fill="none" stroke="#000" rx="40.53" ry="18"/>
+            <text x="198.06" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:ui</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M202.06 40.3v24.16"/>
+            <path d="m205.56 64.38-3.5 10-3.5-10z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="85.06" cy="-90" fill="none" stroke="#000" rx="85.06" ry="18"/>
+            <text x="85.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:designsystem</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M185.21 39.63c-10 10.18-22.73 23.65-33.15 36.37-16.5 20.14-33.45 44.33-45.61 62.4"/>
+            <path d="m109.52 140.11-8.46 6.38 2.63-10.26z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="611.06" cy="-162" fill="none" stroke="#000" rx="49.1" ry="18"/>
+            <text x="611.06" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:data</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M260.79 32.95c79.81 13.53 221.46 37.54 299.28 50.73"/>
+            <path fill="red" d="m558.81 79.92 9.28 5.12-10.45 1.78z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M179.19 109.17c-15.56 9.64-36.48 22.59-54.24 33.6"/>
+            <path d="m127.09 145.56-10.35 2.29 6.66-8.24z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="293.06" cy="-90" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="293.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M222.2 109.85c12.69 9.34 29.33 21.61 43.7 32.19"/>
+            <path d="m267.76 139.06 5.97 8.75-10.13-3.11z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="611.06" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="611.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M200.38 112.2c-.94 20.29.97 53.55 20.68 71.8 46.01 42.62 225.28 51.44 325.4 52.97"/>
+            <path d="m546.2 233.46 9.95 3.63-10.04 3.37z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M573.69 104.09c-48.01 10.54-129.56 28.47-199.63 43.91-5.08 1.12-10.35 2.28-15.64 3.45"/>
+            <path d="m359.58 154.77-10.51-1.26 9.01-5.57z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="781.06" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="781.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M662.9 98.73c62.51 5.97 166.79 20.12 190.16 49.27 10.01 12.48 7.02 21.62 0 36-6.16 12.61-16.93 23.09-28.1 31.31"/>
+            <path d="m827.06 218.12-10.24 2.71 6.31-8.51z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="445.06" cy="-90" fill="none" stroke="#000" rx="66.26" ry="18"/>
+            <text x="445.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:database</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M583.83 108.17c-25.23 10.64-61.09 25.76-89.48 37.73"/>
+            <path fill="red" d="m497.23 148.48-10.57.66 7.85-7.11z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="964.06" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="964.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M657.8 103.2c53.43 10.3 147.66 28.56 228.26 44.8 6.21 1.25 12.68 2.57 19.14 3.89"/>
+            <path d="m905.45 148.37 9.09 5.44-10.5 1.42z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="775.06" cy="-90" fill="none" stroke="#000" rx="64.66" ry="18"/>
+            <text x="775.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:network</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M646.29 108.33c24.97 10.66 60.29 25.74 88.23 37.66"/>
+            <path d="m735.61 142.65 7.82 7.15-10.57-.71z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="611.06" cy="-90" fill="none" stroke="#000" rx="81.29" ry="18"/>
+            <text x="611.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:notifications</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M615.06 112.3v24.16"/>
+            <path d="m618.56 136.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M483.86 181.67c25.43 10.73 60.1 25.35 87.41 36.87"/>
+            <path fill="red" d="m571.08 214.66 7.85 7.11-10.57-.66z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M914.83 177.56c-64.82 12.85-173.94 34.49-241.12 47.81"/>
+            <path d="m674.46 228.79-10.49-1.49 9.13-5.38z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M930.58 181.33c-28.25 10.81-67.2 25.71-97.7 37.38"/>
+            <path d="m834.49 221.84-10.59.3 8.08-6.84z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="964.06" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="964.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M968.06 184.3v24.16"/>
+            <path d="m971.56 208.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M744.68 181.67c-25.13 10.73-59.38 25.35-86.36 36.87"/>
+            <path d="m659.96 221.64-10.57.71 7.82-7.15z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M780.54 184.3c.63 7.29 1.37 15.97 2.07 24.16"/>
+            <path d="m786.1 208.13-2.64 10.26-4.34-9.67z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M615.06 184.3v24.16"/>
+            <path d="m618.56 208.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M652.36 182.36c25.54 10.52 59.58 24.53 86.78 35.73"/>
+            <path d="m740.27 214.77 7.91 7.05-10.58-.58z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:ui</title>
-      <ellipse fill="none" stroke="black" cx="198.06" cy="-162" rx="40.53" ry="18"/>
-      <text text-anchor="middle" x="198.06" y="-157.8" font-family="Times,serif" font-size="14.00">:core:ui</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:feature:settings-&gt;:core:ui</title>
-      <path fill="none" stroke="black" d="M198.06,-215.7C198.06,-208.41 198.06,-199.73 198.06,-191.54"/>
-      <polygon fill="black" stroke="black" points="201.56,-191.62 198.06,-181.62 194.56,-191.62 201.56,-191.62"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:designsystem</title>
-      <ellipse fill="none" stroke="black" cx="85.06" cy="-90" rx="85.06" ry="18"/>
-      <text text-anchor="middle" x="85.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:designsystem</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:feature:settings-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M181.21,-216.37C171.21,-206.19 158.48,-192.72 148.06,-180 131.56,-159.86 114.61,-135.67 102.45,-117.6"/>
-      <polygon fill="black" stroke="black" points="105.52,-115.89 97.06,-109.51 99.69,-119.77 105.52,-115.89"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:data</title>
-      <ellipse fill="none" stroke="black" cx="611.06" cy="-162" rx="49.1" ry="18"/>
-      <text text-anchor="middle" x="611.06" y="-157.8" font-family="Times,serif" font-size="14.00">:core:data</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:feature:settings-&gt;:core:data</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M256.79,-223.05C336.6,-209.52 478.25,-185.51 556.07,-172.32"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="554.81,-176.08 564.09,-170.96 553.64,-169.18 554.81,-176.08"/>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:core:ui-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M175.19,-146.83C159.63,-137.19 138.71,-124.24 120.95,-113.23"/>
-      <polygon fill="black" stroke="black" points="123.09,-110.44 112.74,-108.15 119.4,-116.39 123.09,-110.44"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="293.06" cy="-90" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="293.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:core:ui-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M218.2,-146.15C230.89,-136.81 247.53,-124.54 261.9,-113.96"/>
-      <polygon fill="black" stroke="black" points="263.76,-116.94 269.73,-108.19 259.6,-111.3 263.76,-116.94"/>
-    </g>
-    <g id="node6" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="611.06" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="611.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge6" class="edge">
-      <title>:core:ui-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M196.38,-143.8C195.44,-123.51 197.35,-90.25 217.06,-72 263.07,-29.38 442.34,-20.56 542.46,-19.03"/>
-      <polygon fill="black" stroke="black" points="542.2,-22.54 552.15,-18.91 542.11,-15.54 542.2,-22.54"/>
-    </g>
-    <g id="edge11" class="edge">
-      <title>:core:data-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M569.69,-151.91C521.68,-141.37 440.13,-123.44 370.06,-108 364.98,-106.88 359.71,-105.72 354.42,-104.55"/>
-      <polygon fill="black" stroke="black" points="355.58,-101.23 345.07,-102.49 354.08,-108.06 355.58,-101.23"/>
-    </g>
-    <g id="node7" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="781.06" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="781.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge7" class="edge">
-      <title>:core:data-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M658.9,-157.27C721.41,-151.3 825.69,-137.15 849.06,-108 859.07,-95.52 856.08,-86.38 849.06,-72 842.9,-59.39 832.13,-48.91 820.96,-40.69"/>
-      <polygon fill="black" stroke="black" points="823.06,-37.88 812.82,-35.17 819.13,-43.68 823.06,-37.88"/>
-    </g>
-    <g id="node8" class="node">
-      <title>:core:database</title>
-      <ellipse fill="none" stroke="black" cx="445.06" cy="-90" rx="66.26" ry="18"/>
-      <text text-anchor="middle" x="445.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:database</text>
-    </g>
-    <g id="edge8" class="edge">
-      <title>:core:data-&gt;:core:database</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M579.83,-147.83C554.6,-137.19 518.74,-122.07 490.35,-110.1"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="493.23,-107.52 482.66,-106.86 490.51,-113.97 493.23,-107.52"/>
-    </g>
-    <g id="node9" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="964.06" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="964.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
-    </g>
-    <g id="edge9" class="edge">
-      <title>:core:data-&gt;:core:datastore</title>
-      <path fill="none" stroke="black" d="M653.8,-152.8C707.23,-142.5 801.46,-124.24 882.06,-108 888.27,-106.75 894.74,-105.43 901.2,-104.11"/>
-      <polygon fill="black" stroke="black" points="901.45,-107.63 910.54,-102.19 900.04,-100.77 901.45,-107.63"/>
-    </g>
-    <g id="node10" class="node">
-      <title>:core:network</title>
-      <ellipse fill="none" stroke="black" cx="775.06" cy="-90" rx="64.66" ry="18"/>
-      <text text-anchor="middle" x="775.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:network</text>
-    </g>
-    <g id="edge10" class="edge">
-      <title>:core:data-&gt;:core:network</title>
-      <path fill="none" stroke="black" d="M642.29,-147.67C667.26,-137.01 702.58,-121.93 730.52,-110.01"/>
-      <polygon fill="black" stroke="black" points="731.61,-113.35 739.43,-106.2 728.86,-106.91 731.61,-113.35"/>
-    </g>
-    <g id="node11" class="node">
-      <title>:core:notifications</title>
-      <ellipse fill="none" stroke="black" cx="611.06" cy="-90" rx="81.29" ry="18"/>
-      <text text-anchor="middle" x="611.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:notifications</text>
-    </g>
-    <g id="edge12" class="edge">
-      <title>:core:data-&gt;:core:notifications</title>
-      <path fill="none" stroke="black" d="M611.06,-143.7C611.06,-136.41 611.06,-127.73 611.06,-119.54"/>
-      <polygon fill="black" stroke="black" points="614.56,-119.62 611.06,-109.62 607.56,-119.62 614.56,-119.62"/>
-    </g>
-    <g id="edge13" class="edge">
-      <title>:core:database-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M479.86,-74.33C505.29,-63.6 539.96,-48.98 567.27,-37.46"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="567.08,-41.34 574.93,-34.23 564.36,-34.89 567.08,-41.34"/>
-    </g>
-    <g id="edge15" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M910.83,-78.44C846.01,-65.59 736.89,-43.95 669.71,-30.63"/>
-      <polygon fill="black" stroke="black" points="670.46,-27.21 659.97,-28.7 669.1,-34.08 670.46,-27.21"/>
-    </g>
-    <g id="edge16" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M926.58,-74.67C898.33,-63.86 859.38,-48.96 828.88,-37.29"/>
-      <polygon fill="black" stroke="black" points="830.49,-34.16 819.9,-33.86 827.98,-40.7 830.49,-34.16"/>
-    </g>
-    <g id="node12" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="964.06" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="964.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge14" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="black" d="M964.06,-71.7C964.06,-64.41 964.06,-55.73 964.06,-47.54"/>
-      <polygon fill="black" stroke="black" points="967.56,-47.62 964.06,-37.62 960.56,-47.62 967.56,-47.62"/>
-    </g>
-    <g id="edge18" class="edge">
-      <title>:core:network-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M740.68,-74.33C715.55,-63.6 681.3,-48.98 654.32,-37.46"/>
-      <polygon fill="black" stroke="black" points="655.96,-34.36 645.39,-33.65 653.21,-40.8 655.96,-34.36"/>
-    </g>
-    <g id="edge17" class="edge">
-      <title>:core:network-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M776.54,-71.7C777.17,-64.41 777.91,-55.73 778.61,-47.54"/>
-      <polygon fill="black" stroke="black" points="782.1,-47.87 779.46,-37.61 775.12,-47.28 782.1,-47.87"/>
-    </g>
-    <g id="edge19" class="edge">
-      <title>:core:notifications-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M611.06,-71.7C611.06,-64.41 611.06,-55.73 611.06,-47.54"/>
-      <polygon fill="black" stroke="black" points="614.56,-47.62 611.06,-37.62 607.56,-47.62 614.56,-47.62"/>
-    </g>
-    <g id="edge20" class="edge">
-      <title>:core:notifications-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M648.36,-73.64C673.9,-63.12 707.94,-49.11 735.14,-37.91"/>
-      <polygon fill="black" stroke="black" points="736.27,-41.23 744.18,-34.18 733.6,-34.76 736.27,-41.23"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_feature_topic.svg
+++ b/docs/images/graphs/dep_graph_feature_topic.svg
@@ -1,168 +1,133 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1064pt" height="260pt" viewBox="0.00 0.00 1063.53 260.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 256)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-256 1059.53,-256 1059.53,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:feature:topic</title>
-      <ellipse fill="none" stroke="black" cx="198.06" cy="-234" rx="62.51" ry="18"/>
-      <text text-anchor="middle" x="198.06" y="-229.8" font-family="Times,serif" font-size="14.00">:feature:topic</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="1064pt" height="260pt" viewBox="0 0 1063.53 260">
+    <g class="graph">
+        <path fill="#fff" d="M0 260V0h1063.53v260z"/>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="198.06" cy="-234" fill="none" stroke="#000" rx="62.51" ry="18"/>
+            <text x="198.06" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:feature:topic</text>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="198.06" cy="-162" fill="none" stroke="#000" rx="40.53" ry="18"/>
+            <text x="198.06" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:ui</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M202.06 40.3v24.16"/>
+            <path d="m205.56 64.38-3.5 10-3.5-10z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="85.06" cy="-90" fill="none" stroke="#000" rx="85.06" ry="18"/>
+            <text x="85.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:designsystem</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M185.21 39.63c-10 10.18-22.73 23.65-33.15 36.37-16.5 20.14-33.45 44.33-45.61 62.4"/>
+            <path d="m109.52 140.11-8.46 6.38 2.63-10.26z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="611.06" cy="-162" fill="none" stroke="#000" rx="49.1" ry="18"/>
+            <text x="611.06" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:data</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M254.78 31.94C333.23 45.23 480 70.11 559.86 83.64"/>
+            <path fill="red" d="m558.88 79.93 9.27 5.12-10.44 1.78z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M179.19 109.17c-15.56 9.64-36.48 22.59-54.24 33.6"/>
+            <path d="m127.09 145.56-10.35 2.29 6.66-8.24z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="293.06" cy="-90" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="293.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M222.2 109.85c12.69 9.34 29.33 21.61 43.7 32.19"/>
+            <path d="m267.76 139.06 5.97 8.75-10.13-3.11z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="611.06" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="611.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M200.38 112.2c-.94 20.29.97 53.55 20.68 71.8 46.01 42.62 225.28 51.44 325.4 52.97"/>
+            <path d="m546.2 233.46 9.95 3.63-10.04 3.37z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M573.69 104.09c-48.01 10.54-129.56 28.47-199.63 43.91-5.08 1.12-10.35 2.28-15.64 3.45"/>
+            <path d="m359.58 154.77-10.51-1.26 9.01-5.57z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="781.06" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="781.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M662.9 98.73c62.51 5.97 166.79 20.12 190.16 49.27 10.01 12.48 7.02 21.62 0 36-6.16 12.61-16.93 23.09-28.1 31.31"/>
+            <path d="m827.06 218.12-10.24 2.71 6.31-8.51z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="445.06" cy="-90" fill="none" stroke="#000" rx="66.26" ry="18"/>
+            <text x="445.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:database</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M583.83 108.17c-25.23 10.64-61.09 25.76-89.48 37.73"/>
+            <path fill="red" d="m497.23 148.48-10.57.66 7.85-7.11z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="964.06" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="964.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M657.8 103.2c53.43 10.3 147.66 28.56 228.26 44.8 6.21 1.25 12.68 2.57 19.14 3.89"/>
+            <path d="m905.45 148.37 9.09 5.44-10.5 1.42z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="775.06" cy="-90" fill="none" stroke="#000" rx="64.66" ry="18"/>
+            <text x="775.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:network</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M646.29 108.33c24.97 10.66 60.29 25.74 88.23 37.66"/>
+            <path d="m735.61 142.65 7.82 7.15-10.57-.71z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="611.06" cy="-90" fill="none" stroke="#000" rx="81.29" ry="18"/>
+            <text x="611.06" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:notifications</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M615.06 112.3v24.16"/>
+            <path d="m618.56 136.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M483.86 181.67c25.43 10.73 60.1 25.35 87.41 36.87"/>
+            <path fill="red" d="m571.08 214.66 7.85 7.11-10.57-.66z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M914.83 177.56c-64.82 12.85-173.94 34.49-241.12 47.81"/>
+            <path d="m674.46 228.79-10.49-1.49 9.13-5.38z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M930.58 181.33c-28.25 10.81-67.2 25.71-97.7 37.38"/>
+            <path d="m834.49 221.84-10.59.3 8.08-6.84z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="964.06" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="964.06" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M968.06 184.3v24.16"/>
+            <path d="m971.56 208.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M744.68 181.67c-25.13 10.73-59.38 25.35-86.36 36.87"/>
+            <path d="m659.96 221.64-10.57.71 7.82-7.15z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M780.54 184.3c.63 7.29 1.37 15.97 2.07 24.16"/>
+            <path d="m786.1 208.13-2.64 10.26-4.34-9.67z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M615.06 184.3v24.16"/>
+            <path d="m618.56 208.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M652.36 182.36c25.54 10.52 59.58 24.53 86.78 35.73"/>
+            <path d="m740.27 214.77 7.91 7.05-10.58-.58z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:ui</title>
-      <ellipse fill="none" stroke="black" cx="198.06" cy="-162" rx="40.53" ry="18"/>
-      <text text-anchor="middle" x="198.06" y="-157.8" font-family="Times,serif" font-size="14.00">:core:ui</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:feature:topic-&gt;:core:ui</title>
-      <path fill="none" stroke="black" d="M198.06,-215.7C198.06,-208.41 198.06,-199.73 198.06,-191.54"/>
-      <polygon fill="black" stroke="black" points="201.56,-191.62 198.06,-181.62 194.56,-191.62 201.56,-191.62"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:designsystem</title>
-      <ellipse fill="none" stroke="black" cx="85.06" cy="-90" rx="85.06" ry="18"/>
-      <text text-anchor="middle" x="85.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:designsystem</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:feature:topic-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M181.21,-216.37C171.21,-206.19 158.48,-192.72 148.06,-180 131.56,-159.86 114.61,-135.67 102.45,-117.6"/>
-      <polygon fill="black" stroke="black" points="105.52,-115.89 97.06,-109.51 99.69,-119.77 105.52,-115.89"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:data</title>
-      <ellipse fill="none" stroke="black" cx="611.06" cy="-162" rx="49.1" ry="18"/>
-      <text text-anchor="middle" x="611.06" y="-157.8" font-family="Times,serif" font-size="14.00">:core:data</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:feature:topic-&gt;:core:data</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M250.78,-224.06C329.23,-210.77 476,-185.89 555.86,-172.36"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="554.88,-176.07 564.15,-170.95 553.71,-169.17 554.88,-176.07"/>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:core:ui-&gt;:core:designsystem</title>
-      <path fill="none" stroke="black" d="M175.19,-146.83C159.63,-137.19 138.71,-124.24 120.95,-113.23"/>
-      <polygon fill="black" stroke="black" points="123.09,-110.44 112.74,-108.15 119.4,-116.39 123.09,-110.44"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="293.06" cy="-90" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="293.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:core:ui-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M218.2,-146.15C230.89,-136.81 247.53,-124.54 261.9,-113.96"/>
-      <polygon fill="black" stroke="black" points="263.76,-116.94 269.73,-108.19 259.6,-111.3 263.76,-116.94"/>
-    </g>
-    <g id="node6" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="611.06" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="611.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge6" class="edge">
-      <title>:core:ui-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M196.38,-143.8C195.44,-123.51 197.35,-90.25 217.06,-72 263.07,-29.38 442.34,-20.56 542.46,-19.03"/>
-      <polygon fill="black" stroke="black" points="542.2,-22.54 552.15,-18.91 542.11,-15.54 542.2,-22.54"/>
-    </g>
-    <g id="edge11" class="edge">
-      <title>:core:data-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M569.69,-151.91C521.68,-141.37 440.13,-123.44 370.06,-108 364.98,-106.88 359.71,-105.72 354.42,-104.55"/>
-      <polygon fill="black" stroke="black" points="355.58,-101.23 345.07,-102.49 354.08,-108.06 355.58,-101.23"/>
-    </g>
-    <g id="node7" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="781.06" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="781.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge7" class="edge">
-      <title>:core:data-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M658.9,-157.27C721.41,-151.3 825.69,-137.15 849.06,-108 859.07,-95.52 856.08,-86.38 849.06,-72 842.9,-59.39 832.13,-48.91 820.96,-40.69"/>
-      <polygon fill="black" stroke="black" points="823.06,-37.88 812.82,-35.17 819.13,-43.68 823.06,-37.88"/>
-    </g>
-    <g id="node8" class="node">
-      <title>:core:database</title>
-      <ellipse fill="none" stroke="black" cx="445.06" cy="-90" rx="66.26" ry="18"/>
-      <text text-anchor="middle" x="445.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:database</text>
-    </g>
-    <g id="edge8" class="edge">
-      <title>:core:data-&gt;:core:database</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M579.83,-147.83C554.6,-137.19 518.74,-122.07 490.35,-110.1"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="493.23,-107.52 482.66,-106.86 490.51,-113.97 493.23,-107.52"/>
-    </g>
-    <g id="node9" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="964.06" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="964.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
-    </g>
-    <g id="edge9" class="edge">
-      <title>:core:data-&gt;:core:datastore</title>
-      <path fill="none" stroke="black" d="M653.8,-152.8C707.23,-142.5 801.46,-124.24 882.06,-108 888.27,-106.75 894.74,-105.43 901.2,-104.11"/>
-      <polygon fill="black" stroke="black" points="901.45,-107.63 910.54,-102.19 900.04,-100.77 901.45,-107.63"/>
-    </g>
-    <g id="node10" class="node">
-      <title>:core:network</title>
-      <ellipse fill="none" stroke="black" cx="775.06" cy="-90" rx="64.66" ry="18"/>
-      <text text-anchor="middle" x="775.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:network</text>
-    </g>
-    <g id="edge10" class="edge">
-      <title>:core:data-&gt;:core:network</title>
-      <path fill="none" stroke="black" d="M642.29,-147.67C667.26,-137.01 702.58,-121.93 730.52,-110.01"/>
-      <polygon fill="black" stroke="black" points="731.61,-113.35 739.43,-106.2 728.86,-106.91 731.61,-113.35"/>
-    </g>
-    <g id="node11" class="node">
-      <title>:core:notifications</title>
-      <ellipse fill="none" stroke="black" cx="611.06" cy="-90" rx="81.29" ry="18"/>
-      <text text-anchor="middle" x="611.06" y="-85.8" font-family="Times,serif" font-size="14.00">:core:notifications</text>
-    </g>
-    <g id="edge12" class="edge">
-      <title>:core:data-&gt;:core:notifications</title>
-      <path fill="none" stroke="black" d="M611.06,-143.7C611.06,-136.41 611.06,-127.73 611.06,-119.54"/>
-      <polygon fill="black" stroke="black" points="614.56,-119.62 611.06,-109.62 607.56,-119.62 614.56,-119.62"/>
-    </g>
-    <g id="edge13" class="edge">
-      <title>:core:database-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M479.86,-74.33C505.29,-63.6 539.96,-48.98 567.27,-37.46"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="567.08,-41.34 574.93,-34.23 564.36,-34.89 567.08,-41.34"/>
-    </g>
-    <g id="edge15" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M910.83,-78.44C846.01,-65.59 736.89,-43.95 669.71,-30.63"/>
-      <polygon fill="black" stroke="black" points="670.46,-27.21 659.97,-28.7 669.1,-34.08 670.46,-27.21"/>
-    </g>
-    <g id="edge16" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M926.58,-74.67C898.33,-63.86 859.38,-48.96 828.88,-37.29"/>
-      <polygon fill="black" stroke="black" points="830.49,-34.16 819.9,-33.86 827.98,-40.7 830.49,-34.16"/>
-    </g>
-    <g id="node12" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="964.06" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="964.06" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge14" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="black" d="M964.06,-71.7C964.06,-64.41 964.06,-55.73 964.06,-47.54"/>
-      <polygon fill="black" stroke="black" points="967.56,-47.62 964.06,-37.62 960.56,-47.62 967.56,-47.62"/>
-    </g>
-    <g id="edge18" class="edge">
-      <title>:core:network-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M740.68,-74.33C715.55,-63.6 681.3,-48.98 654.32,-37.46"/>
-      <polygon fill="black" stroke="black" points="655.96,-34.36 645.39,-33.65 653.21,-40.8 655.96,-34.36"/>
-    </g>
-    <g id="edge17" class="edge">
-      <title>:core:network-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M776.54,-71.7C777.17,-64.41 777.91,-55.73 778.61,-47.54"/>
-      <polygon fill="black" stroke="black" points="782.1,-47.87 779.46,-37.61 775.12,-47.28 782.1,-47.87"/>
-    </g>
-    <g id="edge19" class="edge">
-      <title>:core:notifications-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M611.06,-71.7C611.06,-64.41 611.06,-55.73 611.06,-47.54"/>
-      <polygon fill="black" stroke="black" points="614.56,-47.62 611.06,-37.62 607.56,-47.62 614.56,-47.62"/>
-    </g>
-    <g id="edge20" class="edge">
-      <title>:core:notifications-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M648.36,-73.64C673.9,-63.12 707.94,-49.11 735.14,-37.91"/>
-      <polygon fill="black" stroke="black" points="736.27,-41.23 744.18,-34.18 733.6,-34.76 736.27,-41.23"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_sync_sync_test.svg
+++ b/docs/images/graphs/dep_graph_sync_sync_test.svg
@@ -1,153 +1,121 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="791pt" height="332pt" viewBox="0.00 0.00 791.39 332.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 328)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-328 787.39,-328 787.39,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:sync:sync-test</title>
-      <ellipse fill="none" stroke="black" cx="453.04" cy="-306" rx="68.43" ry="18"/>
-      <text text-anchor="middle" x="453.04" y="-301.8" font-family="Times,serif" font-size="14.00">:sync:sync-test</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="791pt" height="332pt" viewBox="0 0 791.39 332">
+    <g class="graph">
+        <path fill="#fff" d="M0 332V0h791.39v332z"/>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="453.04" cy="-306" fill="none" stroke="#000" rx="68.43" ry="18"/>
+            <text x="453.04" y="-301.8" font-family="Times,serif" font-size="14" text-anchor="middle">:sync:sync-test</text>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="412.04" cy="-162" fill="none" stroke="#000" rx="49.1" ry="18"/>
+            <text x="412.04" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:data</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M448.89 40.37c-4.55 10.2-10.05 23.45-13.85 35.63-6.18 19.86-11.03 42.82-14.28 60.45"/>
+            <path d="m424.22 136.97-5.19 9.24-1.7-10.46z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="494.04" cy="-234" fill="none" stroke="#000" rx="53.95" ry="18"/>
+            <text x="494.04" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:sync:work</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M466.97 39.95c4.63 7.91 10.26 17.51 15.44 26.36"/>
+            <path fill="red" d="m484.65 63.2 2.03 10.4-8.07-6.86z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="92.04" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="92.04" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M367.83 169.79C265.55 176.21 34.29 193.52 11.04 220c-10.55 12.03-7.76 22.01 0 36 8.09 14.58 22.05 25.67 36.34 33.84"/>
+            <path d="m48.7 286.58 7.21 7.76-10.47-1.56z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="564.04" cy="-90" fill="none" stroke="#000" rx="66.26" ry="18"/>
+            <text x="564.04" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:database</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M445.71 180.66c22.53 10.38 53.84 24.8 79.14 36.45"/>
+            <path fill="red" d="m524.92 213.29 7.62 7.36-10.55-1z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="412.04" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="412.04" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M416.04 184.3v24.16"/>
+            <path d="m419.54 208.38-3.5 10-3.5-10z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="81.04" cy="-90" fill="none" stroke="#000" rx="64.66" ry="18"/>
+            <text x="81.04" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:network</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M373.69 175.43c-50.99 10.22-139.2 28.13-214.65 44.57-4.63 1.01-9.43 2.07-14.25 3.15"/>
+            <path d="m145.57 226.56-10.52-1.21 8.98-5.61z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="716.04" cy="-90" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="716.04" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M456.73 176.37c52.01 11.97 142.52 32.82 202.68 46.67"/>
+            <path d="m659.84 219.55 8.96 5.65-10.53 1.17z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="245.04" cy="-90" fill="none" stroke="#000" rx="81.29" ry="18"/>
+            <text x="245.04" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:notifications</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M384.63 180.17c-24.88 10.43-60.04 25.16-88.32 37.02"/>
+            <path d="m297.82 220.35-10.58.64 7.87-7.09z"/>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M479.03 111.24c-10.64 9.07-24.07 20.54-35.79 30.55"/>
+            <path fill="red" d="m446.86 143.3-9.88 3.83 5.33-9.16z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M522.22 110.47c39.47 25.24 117.88 75.4 163.23 104.4"/>
+            <path d="m687.06 211.75 6.54 8.33-10.31-2.44z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="245.04" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="245.04" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M518.86 250.31c-8.6 1.93-17.46 3.89-25.82 5.69-78.48 16.87-98.73 18.12-177 36-4.28.98-8.72 2.03-13.16 3.1"/>
+            <path fill="red" d="m305.35 298.1-10.55-1.01 8.87-5.79z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M365.1 250.27c-8.69 1.91-17.63 3.88-26.06 5.73-61.62 13.52-132.06 28.88-181.18 39.56"/>
+            <path d="m158.78 298.95-10.52-1.3 9.03-5.54z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M381.03 253.67c-25.66 10.76-60.69 25.44-88.21 36.98"/>
+            <path d="m294.27 293.84-10.57.64 7.87-7.1z"/>
+        </g>
+        <g class="node" transform="translate(4 328)">
+            <ellipse cx="412.04" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="412.04" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M416.04 256.3v24.16"/>
+            <path d="m419.54 280.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M87.76 256.3c1.16 7.38 2.54 16.18 3.84 24.45"/>
+            <path d="m95.03 279.98-1.91 10.42-5.01-9.33z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M119.42 253.67c25.13 10.73 59.38 25.35 86.36 36.87"/>
+            <path d="m206.89 287.2 7.83 7.15-10.58-.71z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M214.71 254.71c-22.34 10.22-51.64 23.63-75.54 34.56"/>
+            <path d="m140.88 292.34-10.55.97 7.64-7.34z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M249.04 256.3v24.16"/>
+            <path d="m252.54 280.38-3.5 10-3.5-10z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:data</title>
-      <ellipse fill="none" stroke="black" cx="412.04" cy="-162" rx="49.1" ry="18"/>
-      <text text-anchor="middle" x="412.04" y="-157.8" font-family="Times,serif" font-size="14.00">:core:data</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:sync:sync-test-&gt;:core:data</title>
-      <path fill="none" stroke="black" d="M444.89,-287.63C440.34,-277.43 434.84,-264.18 431.04,-252 424.86,-232.14 420.01,-209.18 416.76,-191.55"/>
-      <polygon fill="black" stroke="black" points="420.22,-191.03 415.03,-181.79 413.33,-192.25 420.22,-191.03"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:sync:work</title>
-      <ellipse fill="none" stroke="black" cx="494.04" cy="-234" rx="53.95" ry="18"/>
-      <text text-anchor="middle" x="494.04" y="-229.8" font-family="Times,serif" font-size="14.00">:sync:work</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:sync:sync-test-&gt;:sync:work</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M462.97,-288.05C467.6,-280.14 473.23,-270.54 478.41,-261.69"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="480.65,-264.8 482.68,-254.4 474.61,-261.26 480.65,-264.8"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="92.04" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="92.04" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:core:data-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M363.83,-158.21C261.55,-151.79 30.29,-134.48 7.04,-108 -3.51,-95.97 -0.72,-85.99 7.04,-72 15.13,-57.42 29.09,-46.33 43.38,-38.16"/>
-      <polygon fill="black" stroke="black" points="44.7,-41.42 51.91,-33.66 41.44,-35.22 44.7,-41.42"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:core:database</title>
-      <ellipse fill="none" stroke="black" cx="564.04" cy="-90" rx="66.26" ry="18"/>
-      <text text-anchor="middle" x="564.04" y="-85.8" font-family="Times,serif" font-size="14.00">:core:database</text>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:core:data-&gt;:core:database</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M441.71,-147.34C464.24,-136.96 495.55,-122.54 520.85,-110.89"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="520.92,-114.71 528.54,-107.35 517.99,-108.35 520.92,-114.71"/>
-    </g>
-    <g id="node6" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="412.04" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="412.04" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:core:data-&gt;:core:datastore</title>
-      <path fill="none" stroke="black" d="M412.04,-143.7C412.04,-136.41 412.04,-127.73 412.04,-119.54"/>
-      <polygon fill="black" stroke="black" points="415.54,-119.62 412.04,-109.62 408.54,-119.62 415.54,-119.62"/>
-    </g>
-    <g id="node7" class="node">
-      <title>:core:network</title>
-      <ellipse fill="none" stroke="black" cx="81.04" cy="-90" rx="64.66" ry="18"/>
-      <text text-anchor="middle" x="81.04" y="-85.8" font-family="Times,serif" font-size="14.00">:core:network</text>
-    </g>
-    <g id="edge6" class="edge">
-      <title>:core:data-&gt;:core:network</title>
-      <path fill="none" stroke="black" d="M369.69,-152.57C318.7,-142.35 230.49,-124.44 155.04,-108 150.41,-106.99 145.61,-105.93 140.79,-104.85"/>
-      <polygon fill="black" stroke="black" points="141.57,-101.44 131.05,-102.65 140.03,-108.26 141.57,-101.44"/>
-    </g>
-    <g id="node8" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="716.04" cy="-90" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="716.04" y="-85.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge7" class="edge">
-      <title>:core:data-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M452.73,-151.63C504.74,-139.66 595.25,-118.81 655.41,-104.96"/>
-      <polygon fill="black" stroke="black" points="655.84,-108.45 664.8,-102.8 654.27,-101.63 655.84,-108.45"/>
-    </g>
-    <g id="node9" class="node">
-      <title>:core:notifications</title>
-      <ellipse fill="none" stroke="black" cx="245.04" cy="-90" rx="81.29" ry="18"/>
-      <text text-anchor="middle" x="245.04" y="-85.8" font-family="Times,serif" font-size="14.00">:core:notifications</text>
-    </g>
-    <g id="edge8" class="edge">
-      <title>:core:data-&gt;:core:notifications</title>
-      <path fill="none" stroke="black" d="M380.63,-147.83C355.75,-137.4 320.59,-122.67 292.31,-110.81"/>
-      <polygon fill="black" stroke="black" points="293.82,-107.65 283.24,-107.01 291.11,-114.1 293.82,-107.65"/>
-    </g>
-    <g id="edge18" class="edge">
-      <title>:sync:work-&gt;:core:data</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M475.03,-216.76C464.39,-207.69 450.96,-196.22 439.24,-186.21"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="442.86,-184.7 432.98,-180.87 438.31,-190.03 442.86,-184.7"/>
-    </g>
-    <g id="edge17" class="edge">
-      <title>:sync:work-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M518.22,-217.53C557.69,-192.29 636.1,-142.13 681.45,-113.13"/>
-      <polygon fill="black" stroke="black" points="683.06,-116.25 689.6,-107.92 679.29,-110.36 683.06,-116.25"/>
-    </g>
-    <g id="node10" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="245.04" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="245.04" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge9" class="edge">
-      <title>:core:database-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M514.86,-77.69C506.26,-75.76 497.4,-73.8 489.04,-72 410.56,-55.13 390.31,-53.88 312.04,-36 307.76,-35.02 303.32,-33.97 298.88,-32.9"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="301.35,-29.9 290.8,-30.91 299.67,-36.7 301.35,-29.9"/>
-    </g>
-    <g id="edge12" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M361.1,-77.73C352.41,-75.82 343.47,-73.85 335.04,-72 273.42,-58.48 202.98,-43.12 153.86,-32.44"/>
-      <polygon fill="black" stroke="black" points="154.78,-29.05 144.26,-30.35 153.29,-35.89 154.78,-29.05"/>
-    </g>
-    <g id="edge11" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M377.03,-74.33C351.37,-63.57 316.34,-48.89 288.82,-37.35"/>
-      <polygon fill="black" stroke="black" points="290.27,-34.16 279.7,-33.52 287.57,-40.62 290.27,-34.16"/>
-    </g>
-    <g id="node11" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="412.04" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="412.04" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge10" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="black" d="M412.04,-71.7C412.04,-64.41 412.04,-55.73 412.04,-47.54"/>
-      <polygon fill="black" stroke="black" points="415.54,-47.62 412.04,-37.62 408.54,-47.62 415.54,-47.62"/>
-    </g>
-    <g id="edge13" class="edge">
-      <title>:core:network-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M83.76,-71.7C84.92,-64.32 86.3,-55.52 87.6,-47.25"/>
-      <polygon fill="black" stroke="black" points="91.03,-48.02 89.12,-37.6 84.11,-46.93 91.03,-48.02"/>
-    </g>
-    <g id="edge14" class="edge">
-      <title>:core:network-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M115.42,-74.33C140.55,-63.6 174.8,-48.98 201.78,-37.46"/>
-      <polygon fill="black" stroke="black" points="202.89,-40.8 210.72,-33.65 200.14,-34.36 202.89,-40.8"/>
-    </g>
-    <g id="edge16" class="edge">
-      <title>:core:notifications-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M210.71,-73.29C188.37,-63.07 159.07,-49.66 135.17,-38.73"/>
-      <polygon fill="black" stroke="black" points="136.88,-35.66 126.33,-34.69 133.97,-42.03 136.88,-35.66"/>
-    </g>
-    <g id="edge15" class="edge">
-      <title>:core:notifications-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M245.04,-71.7C245.04,-64.41 245.04,-55.73 245.04,-47.54"/>
-      <polygon fill="black" stroke="black" points="248.54,-47.62 245.04,-37.62 241.54,-47.62 248.54,-47.62"/>
-    </g>
-  </g>
 </svg>

--- a/docs/images/graphs/dep_graph_sync_work.svg
+++ b/docs/images/graphs/dep_graph_sync_work.svg
@@ -1,138 +1,109 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="813pt" height="260pt" viewBox="0.00 0.00 812.60 260.00">
-  <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 256)">
-    <title>G</title>
-    <polygon fill="white" stroke="none" points="-4,4 -4,-256 808.6,-256 808.6,4 -4,4"/>
-    <g id="node1" class="node">
-      <title>:sync:work</title>
-      <ellipse fill="none" stroke="black" cx="161.34" cy="-234" rx="53.95" ry="18"/>
-      <text text-anchor="middle" x="161.34" y="-229.8" font-family="Times,serif" font-size="14.00">:sync:work</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="1084" height="260pt" viewBox="0 0 812.6 260">
+    <g class="graph">
+        <path fill="#fff" d="M0 260V0h812.6v260z"/>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="161.34" cy="-234" fill="none" stroke="#000" rx="53.95" ry="18"/>
+            <text x="161.34" y="-229.8" font-family="Times,serif" font-size="14" text-anchor="middle">:sync:work</text>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="67.34" cy="-90" fill="none" stroke="#000" rx="67.34" ry="18"/>
+            <text x="67.34" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:analytics</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="m154.19 39.85-65.45 98.86"/>
+            <path d="m91.75 140.51-8.43 6.4 2.6-10.27z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="255.34" cy="-162" fill="none" stroke="#000" rx="49.1" ry="18"/>
+            <text x="255.34" y="-157.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:data</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M186.67 38.88c12.59 9.38 28.72 21.39 42.58 31.71"/>
+            <path fill="red" d="m230.06 66.83 5.93 8.78-10.11-3.16z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M225.73 107.51c-29.45 10.97-72.61 27.04-105.81 39.4"/>
+            <path d="m121.53 150.05-10.6.21 8.15-6.77z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="266.34" cy="-18" fill="none" stroke="#000" rx="66.81" ry="18"/>
+            <text x="266.34" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:common</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M228.51 108.42c-16 8.75-34.07 21.87-43.17 39.58-7.31 14.23-7.76 22.01 0 36 8.09 14.58 22.04 25.67 36.33 33.84"/>
+            <path d="m222.99 214.58 7.22 7.76-10.48-1.56z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="738.34" cy="-90" fill="none" stroke="#000" rx="66.26" ry="18"/>
+            <text x="738.34" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:database</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M306.37 99.66c76.16 7.87 231.05 25.23 360.97 48.34 5.15.92 10.48 1.95 15.82 3.04"/>
+            <path fill="red" d="m682.05 147.23 9.05 5.5-10.51 1.35z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="586.34" cy="-90" fill="none" stroke="#000" rx="67.87" ry="18"/>
+            <text x="586.34" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M301.62 103.67c50.44 10.37 137.29 28.35 211.72 44.33 4.88 1.05 9.92 2.14 14.99 3.24"/>
+            <path d="m528.92 147.79 9.02 5.56-10.52 1.28z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="255.34" cy="-90" fill="none" stroke="#000" rx="64.66" ry="18"/>
+            <text x="255.34" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:network</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M259.34 112.3v24.16"/>
+            <path d="m262.84 136.38-3.5 10-3.5-10z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="419.34" cy="-90" fill="none" stroke="#000" rx="81.29" ry="18"/>
+            <text x="419.34" y="-85.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:notifications</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M290.58 108.33c24.28 10.37 58.36 24.91 85.91 36.67"/>
+            <path d="m377.86 141.78 7.83 7.15-10.57-.71z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="419.34" cy="-18" fill="none" stroke="#000" rx="57.16" ry="18"/>
+            <text x="419.34" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:model</text>
+        </g>
+        <g stroke="red" stroke-width="2" class="edge">
+            <path fill="none" d="M693.16 178.31c-8.6 1.93-17.46 3.89-25.82 5.69-78.48 16.87-98.74 18.12-177 36-4.28.98-8.72 2.03-13.16 3.1"/>
+            <path fill="red" d="m479.65 226.1-10.55-1.01 8.87-5.79z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M539.4 178.27c-8.69 1.91-17.63 3.88-26.06 5.73-61.62 13.52-132.07 28.88-181.18 39.56"/>
+            <path d="m333.07 226.95-10.51-1.3 9.03-5.54z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M555.33 181.67c-25.67 10.76-60.69 25.44-88.21 36.98"/>
+            <path d="m468.57 221.84-10.58.64 7.87-7.1z"/>
+        </g>
+        <g class="node" transform="translate(4 256)">
+            <ellipse cx="586.34" cy="-18" fill="none" stroke="#000" rx="91.47" ry="18"/>
+            <text x="586.34" y="-13.8" font-family="Times,serif" font-size="14" text-anchor="middle">:core:datastore-proto</text>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M590.34 184.3v24.16"/>
+            <path d="m593.84 208.38-3.5 10-3.5-10z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M262.06 184.3c1.16 7.38 2.54 16.18 3.84 24.45"/>
+            <path d="m269.32 207.98-1.9 10.42-5.01-9.33z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M293.72 181.67c25.13 10.73 59.38 25.35 86.36 36.87"/>
+            <path d="m381.19 215.2 7.82 7.15-10.57-.71z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M389.01 182.71c-22.34 10.22-51.64 23.63-75.54 34.56"/>
+            <path d="m315.18 220.34-10.55.97 7.64-7.34z"/>
+        </g>
+        <g stroke="#000" class="edge">
+            <path fill="none" d="M423.34 184.3v24.16"/>
+            <path d="m426.84 208.38-3.5 10-3.5-10z"/>
+        </g>
     </g>
-    <g id="node2" class="node">
-      <title>:core:analytics</title>
-      <ellipse fill="none" stroke="black" cx="67.34" cy="-90" rx="67.34" ry="18"/>
-      <text text-anchor="middle" x="67.34" y="-85.8" font-family="Times,serif" font-size="14.00">:core:analytics</text>
-    </g>
-    <g id="edge1" class="edge">
-      <title>:sync:work-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M150.19,-216.15C134.01,-191.71 103.86,-146.17 84.74,-117.29"/>
-      <polygon fill="black" stroke="black" points="87.75,-115.49 79.32,-109.09 81.92,-119.36 87.75,-115.49"/>
-    </g>
-    <g id="node3" class="node">
-      <title>:core:data</title>
-      <ellipse fill="none" stroke="black" cx="255.34" cy="-162" rx="49.1" ry="18"/>
-      <text text-anchor="middle" x="255.34" y="-157.8" font-family="Times,serif" font-size="14.00">:core:data</text>
-    </g>
-    <g id="edge2" class="edge">
-      <title>:sync:work-&gt;:core:data</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M182.67,-217.12C195.26,-207.74 211.39,-195.73 225.25,-185.41"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="226.06,-189.17 231.99,-180.39 221.88,-183.55 226.06,-189.17"/>
-    </g>
-    <g id="edge7" class="edge">
-      <title>:core:data-&gt;:core:analytics</title>
-      <path fill="none" stroke="black" d="M221.73,-148.49C192.28,-137.52 149.12,-121.45 115.92,-109.09"/>
-      <polygon fill="black" stroke="black" points="117.53,-105.95 106.93,-105.74 115.08,-112.51 117.53,-105.95"/>
-    </g>
-    <g id="node4" class="node">
-      <title>:core:common</title>
-      <ellipse fill="none" stroke="black" cx="266.34" cy="-18" rx="66.81" ry="18"/>
-      <text text-anchor="middle" x="266.34" y="-13.8" font-family="Times,serif" font-size="14.00">:core:common</text>
-    </g>
-    <g id="edge3" class="edge">
-      <title>:core:data-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M224.51,-147.58C208.51,-138.83 190.44,-125.71 181.34,-108 174.03,-93.77 173.58,-85.99 181.34,-72 189.43,-57.42 203.38,-46.33 217.67,-38.16"/>
-      <polygon fill="black" stroke="black" points="218.99,-41.42 226.21,-33.66 215.73,-35.22 218.99,-41.42"/>
-    </g>
-    <g id="node5" class="node">
-      <title>:core:database</title>
-      <ellipse fill="none" stroke="black" cx="738.34" cy="-90" rx="66.26" ry="18"/>
-      <text text-anchor="middle" x="738.34" y="-85.8" font-family="Times,serif" font-size="14.00">:core:database</text>
-    </g>
-    <g id="edge4" class="edge">
-      <title>:core:data-&gt;:core:database</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M302.37,-156.34C378.53,-148.47 533.42,-131.11 663.34,-108 668.49,-107.08 673.82,-106.05 679.16,-104.96"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="678.05,-108.77 687.1,-103.27 676.59,-101.92 678.05,-108.77"/>
-    </g>
-    <g id="node6" class="node">
-      <title>:core:datastore</title>
-      <ellipse fill="none" stroke="black" cx="586.34" cy="-90" rx="67.87" ry="18"/>
-      <text text-anchor="middle" x="586.34" y="-85.8" font-family="Times,serif" font-size="14.00">:core:datastore</text>
-    </g>
-    <g id="edge5" class="edge">
-      <title>:core:data-&gt;:core:datastore</title>
-      <path fill="none" stroke="black" d="M297.62,-152.33C348.06,-141.96 434.91,-123.98 509.34,-108 514.22,-106.95 519.26,-105.86 524.33,-104.76"/>
-      <polygon fill="black" stroke="black" points="524.92,-108.21 533.94,-102.65 523.42,-101.37 524.92,-108.21"/>
-    </g>
-    <g id="node7" class="node">
-      <title>:core:network</title>
-      <ellipse fill="none" stroke="black" cx="255.34" cy="-90" rx="64.66" ry="18"/>
-      <text text-anchor="middle" x="255.34" y="-85.8" font-family="Times,serif" font-size="14.00">:core:network</text>
-    </g>
-    <g id="edge6" class="edge">
-      <title>:core:data-&gt;:core:network</title>
-      <path fill="none" stroke="black" d="M255.34,-143.7C255.34,-136.41 255.34,-127.73 255.34,-119.54"/>
-      <polygon fill="black" stroke="black" points="258.84,-119.62 255.34,-109.62 251.84,-119.62 258.84,-119.62"/>
-    </g>
-    <g id="node8" class="node">
-      <title>:core:notifications</title>
-      <ellipse fill="none" stroke="black" cx="419.34" cy="-90" rx="81.29" ry="18"/>
-      <text text-anchor="middle" x="419.34" y="-85.8" font-family="Times,serif" font-size="14.00">:core:notifications</text>
-    </g>
-    <g id="edge8" class="edge">
-      <title>:core:data-&gt;:core:notifications</title>
-      <path fill="none" stroke="black" d="M286.58,-147.67C310.86,-137.3 344.94,-122.76 372.49,-111"/>
-      <polygon fill="black" stroke="black" points="373.86,-114.22 381.69,-107.07 371.12,-107.78 373.86,-114.22"/>
-    </g>
-    <g id="node9" class="node">
-      <title>:core:model</title>
-      <ellipse fill="none" stroke="black" cx="419.34" cy="-18" rx="57.16" ry="18"/>
-      <text text-anchor="middle" x="419.34" y="-13.8" font-family="Times,serif" font-size="14.00">:core:model</text>
-    </g>
-    <g id="edge9" class="edge">
-      <title>:core:database-&gt;:core:model</title>
-      <path fill="none" stroke="red" stroke-width="2" d="M689.16,-77.69C680.56,-75.76 671.7,-73.8 663.34,-72 584.86,-55.13 564.6,-53.88 486.34,-36 482.06,-35.02 477.62,-33.97 473.18,-32.9"/>
-      <polygon fill="red" stroke="red" stroke-width="2" points="475.65,-29.9 465.1,-30.91 473.97,-36.7 475.65,-29.9"/>
-    </g>
-    <g id="edge12" class="edge">
-      <title>:core:datastore-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M535.4,-77.73C526.71,-75.82 517.77,-73.85 509.34,-72 447.72,-58.48 377.27,-43.12 328.16,-32.44"/>
-      <polygon fill="black" stroke="black" points="329.07,-29.05 318.56,-30.35 327.59,-35.89 329.07,-29.05"/>
-    </g>
-    <g id="edge11" class="edge">
-      <title>:core:datastore-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M551.33,-74.33C525.66,-63.57 490.64,-48.89 463.12,-37.35"/>
-      <polygon fill="black" stroke="black" points="464.57,-34.16 453.99,-33.52 461.86,-40.62 464.57,-34.16"/>
-    </g>
-    <g id="node10" class="node">
-      <title>:core:datastore-proto</title>
-      <ellipse fill="none" stroke="black" cx="586.34" cy="-18" rx="91.47" ry="18"/>
-      <text text-anchor="middle" x="586.34" y="-13.8" font-family="Times,serif" font-size="14.00">:core:datastore-proto</text>
-    </g>
-    <g id="edge10" class="edge">
-      <title>:core:datastore-&gt;:core:datastore-proto</title>
-      <path fill="none" stroke="black" d="M586.34,-71.7C586.34,-64.41 586.34,-55.73 586.34,-47.54"/>
-      <polygon fill="black" stroke="black" points="589.84,-47.62 586.34,-37.62 582.84,-47.62 589.84,-47.62"/>
-    </g>
-    <g id="edge13" class="edge">
-      <title>:core:network-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M258.06,-71.7C259.22,-64.32 260.6,-55.52 261.9,-47.25"/>
-      <polygon fill="black" stroke="black" points="265.32,-48.02 263.42,-37.6 258.41,-46.93 265.32,-48.02"/>
-    </g>
-    <g id="edge14" class="edge">
-      <title>:core:network-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M289.72,-74.33C314.85,-63.6 349.1,-48.98 376.08,-37.46"/>
-      <polygon fill="black" stroke="black" points="377.19,-40.8 385.01,-33.65 374.44,-34.36 377.19,-40.8"/>
-    </g>
-    <g id="edge16" class="edge">
-      <title>:core:notifications-&gt;:core:common</title>
-      <path fill="none" stroke="black" d="M385.01,-73.29C362.67,-63.07 333.37,-49.66 309.47,-38.73"/>
-      <polygon fill="black" stroke="black" points="311.18,-35.66 300.63,-34.69 308.27,-42.03 311.18,-35.66"/>
-    </g>
-    <g id="edge15" class="edge">
-      <title>:core:notifications-&gt;:core:model</title>
-      <path fill="none" stroke="black" d="M419.34,-71.7C419.34,-64.41 419.34,-55.73 419.34,-47.54"/>
-      <polygon fill="black" stroke="black" points="422.84,-47.62 419.34,-37.62 415.84,-47.62 422.84,-47.62"/>
-    </g>
-  </g>
 </svg>

--- a/generateModuleGraphs.sh
+++ b/generateModuleGraphs.sh
@@ -121,7 +121,7 @@ echo "$module_paths" | while read -r module_path; do
           -Pmodules.graph.output.gv="/tmp/${file_name}.gv" \
           -Pmodules.graph.of.module="${module_path}" </dev/null
 
-        # Convert to SVG using dot, then compress and cleanup output
+        # Convert to SVG using dot, and cleanup/compress using svgo
         dot -Tsvg "/tmp/${file_name}.gv" |
           svgo --multipass --pretty --output="docs/images/graphs/${file_name}.svg" -
         # Remove the temporary .gv file

--- a/generateModuleGraphs.sh
+++ b/generateModuleGraphs.sh
@@ -31,6 +31,14 @@ then
     exit 1
 fi
 
+# Check if the svgo command is available
+if ! command -v svgo &> /dev/null
+then
+    echo "The 'svgo' command is not found. This is required to cleanup and compress SVGs."
+    echo "Installation instructions available at https://github.com/svg/svgo."
+    exit 1
+fi
+
 # Check for a version of grep which supports Perl regex.
 # On MacOS the OS installed grep doesn't support Perl regex so check for the existence of the
 # GNU version instead which is prefixed with 'g' to distinguish it from the OS installed version.
@@ -114,10 +122,9 @@ echo "$module_paths" | while read -r module_path; do
           -Pmodules.graph.of.module="${module_path}" </dev/null
 
         # Convert to SVG using dot, remove unnecessary comments, and reformat
-        dot -Tsvg "/tmp/${file_name}.gv" |
-          sed 's/<!--/\x0<!--/g;s/-->/-->\x0/g' | grep -zv '^<!--' | tr -d '\0' |
-          xmllint --format - \
-          > "docs/images/graphs/${file_name}.svg"
+        dot -Tsvg "/tmp/${file_name}.gv" > "docs/images/graphs/${file_name}.svg"
+        # Compress and cleanup SVG file
+        svgo --multipass --pretty "docs/images/graphs/${file_name}.svg"
         # Remove the temporary .gv file
         rm "/tmp/${file_name}.gv"
     fi

--- a/generateModuleGraphs.sh
+++ b/generateModuleGraphs.sh
@@ -121,10 +121,9 @@ echo "$module_paths" | while read -r module_path; do
           -Pmodules.graph.output.gv="/tmp/${file_name}.gv" \
           -Pmodules.graph.of.module="${module_path}" </dev/null
 
-        # Convert to SVG using dot, remove unnecessary comments, and reformat
-        dot -Tsvg "/tmp/${file_name}.gv" > "docs/images/graphs/${file_name}.svg"
-        # Compress and cleanup SVG file
-        svgo --multipass --pretty "docs/images/graphs/${file_name}.svg"
+        # Convert to SVG using dot, then compress and cleanup output
+        dot -Tsvg "/tmp/${file_name}.gv" |
+          svgo --multipass --pretty --output="docs/images/graphs/${file_name}.svg" -
         # Remove the temporary .gv file
         rm "/tmp/${file_name}.gv"
     fi


### PR DESCRIPTION
Although this adds another requirement to execute this script, it will prevent OS-specific issues on `sed` and `grep` as described in #1503, and make sure anyone can generate the same SVG output files.

`--pretty` is kept for convenience but can be removed if needed.

Closes #1503