### PR TITLE
Remove `@Keep` from `DetailPaneNavHostRoute`

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/interests2pane/InterestsListDetailScreen.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/interests2pane/InterestsListDetailScreen.kt
@@ -17,7 +17,6 @@
 package com.google.samples.apps.nowinandroid.ui.interests2pane
 
 import androidx.activity.compose.BackHandler
-import androidx.annotation.Keep
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
@@ -54,8 +53,6 @@ import java.util.UUID
 
 @Serializable internal object TopicPlaceholderRoute
 
-// TODO: Remove @Keep when https://issuetracker.google.com/353898971 is fixed
-@Keep
 @Serializable internal object DetailPaneNavHostRoute
 
 fun NavGraphBuilder.interestsListDetailScreen() {


### PR DESCRIPTION
**What I have done and why**

This [issue](https://issuetracker.google.com/issues/353898971) was [fixed](https://github.com/Kotlin/kotlinx.serialization/pull/2865) in `kotlinx-serialization 1.8.0`.


