### PR TITLE
Fix Gradle setup action

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -44,8 +44,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          validate-wrappers: true
-          gradle-home-cache-cleanup: true
+          cache-cleanup: true
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          cache-cleanup: true
+          cache-cleanup: on-success
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-cleanup: on-success
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3

--- a/.github/workflows/NightlyBaselineProfiles.yaml
+++ b/.github/workflows/NightlyBaselineProfiles.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          cache-cleanup: true
+          cache-cleanup: on-success
 
       - name: Setup GMD
         run: ./gradlew :benchmarks:pixel6Api33Setup

--- a/.github/workflows/NightlyBaselineProfiles.yaml
+++ b/.github/workflows/NightlyBaselineProfiles.yaml
@@ -18,9 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
-
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
@@ -29,6 +26,11 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-cleanup: true
 
       - name: Setup GMD
         run: ./gradlew :benchmarks:pixel6Api33Setup

--- a/.github/workflows/NightlyBaselineProfiles.yaml
+++ b/.github/workflows/NightlyBaselineProfiles.yaml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-cleanup: on-success
 
       - name: Setup GMD
         run: ./gradlew :benchmarks:pixel6Api33Setup

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -34,8 +34,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          validate-wrappers: true
-          gradle-home-cache-cleanup: true
+          cache-cleanup: true
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          cache-cleanup: true
+          cache-cleanup: on-success
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-cleanup: on-success
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3


### PR DESCRIPTION
- NightlyBaselineProfiles only used the wrapper validation action, which has been deprecated, and [merged as default in the main setup action](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#gradle-wrapper-validation). (Introduced in #1173)
- Remove explicit `validate-wrappers`, as [it is implicitly set as true by default](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#gradle-wrapper-validation)
- [Replace the deprecated `gradle-home-cache-cleanup` superseded by `cache-cleanup`](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#configuring-cache-cleanup) (enabled by default)


Closes #1626 