### PR TITLE
Renovate: enable automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,6 @@
   "extends": [
     "local>android/.github:renovate-config"
   ],
-  "automerge": false,
   "baseBranches": [
     "main"
   ]


### PR DESCRIPTION
Re-enable automerge so that minor version updates are merged automatically as long as CI passes. 