### PR TITLE
Remove ImageLoader from NiaApplication

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaApplication.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaApplication.kt
@@ -17,8 +17,6 @@
 package com.google.samples.apps.nowinandroid
 
 import android.app.Application
-import coil.ImageLoader
-import coil.ImageLoaderFactory
 import com.google.samples.apps.nowinandroid.sync.initializers.Sync
 import com.google.samples.apps.nowinandroid.util.ProfileVerifierLogger
 import dagger.hilt.android.HiltAndroidApp
@@ -28,9 +26,7 @@ import javax.inject.Inject
  * [Application] class for NiA
  */
 @HiltAndroidApp
-class NiaApplication : Application(), ImageLoaderFactory {
-    @Inject
-    lateinit var imageLoader: dagger.Lazy<ImageLoader>
+class NiaApplication : Application() {
 
     @Inject
     lateinit var profileVerifierLogger: ProfileVerifierLogger
@@ -41,6 +37,4 @@ class NiaApplication : Application(), ImageLoaderFactory {
         Sync.initialize(context = this)
         profileVerifierLogger()
     }
-
-    override fun newImageLoader(): ImageLoader = imageLoader.get()
 }


### PR DESCRIPTION
Removed ImageLoader from NiaApplication as it's not needed. 
The ImageLoader is provided to the rest of the app using dagger. 

This appears to make it into the app because of the example on the coil website which is how you can use the ImageLoader without a DI framework.

