### PR TITLE
Replace Annotation to compiler args.

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
@@ -90,5 +90,19 @@ private inline fun <reified T : KotlinTopLevelExtension> Project.configureKotlin
             // Enable experimental coroutines APIs, including Flow
             "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
         )
+        freeCompilerArgs.add(
+            /**
+             * Remove this args after Phase 3.
+             * https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-consistent-copy-visibility/#deprecation-timeline
+             *
+             * Deprecation timeline
+             * Phase 3. (Supposedly Kotlin 2.2 or Kotlin 2.3).
+             * The default changes.
+             * Unless ExposedCopyVisibility is used, the generated 'copy' method has the same visibility as the primary constructor.
+             * The binary signature changes. The error on the declaration is no longer reported.
+             * '-Xconsistent-data-class-copy-visibility' compiler flag and ConsistentCopyVisibility annotation are now unnecessary.
+             */
+            "-Xconsistent-data-class-copy-visibility"
+        )
     }
 }

--- a/core/model/src/main/kotlin/com/google/samples/apps/nowinandroid/core/model/data/UserNewsResource.kt
+++ b/core/model/src/main/kotlin/com/google/samples/apps/nowinandroid/core/model/data/UserNewsResource.kt
@@ -22,7 +22,6 @@ import kotlinx.datetime.Instant
  * A [NewsResource] with additional user information such as whether the user is following the
  * news resource's topics and whether they have saved (bookmarked) this news resource.
  */
-@ConsistentCopyVisibility
 data class UserNewsResource internal constructor(
     val id: String,
     val title: String,


### PR DESCRIPTION
**What I have done and why**
Compiler args makes all data class as applied ConsistentCopyVisibility.
No need manual annotation.

https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-consistent-copy-visibility/#deprecation-timeline