### PR TITLE
add ConfirmHapticFeedback in IconButton

### DIFF
--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/IconButton.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/IconButton.kt
@@ -24,6 +24,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import com.google.samples.apps.nowinandroid.core.designsystem.icon.NiaIcons
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 
@@ -48,11 +50,15 @@ fun NiaIconToggleButton(
     icon: @Composable () -> Unit,
     checkedIcon: @Composable () -> Unit = icon,
 ) {
+    val haptics = LocalHapticFeedback.current
     // TODO: File bug
     // Can't use regular IconToggleButton as it doesn't include a shape (appears square)
     FilledIconToggleButton(
         checked = checked,
-        onCheckedChange = onCheckedChange,
+        onCheckedChange = { isChecked ->
+            onCheckedChange(isChecked)
+            if (isChecked) haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+        },
         modifier = modifier,
         enabled = enabled,
         colors = IconButtonDefaults.iconToggleButtonColors(


### PR DESCRIPTION
**What I have done and why**

I thought it would be better to have haptics feedback to make it more obvious that the button was tapped, so I added haptics feedback to the commonly used IconButton

**ref**
[Android Developers - Compose UI - 1.8.0-alpha06](https://developer.android.com/jetpack/androidx/releases/compose-ui?_gl=1*qirkrx*_up*MQ..*_ga*MTEzNTM3NDg3Ni4xNzM2NzQxNTEw*_ga_6HH9YJMN9M*MTczNjc0MTUwOS4xLjAuMTczNjc0MTUwOS4wLjAuNzk1MTkyMDYx#1.8.0-alpha06)
> LocalHapticFeedback now provides a default HapticFeedback implementation when the Vibrator API indicates that haptics are supported. The following have been added to the HapticFeedbackType - Confirm, ContextClick, GestureEnd, GestureThresholdActivate, Reject, SegmentFrequentTick, SegmentTick, ToggleOn, ToggleOff, VirtualKey. Wear Compose long-clickable components such as Button, IconButton, TextButton, and Card now perform the LONG_PRESS haptic when a long-click handler has been supplied. ([I5083d](https://android-review.googlesource.com/#/q/I5083db2ce3619189c0a3793de9f535d996029c75))

[Android Developers - HapticFeedbackType](https://developer.android.com/reference/kotlin/androidx/compose/ui/hapticfeedback/HapticFeedbackType)
> `Confirm`
> A haptic effect to signal the confirmation or successful completion of a user interaction..

[Android Developers - Tap and press # long-press-show ](https://developer.android.com/develop/ui/compose/touch-input/pointer-input/tap-and-press#long-press-show)




**What I have tried**
I thought that `HapticFeedbackType` had `ToggleOn` and `ToggleOff`, which seemed to be better, but on my device Pixel 6, I didn't get any haptic feedback.
So I thought `Confirm` was appropriate.

```kotlin
onCheckedChange(isChecked)
    haptics.performHapticFeedback(
        if (isChecked) HapticFeedbackType.ToggleOn else HapticFeedbackType.ToggleOff
    )
},
```

