### PR TITLE
Reduce icon sizes

### DIFF
--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/InterestsItem.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/InterestsItem.kt
@@ -54,7 +54,7 @@ fun InterestsItem(
 ) {
     ListItem(
         leadingContent = {
-            InterestsIcon(topicImageUrl, iconModifier.size(64.dp))
+            InterestsIcon(topicImageUrl, iconModifier.size(48.dp))
         },
         headlineContent = {
             Text(text = name)

--- a/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
@@ -212,7 +212,7 @@ private fun TopicHeader(name: String, description: String, imageUrl: String) {
             contentDescription = null,
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
-                .size(216.dp)
+                .size(132.dp)
                 .padding(bottom = 12.dp),
         )
         Text(name, style = MaterialTheme.typography.displayMedium)


### PR DESCRIPTION
**What I have done and why**
The topic icons were, for some reason, extremely large compared to the rest of the content. This PR simply reduces the icon sizes on the topic list and detail screens to make more space for other content. 

| Before   |  After |
|---|---|
| ![image](https://github.com/user-attachments/assets/9a651660-642d-40ab-bac2-631e0102ef37) | ![image](https://github.com/user-attachments/assets/d0880fe8-3134-4770-851b-889fbe4b6a8c) |
| ![image](https://github.com/user-attachments/assets/584ea26a-1b21-48ac-8c91-a9cf0f3d2480) | ![image](https://github.com/user-attachments/assets/37427a1e-1814-45a8-90e4-c59eba42ede7) |



