### PR TITLE
Publishing GHA builds to scans.gradle.com

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -39,6 +39,9 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
 
       - name: Check build-logic
         run: ./gradlew :build-logic:convention:check
@@ -190,6 +193,9 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
 
       - name: Build projects and run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/NightlyBaselineProfiles.yaml
+++ b/.github/workflows/NightlyBaselineProfiles.yaml
@@ -39,6 +39,9 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -36,6 +36,9 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3


### PR DESCRIPTION
The project is using the GitHub Action setup-gradle and publishing a job summary at the end of the build without publishing build scans:
![Screenshot 2025-01-14 at 2 43 03 PM](https://github.com/user-attachments/assets/8a3b8e8c-b40b-4f77-865a-971979a692b1)
Enabling build scans could provide valuable insights into the CI builds(debugging configuration cache issues, performance, dependency resolution...). This PR enables the publishing of build scans on CI to [scans.gradle.com](https://scans.gradle.com/). The summary output will be:
![Screenshot 2025-01-14 at 2 34 25 PM](https://github.com/user-attachments/assets/542ce098-1f0b-4647-a0b9-02b1a501337a)

Example summary generating build scans:
https://github.com/cdsap/nowinandroid/actions/runs/12776910544
Build scan generated: https://scans.gradle.com/s/dlawyfupec5aa

Issue #1810 