### PR TITLE
Follow kotlin dsl without type-safe documentation on plugins

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -23,18 +23,17 @@ import com.google.samples.apps.nowinandroid.configureKotlinAndroid
 import com.google.samples.apps.nowinandroid.configurePrintApksTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
 
 class AndroidApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            with(pluginManager) {
-                apply("com.android.application")
-                apply("org.jetbrains.kotlin.android")
-                apply("nowinandroid.android.lint")
-                apply("com.dropbox.dependency-guard")
-            }
+            apply(plugin = "com.android.application")
+            apply(plugin = "org.jetbrains.kotlin.android")
+            apply(plugin = "nowinandroid.android.lint")
+            apply(plugin = "com.dropbox.dependency-guard")
 
             extensions.configure<ApplicationExtension> {
                 configureKotlinAndroid(this)
@@ -49,5 +48,4 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             }
         }
     }
-
 }

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationFirebaseConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationFirebaseConventionPlugin.kt
@@ -19,6 +19,7 @@ import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
 import com.google.samples.apps.nowinandroid.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.exclude
@@ -26,11 +27,9 @@ import org.gradle.kotlin.dsl.exclude
 class AndroidApplicationFirebaseConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            with(pluginManager) {
-                apply("com.google.gms.google-services")
-                apply("com.google.firebase.firebase-perf")
-                apply("com.google.firebase.crashlytics")
-            }
+            apply(plugin = "com.google.gms.google-services")
+            apply(plugin = "com.google.firebase.firebase-perf")
+            apply(plugin = "com.google.firebase.crashlytics")
 
             dependencies {
                 val bom = libs.findLibrary("firebase-bom").get()

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationJacocoConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationJacocoConventionPlugin.kt
@@ -19,12 +19,14 @@ import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.google.samples.apps.nowinandroid.configureJacoco
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.getByType
 
 class AndroidApplicationJacocoConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            pluginManager.apply("jacoco")
+            apply(plugin = "jacoco")
+
             val androidExtension = extensions.getByType<ApplicationExtension>()
 
             androidExtension.buildTypes.configureEach {

--- a/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
@@ -19,17 +19,17 @@ import com.google.samples.apps.nowinandroid.configureGradleManagedDevices
 import com.google.samples.apps.nowinandroid.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 
 class AndroidFeatureConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            pluginManager.apply {
-                apply("nowinandroid.android.library")
-                apply("nowinandroid.hilt")
-                apply("org.jetbrains.kotlin.plugin.serialization")
-            }
+            apply(plugin = "nowinandroid.android.library")
+            apply(plugin = "nowinandroid.hilt")
+            apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+
             extensions.configure<LibraryExtension> {
                 testOptions.animationsDisabled = true
                 configureGradleManagedDevices(this)
@@ -47,7 +47,9 @@ class AndroidFeatureConventionPlugin : Plugin<Project> {
                 "implementation"(libs.findLibrary("kotlinx.serialization.json").get())
 
                 "testImplementation"(libs.findLibrary("androidx.navigation.testing").get())
-                "androidTestImplementation"(libs.findLibrary("androidx.lifecycle.runtimeTesting").get())
+                "androidTestImplementation"(
+                    libs.findLibrary("androidx.lifecycle.runtimeTesting").get(),
+                )
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -24,17 +24,16 @@ import com.google.samples.apps.nowinandroid.disableUnnecessaryAndroidTests
 import com.google.samples.apps.nowinandroid.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 
 class AndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            with(pluginManager) {
-                apply("com.android.library")
-                apply("org.jetbrains.kotlin.android")
-                apply("nowinandroid.android.lint")
-            }
+            apply(plugin = "com.android.library")
+            apply(plugin = "org.jetbrains.kotlin.android")
+            apply(plugin = "nowinandroid.android.lint")
 
             extensions.configure<LibraryExtension> {
                 configureKotlinAndroid(this)
@@ -45,7 +44,9 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 configureGradleManagedDevices(this)
                 // The resource prefix is derived from the module name,
                 // so resources inside ":core:module1" must be prefixed with "core_module1_"
-                resourcePrefix = path.split("""\W""".toRegex()).drop(1).distinct().joinToString(separator = "_").lowercase() + "_"
+                resourcePrefix =
+                    path.split("""\W""".toRegex()).drop(1).distinct().joinToString(separator = "_")
+                        .lowercase() + "_"
             }
             extensions.configure<LibraryAndroidComponentsExtension> {
                 configurePrintApksTask(this)

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryJacocoConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryJacocoConventionPlugin.kt
@@ -15,17 +15,18 @@
  */
 
 import com.android.build.api.dsl.LibraryExtension
-import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.google.samples.apps.nowinandroid.configureJacoco
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.getByType
 
 class AndroidLibraryJacocoConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            pluginManager.apply("jacoco")
+            apply(plugin = "jacoco")
+
             val androidExtension = extensions.getByType<LibraryExtension>()
 
             androidExtension.buildTypes.configureEach {

--- a/build-logic/convention/src/main/kotlin/AndroidLintConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLintConventionPlugin.kt
@@ -19,6 +19,7 @@ import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.dsl.Lint
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 
 class AndroidLintConventionPlugin : Plugin<Project> {
@@ -32,7 +33,7 @@ class AndroidLintConventionPlugin : Plugin<Project> {
                     configure<LibraryExtension> { lint(Lint::configure) }
 
                 else -> {
-                    pluginManager.apply("com.android.lint")
+                    apply(plugin = "com.android.lint")
                     configure<Lint>(Lint::configure)
                 }
             }

--- a/build-logic/convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
@@ -19,6 +19,7 @@ import com.google.devtools.ksp.gradle.KspExtension
 import com.google.samples.apps.nowinandroid.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 
@@ -26,8 +27,8 @@ class AndroidRoomConventionPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         with(target) {
-            pluginManager.apply("androidx.room")
-            pluginManager.apply("com.google.devtools.ksp")
+            apply(plugin = "androidx.room")
+            apply(plugin = "com.google.devtools.ksp")
 
             extensions.configure<KspExtension> {
                 arg("room.generateKotlin", "true")

--- a/build-logic/convention/src/main/kotlin/AndroidTestConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidTestConventionPlugin.kt
@@ -19,15 +19,14 @@ import com.google.samples.apps.nowinandroid.configureGradleManagedDevices
 import com.google.samples.apps.nowinandroid.configureKotlinAndroid
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 
 class AndroidTestConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            with(pluginManager) {
-                apply("com.android.test")
-                apply("org.jetbrains.kotlin.android")
-            }
+            apply(plugin = "com.android.test")
+            apply(plugin = "org.jetbrains.kotlin.android")
 
             extensions.configure<TestExtension> {
                 configureKotlinAndroid(this)
@@ -36,5 +35,4 @@ class AndroidTestConventionPlugin : Plugin<Project> {
             }
         }
     }
-
 }

--- a/build-logic/convention/src/main/kotlin/HiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/HiltConventionPlugin.kt
@@ -18,12 +18,14 @@ import com.android.build.gradle.api.AndroidBasePlugin
 import com.google.samples.apps.nowinandroid.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.dependencies
 
 class HiltConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            pluginManager.apply("com.google.devtools.ksp")
+            apply(plugin = "com.google.devtools.ksp")
+
             dependencies {
                 "ksp"(libs.findLibrary("hilt.compiler").get())
             }
@@ -37,7 +39,7 @@ class HiltConventionPlugin : Plugin<Project> {
 
             /** Add support for Android modules, based on [AndroidBasePlugin] */
             pluginManager.withPlugin("com.android.base") {
-                pluginManager.apply("dagger.hilt.android.plugin")
+                apply(plugin = "dagger.hilt.android.plugin")
                 dependencies {
                     "implementation"(libs.findLibrary("hilt.android").get())
                 }

--- a/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
@@ -18,15 +18,15 @@ import com.google.samples.apps.nowinandroid.configureKotlinJvm
 import com.google.samples.apps.nowinandroid.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.dependencies
 
 class JvmLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            with(pluginManager) {
-                apply("org.jetbrains.kotlin.jvm")
-                apply("nowinandroid.android.lint")
-            }
+            apply(plugin = "org.jetbrains.kotlin.jvm")
+            apply(plugin = "nowinandroid.android.lint")
+
             configureKotlinJvm()
             dependencies {
                 "testImplementation"(libs.findLibrary("kotlin.test").get())


### PR DESCRIPTION
**What I have done and why**
Follow kotlin dsl without type-safe documentation on plugins
https://docs.gradle.org/current/userguide/kotlin_dsl.html#ex-configuring-plugins-without-type-safe-accessors

>apply(plugin = "java-library")