### PR TITLE
Remove enableStrongSkippingMode.

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/AndroidCompose.kt
@@ -65,8 +65,7 @@ internal fun Project.configureAndroidCompose(
             .relativeToRootProject("compose-reports")
             .let(reportsDestination::set)
 
-        stabilityConfigurationFile = rootProject.layout.projectDirectory.file("compose_compiler_config.conf")
-        
-        enableStrongSkippingMode = true
+        stabilityConfigurationFile =
+            rootProject.layout.projectDirectory.file("compose_compiler_config.conf")
     }
 }


### PR DESCRIPTION
**What I have done and why**

Fix #1592 

Now enableStrongSkipping mode enable is default.
https://kotlinlang.org/docs/whatsnew2020.html#strong-skipping-mode-enabled-by-default