### PR TITLE
Update DeviceConfigurationOverride.WindowInsets to match upstream implementation

### DIFF
--- a/app/src/testDemo/kotlin/com/google/samples/apps/nowinandroid/ui/DeviceConfigurationOverrideWindowInsets.kt
+++ b/app/src/testDemo/kotlin/com/google/samples/apps/nowinandroid/ui/DeviceConfigurationOverrideWindowInsets.kt
@@ -17,18 +17,17 @@
 package com.google.samples.apps.nowinandroid.ui
 
 import android.view.WindowInsets
-import android.widget.FrameLayout
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.AbstractComposeView
 import androidx.compose.ui.test.DeviceConfigurationOverride
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.children
 
 /**
- * A [DeviceConfigurationOverride] that allows overriding the [windowInsets] available
- * to the content under test.
+ * A [DeviceConfigurationOverride] that overrides the window insets for the contained content.
  */
 @Suppress("ktlint:standard:function-naming")
 fun DeviceConfigurationOverride.Companion.WindowInsets(
@@ -38,10 +37,17 @@ fun DeviceConfigurationOverride.Companion.WindowInsets(
     val currentWindowInsets by rememberUpdatedState(windowInsets)
     AndroidView(
         factory = { context ->
-            object : FrameLayout(context) {
+            object : AbstractComposeView(context) {
+                @Composable
+                override fun Content() {
+                    currentContentUnderTest()
+                }
+
                 override fun dispatchApplyWindowInsets(insets: WindowInsets): WindowInsets {
                     children.forEach {
-                        it.dispatchApplyWindowInsets(currentWindowInsets.toWindowInsets())
+                        it.dispatchApplyWindowInsets(
+                            WindowInsets(currentWindowInsets.toWindowInsets()),
+                        )
                     }
                     return WindowInsetsCompat.CONSUMED.toWindowInsets()!!
                 }
@@ -52,17 +58,10 @@ fun DeviceConfigurationOverride.Companion.WindowInsets(
                  */
                 @Deprecated("Deprecated in Java")
                 override fun requestFitSystemWindows() {
-                    dispatchApplyWindowInsets(currentWindowInsets.toWindowInsets()!!)
+                    dispatchApplyWindowInsets(WindowInsets(currentWindowInsets.toWindowInsets()!!))
                 }
-            }.apply {
-                addView(
-                    ComposeView(context).apply {
-                        setContent {
-                            currentContentUnderTest()
-                        }
-                    },
-                )
             }
         },
+        update = { with(currentWindowInsets) { it.requestApplyInsets() } },
     )
 }


### PR DESCRIPTION
Updates the local version of `DeviceConfigurationOverride.WindowInsets` to match the implementation of the one in upstream Compose merged in https://android-review.git.corp.google.com/c/platform/frameworks/support/+/3143004

This fixes behavior on devices running SDK 29 and below.