### PR TITLE
currentTopLevelDestination is null momentarily , causing the TopAppBar to flicker while navigating  

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt
@@ -89,8 +89,11 @@ class NiaAppState(
 
     val currentTopLevelDestination: TopLevelDestination?
         @Composable get() {
-            return TopLevelDestination.entries.firstOrNull { topLevelDestination ->
-                currentDestination?.hasRoute(route = topLevelDestination.route) ?: false
+            val currentDestination = currentDestination
+            return remember(currentDestination) {
+                TopLevelDestination.entries.firstOrNull { topLevelDestination ->
+                    currentDestination?.hasRoute(route = topLevelDestination.route) ?: false
+                }
             }
         }
 


### PR DESCRIPTION

**Issue**
currentTopLevelDestination is null momentarily , causing the TopAppBar to flicker while navigating the top level destinations. 
In short the problem lies here

```
val currentTopLevelDestination: TopLevelDestination?
        @Composable get() {
            return TopLevelDestination.entries.firstOrNull { topLevelDestination ->
                Log.d("currentDestination","$currentDestination")
                currentDestination?.hasRoute(route = topLevelDestination.route) ?: false
            }
        }
```

The log statement above would confirm that while switching between the top level composables , the currentDestination is obtained as null at times , until it is not . 

I dont have the exact reasoning as to why that is. My hypothesis is that since there is no "gate" between the `currentDestination` composable and the `currentTopLevelDestination` , `currentTopLevelDestination` reacts to everything that occurs to `currentDestination` and perhaps `currentDestination` goes through a null while going from one destination to another.

**Solution**

I just gated the `currentTopLevelDestination` with a remember . 




[Before](https://github.com/user-attachments/assets/7ec6fed2-efde-4372-8c7e-e58b8865b26d)
[After](https://github.com/user-attachments/assets/f2c69ee5-f7b2-4728-ba66-456b5d16d8bb)

