### PR TITLE
Enable daemon and change number of workers 2 to 4 on CI gradle property

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-org.gradle.daemon=false
+org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.workers.max=2
 org.gradle.configuration-cache=true

--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -16,7 +16,7 @@
 
 org.gradle.daemon=true
 org.gradle.parallel=true
-org.gradle.workers.max=2
+org.gradle.workers.max=4
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 


### PR DESCRIPTION
What I have done and why
Enable daemon on CI.
Change number of workers from 2 to 4.

It is as though can use daemon on CI.
https://github.com/gradle/gradle-build-action/issues/113

Github runners have four cores.
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories