### PR TITLE
Change `set` to `=` operator in Kotlin DSL

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
@@ -16,10 +16,10 @@
 
 package com.google.samples.apps.nowinandroid
 
+import com.android.SdkConstants
 import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.gradle.BaseExtension
-import com.android.SdkConstants
 import com.google.common.truth.Truth.assertWithMessage
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
@@ -36,6 +36,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.configurationcache.extensions.capitalized
+import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.register
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.process.ExecOperations
@@ -117,23 +118,20 @@ fun Project.configureBadgingTasks(
         val generateBadgingTaskName = "generate${capitalizedVariantName}Badging"
         val generateBadging =
             tasks.register<GenerateBadgingTask>(generateBadgingTaskName) {
-                apk.set(
-                    variant.artifacts.get(SingleArtifact.APK_FROM_BUNDLE),
-                )
-                aapt2Executable.set(
-                    File(
-                        baseExtension.sdkDirectory,
-                        "${SdkConstants.FD_BUILD_TOOLS}/" +
-                            "${baseExtension.buildToolsVersion}/" +
-                            SdkConstants.FN_AAPT2,
-                    ),
+                apk = variant.artifacts.get(SingleArtifact.APK_FROM_BUNDLE)
+
+                aapt2Executable = File(
+                    baseExtension.sdkDirectory,
+                    "${SdkConstants.FD_BUILD_TOOLS}/" +
+                        "${baseExtension.buildToolsVersion}/" +
+                        SdkConstants.FN_AAPT2,
                 )
 
-                badging.set(
-                    project.layout.buildDirectory.file(
-                        "outputs/apk_from_bundle/${variant.name}/${variant.name}-badging.txt",
-                    ),
+
+                badging = project.layout.buildDirectory.file(
+                    "outputs/apk_from_bundle/${variant.name}/${variant.name}-badging.txt",
                 )
+
             }
 
         val updateBadgingTaskName = "update${capitalizedVariantName}Badging"
@@ -144,17 +142,14 @@ fun Project.configureBadgingTasks(
 
         val checkBadgingTaskName = "check${capitalizedVariantName}Badging"
         tasks.register<CheckBadgingTask>(checkBadgingTaskName) {
-            goldenBadging.set(
-                project.layout.projectDirectory.file("${variant.name}-badging.txt"),
-            )
-            generatedBadging.set(
-                generateBadging.get().badging,
-            )
-            this.updateBadgingTaskName.set(updateBadgingTaskName)
+            goldenBadging = project.layout.projectDirectory.file("${variant.name}-badging.txt")
 
-            output.set(
-                project.layout.buildDirectory.dir("intermediates/$checkBadgingTaskName"),
-            )
+            generatedBadging = generateBadging.get().badging
+
+            this.updateBadgingTaskName = updateBadgingTaskName
+
+            output = project.layout.buildDirectory.dir("intermediates/$checkBadgingTaskName")
+
         }
     }
 }

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Jacoco.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Jacoco.kt
@@ -24,6 +24,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
@@ -79,8 +80,8 @@ internal fun Project.configureJacoco(
                     }
                 )
                 reports {
-                    xml.required.set(true)
-                    html.required.set(true)
+                    xml.required = true
+                    html.required = true
                 }
 
                 // TODO: This is missing files in src/debug/, src/prod, src/demo, src/demoDebug...

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Jacoco.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Jacoco.kt
@@ -67,9 +67,13 @@ internal fun Project.configureJacoco(
         val myObjFactory = project.objects
         val buildDir = layout.buildDirectory.get().asFile
         val allJars: ListProperty<RegularFile> = myObjFactory.listProperty(RegularFile::class.java)
-        val allDirectories: ListProperty<Directory> = myObjFactory.listProperty(Directory::class.java)
+        val allDirectories: ListProperty<Directory> =
+            myObjFactory.listProperty(Directory::class.java)
         val reportTask =
-            tasks.register("create${variant.name.capitalize()}CombinedCoverageReport", JacocoReport::class) {
+            tasks.register(
+                "create${variant.name.capitalize()}CombinedCoverageReport",
+                JacocoReport::class,
+            ) {
 
                 classDirectories.setFrom(
                     allJars,
@@ -77,7 +81,7 @@ internal fun Project.configureJacoco(
                         dirs.map { dir ->
                             myObjFactory.fileTree().setDir(dir).exclude(coverageExclusions)
                         }
-                    }
+                    },
                 )
                 reports {
                     xml.required = true
@@ -85,15 +89,20 @@ internal fun Project.configureJacoco(
                 }
 
                 // TODO: This is missing files in src/debug/, src/prod, src/demo, src/demoDebug...
-                sourceDirectories.setFrom(files("$projectDir/src/main/java", "$projectDir/src/main/kotlin"))
+                sourceDirectories.setFrom(
+                    files(
+                        "$projectDir/src/main/java",
+                        "$projectDir/src/main/kotlin",
+                    ),
+                )
 
                 executionData.setFrom(
                     project.fileTree("$buildDir/outputs/unit_test_code_coverage/${variant.name}UnitTest")
                         .matching { include("**/*.exec") },
 
                     project.fileTree("$buildDir/outputs/code_coverage/${variant.name}AndroidTest")
-                        .matching { include("**/*.ec") }
-                    )
+                        .matching { include("**/*.ec") },
+                )
             }
 
 

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/PrintTestApks.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/PrintTestApks.kt
@@ -54,7 +54,7 @@ internal fun Project.configurePrintApksTask(extension: AndroidComponentsExtensio
             if (artifact != null && testSources != null) {
                 tasks.register(
                     "${variant.name}PrintTestApk",
-                    PrintApkLocationTask::class.java
+                    PrintApkLocationTask::class.java,
                 ) {
                     apkFolder = artifact
                     builtArtifactsLoader = loader

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/PrintTestApks.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/PrintTestApks.kt
@@ -33,6 +33,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.assign
 import org.gradle.work.DisableCachingByDefault
 import java.io.File
 
@@ -55,10 +56,10 @@ internal fun Project.configurePrintApksTask(extension: AndroidComponentsExtensio
                     "${variant.name}PrintTestApk",
                     PrintApkLocationTask::class.java
                 ) {
-                    apkFolder.set(artifact)
-                    builtArtifactsLoader.set(loader)
-                    variantName.set(variant.name)
-                    sources.set(testSources)
+                    apkFolder = artifact
+                    builtArtifactsLoader = loader
+                    variantName = variant.name
+                    sources = testSources
                 }
             }
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,7 +24,7 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
     repositories {
         google()
         mavenCentral()
@@ -63,4 +63,3 @@ include(":lint")
 include(":sync:work")
 include(":sync:sync-test")
 include(":ui-test-hilt-manifest")
-


### PR DESCRIPTION
**What I have done and why**

From this documentation https://docs.gradle.org/current/userguide/kotlin_dsl.html#kotdsl:assignment, kotlin DSL preferred assign lazily using `=` operator.

> Using the = operator is the preferred way to call set() in the Kotlin DSL.
