### PR TITLE
Change display name each flavor on debug

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,6 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix = NiaBuildType.DEBUG.applicationIdSuffix
-            resValue("string", "app_name_display", "@string/app_name_debug")
         }
         release {
             isMinifyEnabled = true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,6 +43,7 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix = NiaBuildType.DEBUG.applicationIdSuffix
+            resValue("string", "app_name_display", "@string/app_name_debug")
         }
         release {
             isMinifyEnabled = true
@@ -55,6 +56,7 @@ android {
             signingConfig = signingConfigs.named("debug").get()
             // Ensure Baseline Profile is fresh for release builds.
             baselineProfile.automaticGenerationDuringBuild = true
+            resValue("string", "app_name_display", "@string/app_name")
         }
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
         android:allowBackup="true"
         android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="@string/app_name_display"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Nia.Splash">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,5 +16,6 @@
 -->
 <resources>
     <string name="app_name">Now in Android</string>
+    <string name="app_name_debug">Debug Now in Android</string>
     <string name="not_connected">⚠️ You aren’t connected to the internet</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
 -->
 <resources>
     <string name="app_name">Now in Android</string>
-    <string name="app_name_debug">Debug Now in Android</string>
+    <string name="app_name_demo">Demo Now in Android</string>
+    <string name="app_name_prod">Prod Now in Android</string>
     <string name="not_connected">⚠️ You aren’t connected to the internet</string>
 </resources>

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaFlavor.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaFlavor.kt
@@ -29,6 +29,7 @@ fun configureFlavors(
             NiaFlavor.values().forEach {
                 create(it.name) {
                     dimension = it.dimension.name
+                    resValue("string", "app_name_display", "@string/app_name_$it")
                     flavorConfigurationBlock(this, it)
                     if (this@apply is ApplicationExtension && this is ApplicationProductFlavor) {
                         if (it.applicationIdSuffix != null) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,6 @@ kotlin.code.style=official
 
 # Disable build features that are enabled by default,
 # https://developer.android.com/build/releases/gradle-plugin#default-changes
-android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 
 # Run Roborazzi screenshot tests with the local tests


### PR DESCRIPTION
**What I have done and why**

prodDebug and demoDebug is hardly distinguish each app on the screen.
I changed the app name based on the flavor on `debug`, except `release`.

| before | after |
|-------|------|
|![Screenshot_20240711_163737](https://github.com/android/nowinandroid/assets/48680511/ee1f45de-6ec8-470b-a8eb-cf75a0165a7f)|![Screenshot_20240711_191553](https://github.com/android/nowinandroid/assets/48680511/a2155943-f89f-451c-bead-4e6202c311db)|


Now, we can distinguish both at once glance on the screen.