### PR TITLE
Fix #1595 navigation to topic detail screen causes crash

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/interests2pane/InterestsListDetailScreen.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/interests2pane/InterestsListDetailScreen.kt
@@ -17,6 +17,7 @@
 package com.google.samples.apps.nowinandroid.ui.interests2pane
 
 import androidx.activity.compose.BackHandler
+import androidx.annotation.Keep
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
@@ -53,6 +54,8 @@ import java.util.UUID
 
 @Serializable internal object TopicPlaceholderRoute
 
+// TODO: Remove @Keep when https://issuetracker.google.com/353898971 is fixed
+@Keep
 @Serializable internal object DetailPaneNavHostRoute
 
 fun NavGraphBuilder.interestsListDetailScreen() {


### PR DESCRIPTION
Fixes #1595 by `@Keep`ing a navigation route which is only used as a type parameter and a class reference, and is therefore removed during minification. This would cause a crash when navigating to the topic detail screen.  