### PR TITLE
Remove default (and deprecated) `gradle-setup` parameters

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -199,9 +199,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          validate-wrappers: true
-          gradle-home-cache-cleanup: true
 
       - name: Build projects and run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
- https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-gradle-home-cache-cleanup-input-parameter-has-been-replaced-by-cache-cleanup
- https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#gradle-wrapper-validation