### PR TITLE
Check presence of sarif files before executing `codeql-action/upload-sarif`

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -151,7 +151,7 @@ jobs:
           path: '**/build/reports/lint-results-*.html'
 
       - name: Upload lint reports (SARIF)
-        if: always()
+        if: ${{ !cancelled() && hashFiles('**/*.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: './'


### PR DESCRIPTION
because the action behavior is to throw errors when no sarif files are available...

Closes #1759