### PR TITLE
fix typo

### DIFF
--- a/compose_compiler_config.conf
+++ b/compose_compiler_config.conf
@@ -1,5 +1,5 @@
 // This file contains classes (with possible wildcards) that the Compose Compiler will treat as stable.
-// It allows us to define classes that our not part of our codebase without wrapping them in a stable class.
+// It allows us to define classes that are not part of our codebase without wrapping them in a stable class.
 // For more information, check https://developer.android.com/jetpack/compose/performance/stability/fix#configuration-file
 
 // We always use immutable classes for our data model, to avoid running the Compose compiler


### PR DESCRIPTION
This PR fixes a typo in `compose_compiler_config.conf`.