### PR TITLE
Fix duplicate composition trace markers

### DIFF
--- a/feature/foryou/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -82,7 +82,6 @@ import androidx.compose.ui.unit.max
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.tracing.trace
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus.Denied
 import com.google.accompanist.permissions.rememberPermissionState

--- a/feature/foryou/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -320,7 +320,7 @@ private fun TopicSelection(
     onboardingUiState: OnboardingUiState.Shown,
     onTopicCheckedChanged: (String, Boolean) -> Unit,
     modifier: Modifier = Modifier,
-) = trace("TopicSelection") {
+) {
     val lazyGridState = rememberLazyGridState()
     val topicSelectionTestTag = "forYou:topicSelection"
 
@@ -381,7 +381,7 @@ private fun SingleTopicButton(
     imageUrl: String,
     isSelected: Boolean,
     onClick: (String, Boolean) -> Unit,
-) = trace("SingleTopicButton") {
+) {
     Surface(
         modifier = Modifier
             .width(312.dp)


### PR DESCRIPTION
The composition trace markers are enabled by default, and we have corrected the issue of markers being displayed redundantly.

![img](https://github.com/user-attachments/assets/788d5b8f-7b01-4df2-b69b-22aa63963387)  

![image2](https://github.com/user-attachments/assets/e7d533f6-6f3f-4a99-a464-5579dafb46bb)

