### PR TITLE
change collectJob to backgroundScope

### DIFF
--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestTopicDao.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestTopicDao.kt
@@ -51,6 +51,7 @@ class TestTopicDao : TopicDao {
     override suspend fun upsertTopics(entities: List<TopicEntity>) {
         // Overwrite old values with new values
         entitiesStateFlow.update { oldValues -> (entities + oldValues).distinctBy(TopicEntity::id) }
+
     }
 
     override suspend fun deleteTopics(ids: List<String>) {

--- a/feature/bookmarks/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModelTest.kt
+++ b/feature/bookmarks/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModelTest.kt
@@ -64,7 +64,7 @@ class BookmarksViewModelTest {
 
     @Test
     fun oneBookmark_showsInFeed() = runTest {
-        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.feedUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.feedUiState.collect() }
 
         newsRepository.sendNewsResources(newsResourcesTestData)
         userDataRepository.setNewsResourceBookmarked(newsResourcesTestData[0].id, true)
@@ -72,12 +72,11 @@ class BookmarksViewModelTest {
         assertIs<Success>(item)
         assertEquals(item.feed.size, 1)
 
-        collectJob.cancel()
     }
 
     @Test
     fun oneBookmark_whenRemoving_removesFromFeed() = runTest {
-        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.feedUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.feedUiState.collect() }
         // Set the news resources to be used by this test
         newsRepository.sendNewsResources(newsResourcesTestData)
         // Start with the resource saved
@@ -89,6 +88,6 @@ class BookmarksViewModelTest {
         assertIs<Success>(item)
         assertEquals(item.feed.size, 0)
 
-        collectJob.cancel()
+
     }
 }

--- a/feature/foryou/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouViewModelTest.kt
+++ b/feature/foryou/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouViewModelTest.kt
@@ -98,9 +98,8 @@ class ForYouViewModelTest {
 
     @Test
     fun stateIsLoadingWhenFollowedTopicsAreLoading() = runTest {
-        val collectJob1 =
-            launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
-        val collectJob2 = launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
 
         topicsRepository.sendTopics(sampleTopics)
 
@@ -110,30 +109,27 @@ class ForYouViewModelTest {
         )
         assertEquals(NewsFeedUiState.Loading, viewModel.feedState.value)
 
-        collectJob1.cancel()
-        collectJob2.cancel()
     }
 
     @Test
     fun stateIsLoadingWhenAppIsSyncingWithNoInterests() = runTest {
         syncManager.setSyncing(true)
 
-        val collectJob =
-            launch(UnconfinedTestDispatcher()) { viewModel.isSyncing.collect() }
+
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.isSyncing.collect() }
 
         assertEquals(
             true,
             viewModel.isSyncing.value,
         )
 
-        collectJob.cancel()
     }
 
     @Test
     fun onboardingStateIsLoadingWhenTopicsAreLoading() = runTest {
-        val collectJob1 =
-            launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
-        val collectJob2 = launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
+
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
 
         userDataRepository.setFollowedTopicIds(emptySet())
 
@@ -143,15 +139,13 @@ class ForYouViewModelTest {
         )
         assertEquals(NewsFeedUiState.Success(emptyList()), viewModel.feedState.value)
 
-        collectJob1.cancel()
-        collectJob2.cancel()
     }
 
     @Test
     fun onboardingIsShownWhenNewsResourcesAreLoading() = runTest {
-        val collectJob1 =
-            launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
-        val collectJob2 = launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
+
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
 
         topicsRepository.sendTopics(sampleTopics)
         userDataRepository.setFollowedTopicIds(emptySet())
@@ -203,15 +197,13 @@ class ForYouViewModelTest {
             viewModel.feedState.value,
         )
 
-        collectJob1.cancel()
-        collectJob2.cancel()
     }
 
     @Test
     fun onboardingIsShownAfterLoadingEmptyFollowedTopics() = runTest {
-        val collectJob1 =
-            launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
-        val collectJob2 = launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
+
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
 
         topicsRepository.sendTopics(sampleTopics)
         userDataRepository.setFollowedTopicIds(emptySet())
@@ -264,15 +256,13 @@ class ForYouViewModelTest {
             viewModel.feedState.value,
         )
 
-        collectJob1.cancel()
-        collectJob2.cancel()
     }
 
     @Test
     fun onboardingIsNotShownAfterUserDismissesOnboarding() = runTest {
-        val collectJob1 =
-            launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
-        val collectJob2 = launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
+
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
 
         topicsRepository.sendTopics(sampleTopics)
 
@@ -300,15 +290,13 @@ class ForYouViewModelTest {
             viewModel.feedState.value,
         )
 
-        collectJob1.cancel()
-        collectJob2.cancel()
     }
 
     @Test
     fun topicSelectionUpdatesAfterSelectingTopic() = runTest {
-        val collectJob1 =
-            launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
-        val collectJob2 = launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
+
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
 
         topicsRepository.sendTopics(sampleTopics)
         userDataRepository.setFollowedTopicIds(emptySet())
@@ -353,15 +341,12 @@ class ForYouViewModelTest {
             viewModel.feedState.value,
         )
 
-        collectJob1.cancel()
-        collectJob2.cancel()
     }
 
     @Test
     fun topicSelectionUpdatesAfterUnselectingTopic() = runTest {
-        val collectJob1 =
-            launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
-        val collectJob2 = launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
 
         topicsRepository.sendTopics(sampleTopics)
         userDataRepository.setFollowedTopicIds(emptySet())
@@ -416,16 +401,13 @@ class ForYouViewModelTest {
             ),
             viewModel.feedState.value,
         )
-
-        collectJob1.cancel()
-        collectJob2.cancel()
     }
 
     @Test
     fun newsResourceSelectionUpdatesAfterLoadingFollowedTopics() = runTest {
-        val collectJob1 =
-            launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
-        val collectJob2 = launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
+        backgroundScope
+        launch(UnconfinedTestDispatcher()) { viewModel.onboardingUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.feedState.collect() }
 
         val followedTopicIds = setOf("1")
         val userData = emptyUserData.copy(
@@ -460,15 +442,11 @@ class ForYouViewModelTest {
             ),
             viewModel.feedState.value,
         )
-
-        collectJob1.cancel()
-        collectJob2.cancel()
     }
 
     @Test
     fun deepLinkedNewsResourceIsFetchedAndResetAfterViewing() = runTest {
-        val collectJob =
-            launch(UnconfinedTestDispatcher()) { viewModel.deepLinkedNewsResource.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.deepLinkedNewsResource.collect() }
 
         newsRepository.sendNewsResources(sampleNewsResources)
         userDataRepository.setUserData(emptyUserData)
@@ -503,8 +481,6 @@ class ForYouViewModelTest {
                 ),
             ),
         )
-
-        collectJob.cancel()
     }
 
     @Test

--- a/feature/interests/src/test/kotlin/com/google/samples/apps/nowinandroid/interests/InterestsViewModelTest.kt
+++ b/feature/interests/src/test/kotlin/com/google/samples/apps/nowinandroid/interests/InterestsViewModelTest.kt
@@ -68,17 +68,15 @@ class InterestsViewModelTest {
 
     @Test
     fun uiState_whenFollowedTopicsAreLoading_thenShowLoading() = runTest {
-        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
         userDataRepository.setFollowedTopicIds(emptySet())
         assertEquals(InterestsUiState.Loading, viewModel.uiState.value)
-
-        collectJob.cancel()
     }
 
     @Test
     fun uiState_whenFollowingNewTopic_thenShowUpdatedTopics() = runTest {
-        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
         val toggleTopicId = testOutputTopics[1].topic.id
         topicsRepository.sendTopics(testInputTopics.map { it.topic })
@@ -102,13 +100,11 @@ class InterestsViewModelTest {
             ),
             viewModel.uiState.value,
         )
-
-        collectJob.cancel()
     }
 
     @Test
     fun uiState_whenUnfollowingTopics_thenShowUpdatedTopics() = runTest {
-        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
         val toggleTopicId = testOutputTopics[1].topic.id
 
@@ -135,8 +131,6 @@ class InterestsViewModelTest {
             ),
             viewModel.uiState.value,
         )
-
-        collectJob.cancel()
     }
 }
 

--- a/feature/search/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchViewModelTest.kt
+++ b/feature/search/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchViewModelTest.kt
@@ -85,20 +85,16 @@ class SearchViewModelTest {
     fun stateIsEmptyQuery_withEmptySearchQuery() = runTest {
         searchContentsRepository.addNewsResources(newsResourcesTestData)
         searchContentsRepository.addTopics(topicsTestData)
-        val collectJob =
-            launch(UnconfinedTestDispatcher()) { viewModel.searchResultUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.searchResultUiState.collect() }
 
         viewModel.onSearchQueryChanged("")
 
         assertEquals(EmptyQuery, viewModel.searchResultUiState.value)
-
-        collectJob.cancel()
     }
 
     @Test
     fun emptyResultIsReturned_withNotMatchingQuery() = runTest {
-        val collectJob =
-            launch(UnconfinedTestDispatcher()) { viewModel.searchResultUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.searchResultUiState.collect() }
 
         viewModel.onSearchQueryChanged("XXX")
         searchContentsRepository.addNewsResources(newsResourcesTestData)
@@ -106,32 +102,28 @@ class SearchViewModelTest {
 
         val result = viewModel.searchResultUiState.value
         assertIs<SearchResultUiState.Success>(result)
-
-        collectJob.cancel()
     }
 
     @Test
     fun recentSearches_verifyUiStateIsSuccess() = runTest {
-        val collectJob =
-            launch(UnconfinedTestDispatcher()) { viewModel.recentSearchQueriesUiState.collect() }
+
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.recentSearchQueriesUiState.collect() }
         viewModel.onSearchTriggered("kotlin")
 
         val result = viewModel.recentSearchQueriesUiState.value
         assertIs<Success>(result)
 
-        collectJob.cancel()
     }
 
     @Test
     fun searchNotReady_withNoFtsTableEntity() = runTest {
-        val collectJob =
-            launch(UnconfinedTestDispatcher()) { viewModel.searchResultUiState.collect() }
+
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.searchResultUiState.collect() }
 
         viewModel.onSearchQueryChanged("")
 
         assertEquals(SearchNotReady, viewModel.searchResultUiState.value)
 
-        collectJob.cancel()
     }
 
     @Test

--- a/feature/settings/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/settings/SettingsViewModelTest.kt
@@ -52,8 +52,8 @@ class SettingsViewModelTest {
 
     @Test
     fun stateIsSuccessAfterUserDataLoaded() = runTest {
-        val collectJob =
-            launch(UnconfinedTestDispatcher()) { viewModel.settingsUiState.collect() }
+
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.settingsUiState.collect() }
 
         userDataRepository.setThemeBrand(ANDROID)
         userDataRepository.setDarkThemeConfig(DARK)
@@ -69,6 +69,5 @@ class SettingsViewModelTest {
             viewModel.settingsUiState.value,
         )
 
-        collectJob.cancel()
     }
 }

--- a/feature/topic/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModelTest.kt
@@ -73,7 +73,7 @@ class TopicViewModelTest {
 
     @Test
     fun uiStateTopic_whenSuccess_matchesTopicFromRepository() = runTest {
-        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.topicUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.topicUiState.collect() }
 
         topicsRepository.sendTopics(testInputTopics.map(FollowableTopic::topic))
         userDataRepository.setFollowedTopicIds(setOf(testInputTopics[1].topic.id))
@@ -85,8 +85,6 @@ class TopicViewModelTest {
         ).first()
 
         assertEquals(topicFromRepository, item.followableTopic.topic)
-
-        collectJob.cancel()
     }
 
     @Test
@@ -101,18 +99,16 @@ class TopicViewModelTest {
 
     @Test
     fun uiStateTopic_whenFollowedIdsSuccessAndTopicLoading_thenShowLoading() = runTest {
-        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.topicUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.topicUiState.collect() }
 
         userDataRepository.setFollowedTopicIds(setOf(testInputTopics[1].topic.id))
         assertEquals(TopicUiState.Loading, viewModel.topicUiState.value)
-
-        collectJob.cancel()
     }
 
     @Test
     fun uiStateTopic_whenFollowedIdsSuccessAndTopicSuccess_thenTopicSuccessAndNewsLoading() =
         runTest {
-            val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.topicUiState.collect() }
+            backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.topicUiState.collect() }
 
             topicsRepository.sendTopics(testInputTopics.map { it.topic })
             userDataRepository.setFollowedTopicIds(setOf(testInputTopics[1].topic.id))
@@ -122,13 +118,12 @@ class TopicViewModelTest {
             assertIs<TopicUiState.Success>(topicUiState)
             assertIs<NewsUiState.Loading>(newsUiState)
 
-            collectJob.cancel()
         }
 
     @Test
     fun uiStateTopic_whenFollowedIdsSuccessAndTopicSuccessAndNewsIsSuccess_thenAllSuccess() =
         runTest {
-            val collectJob = launch(UnconfinedTestDispatcher()) {
+            backgroundScope.launch(UnconfinedTestDispatcher()) {
                 combine(
                     viewModel.topicUiState,
                     viewModel.newsUiState,
@@ -143,13 +138,11 @@ class TopicViewModelTest {
 
             assertIs<TopicUiState.Success>(topicUiState)
             assertIs<NewsUiState.Success>(newsUiState)
-
-            collectJob.cancel()
         }
 
     @Test
     fun uiStateTopic_whenFollowingTopic_thenShowUpdatedTopic() = runTest {
-        val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.topicUiState.collect() }
+        backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.topicUiState.collect() }
 
         topicsRepository.sendTopics(testInputTopics.map { it.topic })
         // Set which topic IDs are followed, not including 0.
@@ -162,7 +155,6 @@ class TopicViewModelTest {
             viewModel.topicUiState.value,
         )
 
-        collectJob.cancel()
     }
 }
 


### PR DESCRIPTION
Hello, 
‌Based on the latest document available in developer.android, we can use backgroundScope to collect flows instead of making a job object and canceling it after the final assertion.
With that, we do not need to manually cancel the created job, and the cancellation of this coroutine is done automatically before the end of the test. The following links are about the example on the site of developer.android and kotllinlang:

https://developer.android.com/kotlin/flow/test

<img width="1728" alt="Screenshot 2024-09-02 at 8 04 01 PM" src="https://github.com/user-attachments/assets/4a82ab3f-074a-4e1f-a748-058b9ab23e8b">

https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/-test-scope/background-scope.html