### PR TITLE
add android security lint dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -131,6 +131,8 @@ dependencies {
     androidTestImplementation(libs.kotlin.test)
 
     baselineProfile(projects.benchmarks)
+
+    lintChecks(libs.android.security.lint)
 }
 
 baselineProfile {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ room = "2.6.1"
 secrets = "2.0.1"
 truth = "1.4.4"
 turbine = "1.2.0"
+android-security-lint = "1.0.3"
 
 [bundles]
 androidx-compose-ui-test = ["androidx-compose-ui-test", "androidx-compose-ui-testManifest"]
@@ -149,6 +150,7 @@ room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
+android-security-lint = { group = "com.android.security.lint", name = "lint", version.ref = "android-security-lint" }
 
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
This PR adds android security lint check dependency to app module as described in #1680

Ran `./gradlew lint` to check results

<details>
<summary><strong>Before</strong></summary>

![Screenshot 2024-12-23 at 11 06 13 PM](https://github.com/user-attachments/assets/c09afc69-2798-4f2b-8721-80809085d35f)

</details>

<details>
<summary><strong>After</strong></summary>

![Screenshot 2024-12-23 at 11 02 18 PM](https://github.com/user-attachments/assets/2fcaeeb9-4244-435e-8353-a8340f973777)

</details>