### PR TITLE
Fix an uninstall app after instrumented tests problem

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,3 +42,7 @@ android.defaults.buildfeatures.shaders=false
 
 # Run Roborazzi screenshot tests with the local tests
 roborazzi.test.verify=true
+
+# Prevent uninstall app after instrumented tests
+# https://issuetracker.google.com/issues/295039976
+android.injected.androidTest.leaveApksInstalledAfterRun=true


### PR DESCRIPTION
**What I have done and why**

Fix #1530 

https://issuetracker.google.com/issues/295039976
Add `android.injected.androidTest.leaveApksInstalledAfterRun=true` in `gradle.properties`.
