### PR TITLE
Re-enable configuration-cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ org.gradle.configureondemand=false
 org.gradle.caching=true
 
 # Enable configuration caching between builds.
-org.gradle.configuration-cache=false
+org.gradle.configuration-cache=true
 # This option is set because of https://github.com/google/play-services-plugins/issues/246
 # to generate the Configuration Cache regardless of incompatible tasks.
 # See https://github.com/android/nowinandroid/issues/1022 before using it.


### PR DESCRIPTION
Configuration-cache seems to have been disabled by mistake. 

Fixes #1668
