### PR TITLE
Removing API 30 emulator while investigating flakiness

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -166,7 +166,7 @@ jobs:
     timeout-minutes: 55
     strategy:
       matrix:
-        api-level: [26, 30]
+        api-level: [26]
 
     steps:
       - name: Delete unnecessary tools 🔧


### PR DESCRIPTION
The API 30 emulator is always failing now. I'm removing it from our instrumented tests while we investigate the cause and possible solutions. 