### PR TITLE
Update OfflineFirstTopicsRepositoryTest.kt

### DIFF
--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstTopicsRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstTopicsRepositoryTest.kt
@@ -67,7 +67,6 @@ class OfflineFirstTopicsRepositoryTest {
     @Test
     fun offlineFirstTopicsRepository_topics_stream_is_backed_by_topics_dao() =
         testScope.runTest {
-            // After sync, topicDao.getTopicEntities().first() and subject.getTopics().first()
             // will return non-empty lists. 
             subject.syncWith(synchronizer)
             

--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstTopicsRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstTopicsRepositoryTest.kt
@@ -67,7 +67,6 @@ class OfflineFirstTopicsRepositoryTest {
     @Test
     fun offlineFirstTopicsRepository_topics_stream_is_backed_by_topics_dao() =
         testScope.runTest {
-            // will return non-empty lists. 
             subject.syncWith(synchronizer)
             
             assertEquals(

--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstTopicsRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstTopicsRepositoryTest.kt
@@ -67,6 +67,10 @@ class OfflineFirstTopicsRepositoryTest {
     @Test
     fun offlineFirstTopicsRepository_topics_stream_is_backed_by_topics_dao() =
         testScope.runTest {
+            // After sync, topicDao.getTopicEntities().first() and subject.getTopics().first()
+            // will return non-empty lists. 
+            subject.syncWith(synchronizer)
+            
             assertEquals(
                 topicDao.getTopicEntities()
                     .first()

--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstTopicsRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstTopicsRepositoryTest.kt
@@ -68,7 +68,7 @@ class OfflineFirstTopicsRepositoryTest {
     fun offlineFirstTopicsRepository_topics_stream_is_backed_by_topics_dao() =
         testScope.runTest {
             subject.syncWith(synchronizer)
-            
+
             assertEquals(
                 topicDao.getTopicEntities()
                     .first()


### PR DESCRIPTION
Improve the unit test to perform meaningful comparisons instead of simply comparing two empty lists.

In the unit test function  `offlineFirstTopicsRepository_topics_stream_is_backed_by_topics_dao()`

Both `topicDao.getTopicEntities().first().map(TopicEntity::asExternalModel)` and `subject.getTopics().first()` return an empty list.  This is because  `subject.syncWith(synchronizer)` is not called beforehand. 

This unit test doesn't seem meaningful by just comparing two empty lists. 

This PR adds a  `subject.syncWith(synchronizer)` call before retrieving the topic entities, so that lists with actual elements can be compared, to prove that offlineFirstTopicsRepository.getTopics() is based by topicDao.getTopicEntities().