### PR TITLE
Fix the scroll bar thumb jumping when at the end of the LazyStaggeredList with more than one lane and improve smothness of the scroll

### DIFF
--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/LazyScrollbarUtilities.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/LazyScrollbarUtilities.kt
@@ -33,7 +33,7 @@ import kotlin.math.abs
  * @return a [Float] in the range [firstItemPosition..nextItemPosition) where nextItemPosition
  * is the index of the consecutive item along the major axis.
  * */
-internal inline fun <LazyState : ScrollableState, LazyStateItem> LazyState.interpolateIndex(
+internal inline fun <LazyState : ScrollableState, LazyStateItem> LazyState.interpolateFirstItemIndex(
     visibleItems: List<LazyStateItem>,
     crossinline itemSize: LazyState.(LazyStateItem) -> Int,
     crossinline offset: LazyState.(LazyStateItem) -> Int,

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/ScrollbarExt.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/ScrollbarExt.kt
@@ -51,7 +51,7 @@ fun LazyListState.scrollbarState(
             if (visibleItemsInfo.isEmpty()) return@snapshotFlow null
 
             val firstIndex = min(
-                a = interpolateIndex(
+                a = interpolateFirstItemIndex(
                     visibleItems = visibleItemsInfo,
                     itemSize = { it.size },
                     offset = { it.offset },
@@ -114,7 +114,7 @@ fun LazyGridState.scrollbarState(
             if (visibleItemsInfo.isEmpty()) return@snapshotFlow null
 
             val firstIndex = min(
-                a = interpolateIndex(
+                a = interpolateFirstItemIndex(
                     visibleItems = when (layoutInfo.orientation) {
                         Orientation.Vertical -> layoutInfo.visibleItemsInfo.filter { it.row == 0 }
                         Orientation.Horizontal -> layoutInfo.visibleItemsInfo.filter { it.column == 0 }
@@ -191,7 +191,7 @@ fun LazyStaggeredGridState.scrollbarState(
             if (visibleItemsInfo.isEmpty()) return@snapshotFlow null
 
             val firstIndex = min(
-                a = interpolateIndex(
+                a = interpolateFirstItemIndex(
                     visibleItems = layoutInfo.visibleItemsInfo.filter { it.lane == 0 },
                     itemSize = { layoutInfo.orientation.valueOf(it.size) },
                     offset = { layoutInfo.orientation.valueOf(it.offset) },


### PR DESCRIPTION
**What I have done and why**
Bug fix: scroll bar thumb jumping when at the end of the LazyStaggeredList with more than one lane, issue described in: https://github.com/android/nowinandroid/issues/1526.

