### PR TITLE
Update OfflineFirstNewsRepositoryTest.kt

### DIFF
--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
@@ -89,8 +89,6 @@ class OfflineFirstNewsRepositoryTest {
     @Test
     fun offlineFirstNewsRepository_news_resources_stream_is_backed_by_news_resource_dao() =
         testScope.runTest {
-            // After sync, newsResourceDao.getNewsResources().first() and 
-            // subject.getNewsResources().first() will return non-empty lists. 
             subject.syncWith(synchronizer)
             
             assertEquals(

--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
@@ -89,6 +89,10 @@ class OfflineFirstNewsRepositoryTest {
     @Test
     fun offlineFirstNewsRepository_news_resources_stream_is_backed_by_news_resource_dao() =
         testScope.runTest {
+            // After sync, newsResourceDao.getNewsResources().first() and 
+            // subject.getNewsResources().first() will return non-empty lists. 
+            subject.syncWith(synchronizer)
+            
             assertEquals(
                 newsResourceDao.getNewsResources()
                     .first()

--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepositoryTest.kt
@@ -90,7 +90,6 @@ class OfflineFirstNewsRepositoryTest {
     fun offlineFirstNewsRepository_news_resources_stream_is_backed_by_news_resource_dao() =
         testScope.runTest {
             subject.syncWith(synchronizer)
-            
             assertEquals(
                 newsResourceDao.getNewsResources()
                     .first()


### PR DESCRIPTION
Improve the unit test to perform meaningful comparisons instead of simply comparing two empty lists.

In the unit test function offlineFirstNewsRepository_news_resources_stream_is_backed_by_news_resource_dao()

Both newsResourceDao.getNewsResources().first() and subject.getNewsResources().first() return an empty list. This is because subject.syncWith(synchronizer) is not called beforehand. It doesn't seem meaningful by just comparing two empty lists.

This PR adds a subject.syncWith(synchronizer) call before retrieving the lists, similar to PR https://github.com/android/nowinandroid/pull/1798