### PR TITLE
Replace aapt2 executable with lazy property

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
@@ -39,8 +39,6 @@ import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.register
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.process.ExecOperations
-import java.io.File
-import java.util.Locale
 import javax.inject.Inject
 
 @CacheableTask
@@ -123,15 +121,17 @@ fun Project.configureBadgingTasks(
         val generateBadging =
             tasks.register<GenerateBadgingTask>(generateBadgingTaskName) {
                 apk = variant.artifacts.get(SingleArtifact.APK_FROM_BUNDLE)
-
-                aapt2Executable = File(
-                    baseExtension.sdkDirectory,
-                    "${SdkConstants.FD_BUILD_TOOLS}/" +
-                        "${baseExtension.buildToolsVersion}/" +
-                        SdkConstants.FN_AAPT2,
+                aapt2Executable.set(
+                    // TODO: Replace with `sdkComponents.aapt2` when it's available in AGP
+                    //       https://issuetracker.google.com/issues/376815836
+                    componentsExtension.sdkComponents.sdkDirectory.map { directory ->
+                        directory.file(
+                            "${SdkConstants.FD_BUILD_TOOLS}/" +
+                                "${baseExtension.buildToolsVersion}/" +
+                                SdkConstants.FN_AAPT2,
+                        )
+                    }
                 )
-
-
                 badging = project.layout.buildDirectory.file(
                     "outputs/apk_from_bundle/${variant.name}/${variant.name}-badging.txt",
                 )


### PR DESCRIPTION
This replaces the eager evaluation to determine the `aapt2Executable` location with a lazy one, which defers resolving the location until needed.

This fixes #1677