### PR TITLE
Save state of start destination when navigating to route in nested graph

### DIFF
--- a/feature/interests/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/interests/navigation/InterestsNavigation.kt
+++ b/feature/interests/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/interests/navigation/InterestsNavigation.kt
@@ -17,6 +17,7 @@
 package com.google.samples.apps.nowinandroid.feature.interests.navigation
 
 import androidx.navigation.NavController
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavOptions
 import kotlinx.serialization.Serializable
 
@@ -29,5 +30,14 @@ fun NavController.navigateToInterests(
     initialTopicId: String? = null,
     navOptions: NavOptions? = null,
 ) {
-    navigate(route = InterestsRoute(initialTopicId), navOptions)
+    navigate(
+        route = InterestsRoute(initialTopicId),
+        navOptions = navOptions ?: androidx.navigation.navOptions {
+            // When navigating directly to TopicScreen route inside Interests nested graph, we need
+            // to save start destination state
+            popUpTo(this@navigateToInterests.graph.findStartDestination().id) {
+                saveState = true
+            }
+        },
+    )
 }


### PR DESCRIPTION
**What I have done and why**
Save state of start destination (Bookmarks) when navigating to route in Interests nested graph, so when user selects Bookmarks again, correct destination will be restored.

Closes #1779