### PR TITLE
Remove redundant versions from convention plugins

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -179,17 +179,17 @@ room = { id = "androidx.room", version.ref = "room" }
 secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secrets" }
 
 # Plugins defined by this project
-nowinandroid-android-application = { id = "nowinandroid.android.application", version = "unspecified" }
-nowinandroid-android-application-compose = { id = "nowinandroid.android.application.compose", version = "unspecified" }
-nowinandroid-android-application-firebase = { id = "nowinandroid.android.application.firebase", version = "unspecified" }
-nowinandroid-android-application-flavors = { id = "nowinandroid.android.application.flavors", version = "unspecified" }
-nowinandroid-android-application-jacoco = { id = "nowinandroid.android.application.jacoco", version = "unspecified" }
-nowinandroid-android-feature = { id = "nowinandroid.android.feature", version = "unspecified" }
-nowinandroid-android-library = { id = "nowinandroid.android.library", version = "unspecified" }
-nowinandroid-android-library-compose = { id = "nowinandroid.android.library.compose", version = "unspecified" }
-nowinandroid-android-library-jacoco = { id = "nowinandroid.android.library.jacoco", version = "unspecified" }
-nowinandroid-android-lint = { id = "nowinandroid.android.lint", version = "unspecified" }
-nowinandroid-android-room = { id = "nowinandroid.android.room", version = "unspecified" }
-nowinandroid-android-test = { id = "nowinandroid.android.test", version = "unspecified" }
-nowinandroid-hilt = { id = "nowinandroid.hilt", version = "unspecified" }
-nowinandroid-jvm-library = { id = "nowinandroid.jvm.library", version = "unspecified" }
+nowinandroid-android-application = { id = "nowinandroid.android.application" }
+nowinandroid-android-application-compose = { id = "nowinandroid.android.application.compose" }
+nowinandroid-android-application-firebase = { id = "nowinandroid.android.application.firebase" }
+nowinandroid-android-application-flavors = { id = "nowinandroid.android.application.flavors" }
+nowinandroid-android-application-jacoco = { id = "nowinandroid.android.application.jacoco" }
+nowinandroid-android-feature = { id = "nowinandroid.android.feature" }
+nowinandroid-android-library = { id = "nowinandroid.android.library" }
+nowinandroid-android-library-compose = { id = "nowinandroid.android.library.compose" }
+nowinandroid-android-library-jacoco = { id = "nowinandroid.android.library.jacoco" }
+nowinandroid-android-lint = { id = "nowinandroid.android.lint" }
+nowinandroid-android-room = { id = "nowinandroid.android.room" }
+nowinandroid-android-test = { id = "nowinandroid.android.test" }
+nowinandroid-hilt = { id = "nowinandroid.hilt" }
+nowinandroid-jvm-library = { id = "nowinandroid.jvm.library" }


### PR DESCRIPTION
**What I have done and why**

Since Gradle 8.8, we can now define plugins without versions in the version catalog: https://docs.gradle.org/8.8/release-notes.html

This is useful for local convention plugins as we don't need to define a version for our own plugin.

This PR removes the workaround versioning in the version catalog for these plugins.
