### PR TITLE
Remove useSupportLibrary

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,9 +36,6 @@ android {
 
         // Custom test runner to set up Hilt dependency graph
         testInstrumentationRunner = "com.google.samples.apps.nowinandroid.core.testing.NiaTestRunner"
-        vectorDrawables {
-            useSupportLibrary = true
-        }
     }
 
     buildTypes {


### PR DESCRIPTION
**What I have done and why**

`vectorDrawables.useSupportLibrary` is required for API levels below 21, but since this project's min API level is 21, it is no longer needed.
https://developer.android.com/develop/ui/views/graphics/vector-drawable-resources#vector-drawables-backward-solution