### PR TITLE
Exception handling for when reading datastore.

### DIFF
--- a/core/datastore/src/main/kotlin/com/google/samples/apps/nowinandroid/core/datastore/NiaPreferencesDataSource.kt
+++ b/core/datastore/src/main/kotlin/com/google/samples/apps/nowinandroid/core/datastore/NiaPreferencesDataSource.kt
@@ -21,6 +21,7 @@ import androidx.datastore.core.DataStore
 import com.google.samples.apps.nowinandroid.core.model.data.DarkThemeConfig
 import com.google.samples.apps.nowinandroid.core.model.data.ThemeBrand
 import com.google.samples.apps.nowinandroid.core.model.data.UserData
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import java.io.IOException
@@ -30,6 +31,14 @@ class NiaPreferencesDataSource @Inject constructor(
     private val userPreferences: DataStore<UserPreferences>,
 ) {
     val userData = userPreferences.data
+        .catch { exception ->
+            if (exception is IOException) {
+                Log.e("NiaPreferences", "Error reading user preferences.", exception)
+                emit(UserPreferences.getDefaultInstance())
+            } else {
+                throw exception
+            }
+        }
         .map {
             UserData(
                 bookmarkedNewsResources = it.bookmarkedNewsResourceIdsMap.keys,


### PR DESCRIPTION
**What I have done and why**

Datastore file can be corrupted in cases, or simply invalid. So there needs to handle runtime Fatal exception like I found:

FATAL EXCEPTION: main
Process: com.google.samples.apps.nowinandroid.demo.debug, PID: 10565
androidx.datastore.core.CorruptionException: Cannot read proto.
				...

So exception handling is needed, and replaced with `UserPreferences.getDefaultInstance()` when there occurs such exception