### PR TITLE
Fix CI workflow OOM

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -52,7 +52,7 @@ jobs:
         run: yes | sdkmanager --licenses || true
 
       - name: Check build-logic
-        run: ./gradlew check -p build-logic
+        run: ./gradlew :build-logic:convention:check
 
       - name: Check spotless
         run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache

--- a/.github/workflows/NightlyBaselineProfiles.yaml
+++ b/.github/workflows/NightlyBaselineProfiles.yaml
@@ -44,7 +44,7 @@ jobs:
         run: yes | sdkmanager --licenses || true
 
       - name: Check build-logic
-        run: ./gradlew check -p build-logic
+        run: ./gradlew :build-logic:convention:check
 
       - name: Setup GMD
         run: ./gradlew :benchmarks:pixel6Api33Setup


### PR DESCRIPTION
Don't change the start directory with `-p :build-logic` which makes Gradle look for `build-logic/gradle.properties` file that does not exist. Therefore, the heap size was configured with default values (`-Xmx512m`) which is definitely not enough for our linting.

Introduced in this PR, where lint was added in the `:build-logic:convention` project
- #1737

Fixes #1769