### PR TITLE
Use invariant locale when capitalizing Gradle task names

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
@@ -108,7 +108,7 @@ abstract class CheckBadgingTask : DefaultTask() {
 }
 
 private fun String.capitalized() = replaceFirstChar {
-    if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+    if (it.isLowerCase()) it.titlecase() else it.toString()
 }
 
 fun Project.configureBadgingTasks(


### PR DESCRIPTION
### What I have done and why

When copying the badging code from this project, we noticed during code review that the `String.capitalized()` extension function uses the default locale. However, it is undesirable for the user's locale to be used when capitalizing (English) Gradle task names. It mostly works fine, but will e.g. capitalize `install` to `İnstall` ([dotted i](https://en.wikipedia.org/wiki/%C4%B0)) when `Locale.getDefault()` returns the Turkish locale.

This PR changes the code to use the invariant locale instead.

### History
Capitalization for badging task names was added in #1009. The code used an (internal) [extension function from Gradle](https://github.com/gradle/gradle/blob/d51dfd1a6ca7ee2d779de4988241733251e61f8d/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/configurationcache/extensions/CharSequenceExtensions.kt) that also contained this bug.

When the Gradle function was deprecated, the functionality was included in this repository via #1547.

The deprecated function in Gradle has since been [fixed](https://github.com/gradle/gradle/blob/31a34d0b4368081e2a4d784d51fe4287d67dff89/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/configurationcache/extensions/CharSequenceExtensions.kt) and is identical to the one in this PR.
