### PR TITLE
[Fix] Add missing unit test dependency for JVM modules

### DIFF
--- a/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
@@ -17,6 +17,8 @@
 import com.google.samples.apps.nowinandroid.configureKotlinJvm
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.kotlin
 
 class JvmLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -26,6 +28,9 @@ class JvmLibraryConventionPlugin : Plugin<Project> {
                 apply("nowinandroid.android.lint")
             }
             configureKotlinJvm()
+            dependencies {
+                add("testImplementation", kotlin("test"))
+            }
         }
     }
 }


### PR DESCRIPTION
`:core:common` module would not be able to run its unit test: `:core:common:test`

Related to:
- #1546