### PR TITLE
Replace kotlin("test") to version catalog `kotlin.test`.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -123,7 +123,6 @@ dependencies {
     testDemoImplementation(libs.roborazzi)
     testDemoImplementation(projects.core.screenshotTesting)
 
-    androidTestImplementation(kotlin("test"))
     androidTestImplementation(projects.core.testing)
     androidTestImplementation(projects.core.dataTest)
     androidTestImplementation(projects.core.datastoreTest)
@@ -131,6 +130,7 @@ dependencies {
     androidTestImplementation(libs.androidx.navigation.testing)
     androidTestImplementation(libs.androidx.compose.ui.test)
     androidTestImplementation(libs.hilt.android.testing)
+    androidTestImplementation(libs.kotlin.test)
 
     baselineProfile(projects.benchmarks)
 }

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -53,8 +53,8 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 disableUnnecessaryAndroidTests(target)
             }
             dependencies {
-                add("androidTestImplementation", kotlin("test"))
-                add("testImplementation", kotlin("test"))
+                add("androidTestImplementation", libs.findLibrary("kotlin.test").get())
+                add("testImplementation", libs.findLibrary("kotlin.test").get())
 
                 add("implementation", libs.findLibrary("androidx.tracing.ktx").get())
             }

--- a/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
@@ -15,6 +15,7 @@
  */
 
 import com.google.samples.apps.nowinandroid.configureKotlinJvm
+import com.google.samples.apps.nowinandroid.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
@@ -29,7 +30,7 @@ class JvmLibraryConventionPlugin : Plugin<Project> {
             }
             configureKotlinJvm()
             dependencies {
-                add("testImplementation", kotlin("test"))
+                add("testImplementation", libs.findLibrary("kotlin.test").get())
             }
         }
     }

--- a/lint/build.gradle.kts
+++ b/lint/build.gradle.kts
@@ -39,7 +39,7 @@ kotlin {
 dependencies {
     compileOnly(libs.kotlin.stdlib)
     compileOnly(libs.lint.api)
+    testImplementation(libs.kotlin.test)
     testImplementation(libs.lint.checks)
     testImplementation(libs.lint.tests)
-    testImplementation(kotlin("test"))
 }


### PR DESCRIPTION
**What I have done and why**

Get `kotlin("test")` dependencies from version catalog, since #1560 managed by version catalog.
