### PR TITLE
Gradle Configuration Cache on CI

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -17,6 +17,8 @@
 org.gradle.daemon=false
 org.gradle.parallel=true
 org.gradle.workers.max=2
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
 
 kotlin.incremental=false
 

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
@@ -199,6 +201,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build projects and run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/NightlyBaselineProfiles.yaml
+++ b/.github/workflows/NightlyBaselineProfiles.yaml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3

--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -2,3 +2,5 @@
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,6 +39,7 @@ org.gradle.caching=true
 
 # Enable configuration caching between builds.
 org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
 # This option is set because of https://github.com/google/play-services-plugins/issues/246
 # to generate the Configuration Cache regardless of incompatible tasks.
 # See https://github.com/android/nowinandroid/issues/1022 before using it.


### PR DESCRIPTION
- https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#saving-configuration-cache-data
- https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:secrets

And enable parallel Configuration Cache:
- https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:usage:parallel

This needs a `GRADLE_ENCRYPTION_KEY` secret to be configured in the repository [settings/secrets/actions](https://github.com/android/nowinandroid/settings/secrets/actions), otherwise no configuration cache will be saved or restored.  
As explained in the docs, you can use this tool to generate a configuration-cache compatible key: `openssl rand -base64 16`.

This should help reduce the configuration phase for all the main worflow tasks in CI.