### PR TITLE
Integrate compose compiler metrics and reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ Then copy the resulting baseline profile from the emulator to [`app/src/main/bas
 Run the following command to get and analyse compose compiler metrics:
 
 ```bash
-./gradlew assembleRelease -PenableComposeCompilerMetrics=true -PenableComposeCompilerReports=true
+./gradlew assembleRelease -PenableComposeCompilerReportsAndMetrics=true --rerun-tasks
 ```
 
-The reports files will be added to [build/compose-reports](build/compose-reports). The metrics files will also be 
-added to [build/compose-metrics](build/compose-metrics).
+The reports files will be added to ***build/module-name/compose-reports***. The metrics files will also be 
+added to ***build/module-name/compose-metrics***.
 
 For more information on Compose compiler metrics, see [this blog post](https://medium.com/androiddevelopers/jetpack-compose-stability-explained-79c10db270c8).
 

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidCompose.kt
@@ -18,7 +18,6 @@ package com.google.samples.apps.nowinandroid
 
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.Project
-import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
@@ -52,21 +51,14 @@ internal fun Project.configureAndroidCompose(
     }
 
     extensions.configure<ComposeCompilerGradlePluginExtension> {
-        fun Provider<String>.onlyIfTrue() = flatMap { provider { it.takeIf(String::toBoolean) } }
-        fun Provider<*>.relativeToRootProject(dir: String) = flatMap {
-            rootProject.layout.buildDirectory.dir(projectDir.toRelativeString(rootDir))
-        }.map { it.dir(dir) }
+        if (project.hasProperty("enableComposeCompilerReportsAndMetrics")) {
+            metricsDestination = relativeToRootProject("compose-metrics")
+            reportsDestination = relativeToRootProject("compose-reports")
+        }
 
-        project.providers.gradleProperty("enableComposeCompilerMetrics").onlyIfTrue()
-            .relativeToRootProject("compose-metrics")
-            .let(metricsDestination::set)
+        stabilityConfigurationFile =
+            rootProject.layout.projectDirectory.file("compose_compiler_config.conf")
 
-        project.providers.gradleProperty("enableComposeCompilerReports").onlyIfTrue()
-            .relativeToRootProject("compose-reports")
-            .let(reportsDestination::set)
-
-        stabilityConfigurationFile = rootProject.layout.projectDirectory.file("compose_compiler_config.conf")
-        
         enableStrongSkippingMode = true
     }
 }

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/ProjectExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/ProjectExtensions.kt
@@ -19,7 +19,16 @@ package com.google.samples.apps.nowinandroid
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.getByType
 
 val Project.libs
     get(): VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+/**
+ * Create new Directory by [dir] name in the root build directory.
+ */
+internal fun Project.relativeToRootProject(dir: String): Provider<Directory> =
+    rootProject.layout.buildDirectory.dir(projectDir.toRelativeString(rootDir))
+        .map { it.dir(dir) }


### PR DESCRIPTION
**What I have done and why**

From this blog https://chrisbanes.me/posts/composable-metrics/, and commonly we get reports and metrics both at the same time.

So, I'd integrated two manual Property into one custom Property.