### PR TITLE
Add missing `security-events: write` permission

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      security-events: write
 
     timeout-minutes: 60
 


### PR DESCRIPTION
Required by codeql-action: https://github.com/github/codeql-action/tree/main?tab=readme-ov-file#workflow-permissions

See: https://github.com/android/nowinandroid/pull/921#issuecomment-2539483552