### PR TITLE
Remove duplicate dependency

### DIFF
--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -27,7 +27,6 @@ android {
 dependencies {
     implementation(projects.core.data)
     implementation(projects.core.domain)
-    implementation(projects.core.ui)
 
     testImplementation(projects.core.testing)
 


### PR DESCRIPTION
**What I have done and why**

In the `:feature:search` module's `build.gradle.kts`, the `:core:ui` module was being implemented directly. However, this dependency is already included through the `AndroidFeatureConventionPlugin`.

I have removed this redundancy to streamline the build configuration.