### PR TITLE
[Clean-up] Add clean-up for SearchViewModel.

### DIFF
--- a/feature/search/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/SearchViewModel.kt
@@ -43,7 +43,7 @@ import javax.inject.Inject
 class SearchViewModel @Inject constructor(
     getSearchContentsUseCase: GetSearchContentsUseCase,
     recentSearchQueriesUseCase: GetRecentSearchQueriesUseCase,
-    private val searchContentsRepository: SearchContentsRepository,
+    searchContentsRepository: SearchContentsRepository,
     private val recentSearchRepository: RecentSearchRepository,
     private val userDataRepository: UserDataRepository,
     private val savedStateHandle: SavedStateHandle,


### PR DESCRIPTION
**What I have done and why**

Remove `private val` modifier from `searchContentsRepository ` variable inside `SearchViewModel`
