### PR TITLE
Explain why the plugins get listed in the root project build script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,13 @@ buildscript {
 
 }
 
-// Lists all plugins used throughout the project
+/*
+ * By listing all the plugins used throughout all subprojects in the root project build script, it
+ * ensures that the build script classpath remains the same for all projects. This avoids potential
+ * problems with mismatching versions of transitive plugin dependencies. A subproject that applies
+ * an unlisted plugin will have that plugin and its dependencies _appended_ to the classpath, not
+ * replacing pre-existing dependencies.
+ */
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false


### PR DESCRIPTION
It dispels a bit of the magic that happens during a build. See the patch for the thorough explanation.