### PR TITLE
refactor: use object theme to optimize sub system management

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -68,7 +68,7 @@ import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaNavig
 import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaTopAppBar
 import com.google.samples.apps.nowinandroid.core.designsystem.icon.NiaIcons
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.GradientColors
-import com.google.samples.apps.nowinandroid.core.designsystem.theme.LocalGradientColors
+import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import com.google.samples.apps.nowinandroid.feature.settings.SettingsDialog
 import com.google.samples.apps.nowinandroid.navigation.NiaNavHost
 import com.google.samples.apps.nowinandroid.navigation.TopLevelDestination
@@ -88,7 +88,7 @@ fun NiaApp(
     NiaBackground(modifier = modifier) {
         NiaGradientBackground(
             gradientColors = if (shouldShowGradientBackground) {
-                LocalGradientColors.current
+                NiaTheme.gradientColors
             } else {
                 GradientColors()
             },

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/Background.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/Background.kt
@@ -51,8 +51,8 @@ fun NiaBackground(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    val color = NiaTheme.backgroundTheme.color
-    val tonalElevation = NiaTheme.backgroundTheme.tonalElevation
+    val color = NiaTheme.niaBackground.color
+    val tonalElevation = NiaTheme.niaBackground.tonalElevation
     Surface(
         color = if (color == Color.Unspecified) Color.Transparent else color,
         tonalElevation = if (tonalElevation == Dp.Unspecified) 0.dp else tonalElevation,

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/Background.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/Background.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.GradientColors
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.LocalBackgroundTheme
-import com.google.samples.apps.nowinandroid.core.designsystem.theme.LocalGradientColors
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import kotlin.math.tan
 
@@ -52,8 +51,8 @@ fun NiaBackground(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    val color = LocalBackgroundTheme.current.color
-    val tonalElevation = LocalBackgroundTheme.current.tonalElevation
+    val color = NiaTheme.backgroundTheme.color
+    val tonalElevation = NiaTheme.backgroundTheme.tonalElevation
     Surface(
         color = if (color == Color.Unspecified) Color.Transparent else color,
         tonalElevation = if (tonalElevation == Dp.Unspecified) 0.dp else tonalElevation,
@@ -76,7 +75,7 @@ fun NiaBackground(
 @Composable
 fun NiaGradientBackground(
     modifier: Modifier = Modifier,
-    gradientColors: GradientColors = LocalGradientColors.current,
+    gradientColors: GradientColors = NiaTheme.gradientColors,
     content: @Composable () -> Unit,
 ) {
     val currentTopColor by rememberUpdatedState(gradientColors.top)

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/theme/Background.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/theme/Background.kt
@@ -33,4 +33,4 @@ data class BackgroundTheme(
 /**
  * A composition local for [BackgroundTheme].
  */
-val LocalBackgroundTheme = staticCompositionLocalOf { BackgroundTheme() }
+internal val LocalBackgroundTheme = staticCompositionLocalOf { BackgroundTheme() }

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/theme/Gradient.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/theme/Gradient.kt
@@ -37,4 +37,4 @@ data class GradientColors(
 /**
  * A composition local for [GradientColors].
  */
-val LocalGradientColors = staticCompositionLocalOf { GradientColors() }
+internal val LocalGradientColors = staticCompositionLocalOf { GradientColors() }

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/theme/Theme.kt
@@ -260,7 +260,7 @@ object NiaTheme {
         @ReadOnlyComposable
         get() = LocalGradientColors.current
 
-    val backgroundTheme: BackgroundTheme
+    val niaBackground: BackgroundTheme
         @Composable
         @ReadOnlyComposable
         get() = LocalBackgroundTheme.current

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/theme/Theme.kt
@@ -20,7 +20,9 @@ import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Typography
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
@@ -28,6 +30,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -246,5 +249,34 @@ fun NiaTheme(
     }
 }
 
+
 @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.S)
 fun supportsDynamicTheming() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
+object NiaTheme {
+
+    val gradientColors: GradientColors
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalGradientColors.current
+
+    val backgroundTheme: BackgroundTheme
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalBackgroundTheme.current
+
+    val tintTheme: TintTheme
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalTintTheme.current
+
+    val colorScheme: ColorScheme
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.colorScheme
+
+    val typography: Typography
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.typography
+}

--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/theme/Tint.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/theme/Tint.kt
@@ -31,4 +31,4 @@ data class TintTheme(
 /**
  * A composition local for [TintTheme].
  */
-val LocalTintTheme = staticCompositionLocalOf { TintTheme() }
+internal val LocalTintTheme = staticCompositionLocalOf { TintTheme() }

--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridScope
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
@@ -61,7 +60,7 @@ fun LazyStaggeredGridScope.newsFeed(
             ) { userNewsResource ->
                 val context = LocalContext.current
                 val analyticsHelper = LocalAnalyticsHelper.current
-                val backgroundColor = MaterialTheme.colorScheme.background.toArgb()
+                val backgroundColor = NiaTheme.colorScheme.background.toArgb()
 
                 NewsResourceCardExpanded(
                     userNewsResource = userNewsResource,

--- a/feature/bookmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreen.kt
+++ b/feature/bookmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksScreen.kt
@@ -64,7 +64,6 @@ import com.google.samples.apps.nowinandroid.core.designsystem.component.NiaLoadi
 import com.google.samples.apps.nowinandroid.core.designsystem.component.scrollbar.DraggableScrollbar
 import com.google.samples.apps.nowinandroid.core.designsystem.component.scrollbar.rememberDraggableScroller
 import com.google.samples.apps.nowinandroid.core.designsystem.component.scrollbar.scrollbarState
-import com.google.samples.apps.nowinandroid.core.designsystem.theme.LocalTintTheme
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import com.google.samples.apps.nowinandroid.core.model.data.UserNewsResource
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState
@@ -225,7 +224,7 @@ private fun EmptyState(modifier: Modifier = Modifier) {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        val iconTint = LocalTintTheme.current.iconTint
+        val iconTint = NiaTheme.tintTheme.iconTint
         Image(
             modifier = Modifier.fillMaxWidth(),
             painter = painterResource(id = R.drawable.feature_bookmarks_img_empty_bookmarks),


### PR DESCRIPTION
Using object to encapsulate the theme subsystem

**DO NOT CREATE A PULL REQUEST WITHOUT READING THESE INSTRUCTIONS**

## Instructions
No more material themes in apps, this avoids importing different styles so that the theme is always presented as we expect it to be.
colors：NiaTheme.colorScheme.background
custom background：NiaTheme.niaBackground.background
gradient: NiaTheme.gradientColors
**If this is your first pull request**

- [Sign the contributors license agreement](https://cla.developers.google.com/)

**Ensure tests pass and code is formatted correctly**

- Run local tests on the `DemoDebug` variant by running `./gradlew testDemoDebug`
- Fix code formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`

**Add a description**

Using object to manage Theme's subsystems makes it easier to use them instead of using them directly inside the repo, which violates encapsulation.


**NOW DELETE THIS LINE AND EVERYTHING ABOVE IT**

**What I have done and why**

use NiaTheme instead of MaterialTheme  
use properties instead of directly using sub systems

- val backgroundColor = NiaTheme.colorScheme.background.toArgb()  
- val color = NiaTheme.niaBackground.color
- val tonalElevation = NiaTheme.niaBackground.tonalElevation

