### PR TITLE
Use jemalloc in CI

### DIFF
--- a/.github/actions/jemalloc-linux/action.yml
+++ b/.github/actions/jemalloc-linux/action.yml
@@ -1,0 +1,50 @@
+#file: noinspection YAMLSchemaValidation
+name: "jemalloc-linux"
+description: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Restore jemalloc"
+      id: cache-jemalloc
+      uses: actions/cache/restore@v3
+      with:
+        path: /tmp/libjemalloc.so.2
+        key: v2-${{ runner.os }}-jemalloc-5.3.0
+
+    - name: "Relocate jemalloc to expected directory"
+      if: steps.cache-jemalloc.outputs.cache-hit == 'true'
+      shell: bash
+      run: sudo mv /tmp/libjemalloc.so.2 /usr/local/lib/
+
+    - name: "Download jemalloc"
+      if: steps.cache-jemalloc.outputs.cache-hit != 'true'
+      shell: bash
+      run: curl -Ls https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 -o jemalloc-5.3.0.tar.bz2
+
+    - name: "Unzip jemalloc"
+      if: steps.cache-jemalloc.outputs.cache-hit != 'true'
+      shell: bash
+      run: tar xvf jemalloc-5.3.0.tar.bz2
+
+    - name: "Configure jemalloc"
+      if: steps.cache-jemalloc.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd jemalloc-5.3.0
+        ./configure
+        make
+        sudo make install
+
+    - name: "Configure LD_PRELOAD"
+      shell: bash
+      run: |
+        echo 'export LD_PRELOAD=/usr/local/lib/libjemalloc.so.2 app' >> $GITHUB_ENV
+        cp /usr/local/lib/libjemalloc.so.2 /tmp/
+
+    - name: "Save jemalloc"
+      uses: actions/cache/save@v3
+      if: steps.cache-jemalloc.outputs.cache-hit != 'true'
+      with:
+        path: /tmp/libjemalloc.so.2
+        key: v2-${{ runner.os }}-jemalloc-5.3.0

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -41,6 +41,9 @@ jobs:
           distribution: 'zulu'
           java-version: 17
 
+      - uses: ./.github/actions/jemalloc-linux
+        id: cache-jemalloc
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
@@ -198,6 +201,9 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
+
+      - uses: ./.github/actions/jemalloc-linux
+        id: cache-jemalloc
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
**What I have done and why**

In this PR I want to add [jemalloc](https://www.linkedin.com/blog/engineering/infrastructure/taming-memory-fragmentation-in-venice-with-jemalloc) to the GitHub CI as that should give roughly 10% memory savings by fixing native memory fragmentation. I did this through a custom action that caches jemalloc.

You can see in [Inaki's blog post about jemalloc for Gradle Android builds](https://dev.to/cdsap/resource-observability-case-study-jemalloc-in-android-builds-22og) that these significant savings are reproducible and worthwhile considering the very small change needed.
