### PR TITLE
NavHost replaced with if statement

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/interests2pane/InterestsListDetailScreen.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/interests2pane/InterestsListDetailScreen.kt
@@ -17,46 +17,24 @@
 package com.google.samples.apps.nowinandroid.ui.interests2pane
 
 import androidx.activity.compose.BackHandler
-import androidx.annotation.Keep
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
-import androidx.compose.material3.adaptive.WindowAdaptiveInfo
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.layout.AnimatedPane
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
 import androidx.compose.material3.adaptive.layout.PaneAdaptedValue
 import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldDestinationItem
-import androidx.compose.material3.adaptive.layout.calculatePaneScaffoldDirective
 import androidx.compose.material3.adaptive.navigation.ThreePaneScaffoldNavigator
 import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.Saver
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
-import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
 import com.google.samples.apps.nowinandroid.feature.interests.InterestsRoute
 import com.google.samples.apps.nowinandroid.feature.interests.navigation.InterestsRoute
 import com.google.samples.apps.nowinandroid.feature.topic.TopicDetailPlaceholder
-import com.google.samples.apps.nowinandroid.feature.topic.navigation.TopicRoute
-import com.google.samples.apps.nowinandroid.feature.topic.navigation.navigateToTopic
-import com.google.samples.apps.nowinandroid.feature.topic.navigation.topicScreen
-import kotlinx.serialization.Serializable
-import java.util.UUID
-
-@Serializable internal object TopicPlaceholderRoute
-
-// TODO: Remove @Keep when https://issuetracker.google.com/353898971 is fixed
-@Keep
-@Serializable internal object DetailPaneNavHostRoute
+import com.google.samples.apps.nowinandroid.feature.topic.TopicScreen
 
 fun NavGraphBuilder.interestsListDetailScreen() {
     composable<InterestsRoute> {
@@ -64,31 +42,16 @@ fun NavGraphBuilder.interestsListDetailScreen() {
     }
 }
 
-@Composable
-internal fun InterestsListDetailScreen(
-    viewModel: Interests2PaneViewModel = hiltViewModel(),
-    windowAdaptiveInfo: WindowAdaptiveInfo = currentWindowAdaptiveInfo(),
-) {
-    val selectedTopicId by viewModel.selectedTopicId.collectAsStateWithLifecycle()
-    InterestsListDetailScreen(
-        selectedTopicId = selectedTopicId,
-        onTopicClick = viewModel::onTopicClick,
-        windowAdaptiveInfo = windowAdaptiveInfo,
-    )
-}
-
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 internal fun InterestsListDetailScreen(
-    selectedTopicId: String?,
-    onTopicClick: (String) -> Unit,
-    windowAdaptiveInfo: WindowAdaptiveInfo,
+    viewModel: Interests2PaneViewModel = hiltViewModel()
 ) {
-    val listDetailNavigator = rememberListDetailPaneScaffoldNavigator(
-        scaffoldDirective = calculatePaneScaffoldDirective(windowAdaptiveInfo),
+    val selectedTopicId by viewModel.selectedTopicId.collectAsStateWithLifecycle()
+    val listDetailNavigator = rememberListDetailPaneScaffoldNavigator<String>(
         initialDestinationHistory = listOfNotNull(
             ThreePaneScaffoldDestinationItem(ListDetailPaneScaffoldRole.List),
-            ThreePaneScaffoldDestinationItem<Nothing>(ListDetailPaneScaffoldRole.Detail).takeIf {
+            ThreePaneScaffoldDestinationItem<String>(ListDetailPaneScaffoldRole.Detail).takeIf {
                 selectedTopicId != null
             },
         ),
@@ -97,33 +60,9 @@ internal fun InterestsListDetailScreen(
         listDetailNavigator.navigateBack()
     }
 
-    var nestedNavHostStartRoute by remember {
-        val route = selectedTopicId?.let { TopicRoute(id = it) } ?: TopicPlaceholderRoute
-        mutableStateOf(route)
-    }
-    var nestedNavKey by rememberSaveable(
-        stateSaver = Saver({ it.toString() }, UUID::fromString),
-    ) {
-        mutableStateOf(UUID.randomUUID())
-    }
-    val nestedNavController = key(nestedNavKey) {
-        rememberNavController()
-    }
-
-    fun onTopicClickShowDetailPane(topicId: String) {
-        onTopicClick(topicId)
-        if (listDetailNavigator.isDetailPaneVisible()) {
-            // If the detail pane was visible, then use the nestedNavController navigate call
-            // directly
-            nestedNavController.navigateToTopic(topicId) {
-                popUpTo<DetailPaneNavHostRoute>()
-            }
-        } else {
-            // Otherwise, recreate the NavHost entirely, and start at the new destination
-            nestedNavHostStartRoute = TopicRoute(id = topicId)
-            nestedNavKey = UUID.randomUUID()
-        }
-        listDetailNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail)
+    fun onTopicClickShowDetailPane(selectedTopicId: String) {
+        viewModel.onTopicClick(selectedTopicId)
+        listDetailNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail, selectedTopicId)
     }
 
     ListDetailPaneScaffold(
@@ -139,22 +78,15 @@ internal fun InterestsListDetailScreen(
         },
         detailPane = {
             AnimatedPane {
-                key(nestedNavKey) {
-                    NavHost(
-                        navController = nestedNavController,
-                        startDestination = nestedNavHostStartRoute,
-                        route = DetailPaneNavHostRoute::class,
-                    ) {
-                        topicScreen(
-                            showBackButton = !listDetailNavigator.isListPaneVisible(),
-                            onBackClick = listDetailNavigator::navigateBack,
-                            onTopicClick = ::onTopicClickShowDetailPane,
-                        )
-                        composable<TopicPlaceholderRoute> {
-                            TopicDetailPlaceholder()
-                        }
-                    }
-                }
+                if (selectedTopicId != null) {
+                    TopicScreen(
+                        topicId = selectedTopicId!!,
+                        showBackButton = !listDetailNavigator.isListPaneVisible(),
+                        onBackClick = listDetailNavigator::navigateBack,
+                        onTopicClick = ::onTopicClickShowDetailPane,
+                    )
+                } else
+                    TopicDetailPlaceholder()
             }
         },
     )

--- a/feature/foryou/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -175,18 +175,6 @@ internal fun ForYouScreen(
                 onboardingUiState = onboardingUiState,
                 onTopicCheckedChanged = onTopicCheckedChanged,
                 saveFollowedTopics = saveFollowedTopics,
-                // Custom LayoutModifier to remove the enforced parent 16.dp contentPadding
-                // from the LazyVerticalGrid and enable edge-to-edge scrolling for this section
-                interestsItemModifier = Modifier.layout { measurable, constraints ->
-                    val placeable = measurable.measure(
-                        constraints.copy(
-                            maxWidth = constraints.maxWidth + 32.dp.roundToPx(),
-                        ),
-                    )
-                    layout(placeable.width, placeable.height) {
-                        placeable.place(0, 0)
-                    }
-                },
             )
 
             newsFeed(
@@ -258,17 +246,29 @@ private fun LazyStaggeredGridScope.onboarding(
     onboardingUiState: OnboardingUiState,
     onTopicCheckedChanged: (String, Boolean) -> Unit,
     saveFollowedTopics: () -> Unit,
-    interestsItemModifier: Modifier = Modifier,
 ) {
     when (onboardingUiState) {
         OnboardingUiState.Loading,
         OnboardingUiState.LoadFailed,
         OnboardingUiState.NotShown,
-        -> Unit
+            -> Unit
 
         is OnboardingUiState.Shown -> {
             item(span = StaggeredGridItemSpan.FullLine, contentType = "onboarding") {
-                Column(modifier = interestsItemModifier) {
+                // Custom LayoutModifier to remove the enforced parent 16.dp contentPadding
+                // from the LazyVerticalGrid and enable edge-to-edge scrolling for this section
+                Column(
+                    modifier = Modifier.layout { measurable, constraints ->
+                        val placeable = measurable.measure(
+                            constraints.copy(
+                                maxWidth = constraints.maxWidth + 32.dp.roundToPx(),
+                            ),
+                        )
+                        layout(placeable.width, placeable.height) {
+                            placeable.place(0, 0)
+                        }
+                    },
+                ) {
                     Text(
                         text = stringResource(R.string.feature_foryou_onboarding_guidance_title),
                         textAlign = TextAlign.Center,
@@ -493,7 +493,7 @@ private fun feedItemsSize(
         OnboardingUiState.Loading,
         OnboardingUiState.LoadFailed,
         OnboardingUiState.NotShown,
-        -> 0
+            -> 0
 
         is OnboardingUiState.Shown -> 1
     }

--- a/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicScreen.kt
@@ -72,20 +72,24 @@ import com.google.samples.apps.nowinandroid.feature.topic.R.string
 
 @Composable
 fun TopicScreen(
+    topicId: String,
     showBackButton: Boolean,
     onBackClick: () -> Unit,
     onTopicClick: (String) -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: TopicViewModel = hiltViewModel(),
+    viewModel: TopicViewModel = hiltViewModel()
 ) {
+    viewModel.updateTopic(topicId)
+
     val topicUiState: TopicUiState by viewModel.topicUiState.collectAsStateWithLifecycle()
     val newsUiState: NewsUiState by viewModel.newsUiState.collectAsStateWithLifecycle()
+    val selectedTopicId by viewModel.topicId.collectAsStateWithLifecycle()
 
-    TrackScreenViewEvent(screenName = "Topic: ${viewModel.topicId}")
+    TrackScreenViewEvent(screenName = "Topic: $selectedTopicId")
     TopicScreen(
         topicUiState = topicUiState,
         newsUiState = newsUiState,
-        modifier = modifier.testTag("topic:${viewModel.topicId}"),
+        modifier = modifier.testTag("topic:${selectedTopicId}"),
         showBackButton = showBackButton,
         onBackClick = onBackClick,
         onFollowClick = viewModel::followTopicToggle,

--- a/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/navigation/TopicNavigation.kt
+++ b/feature/topic/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/navigation/TopicNavigation.kt
@@ -36,8 +36,10 @@ fun NavGraphBuilder.topicScreen(
     onBackClick: () -> Unit,
     onTopicClick: (String) -> Unit,
 ) {
-    composable<TopicRoute> {
+    composable<TopicRoute> { entry ->
+        val id = entry.arguments?.getString("id")!!
         TopicScreen(
+            topicId = id,
             showBackButton = showBackButton,
             onBackClick = onBackClick,
             onTopicClick = onTopicClick,

--- a/feature/topic/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/com/google/samples/apps/nowinandroid/feature/topic/TopicViewModelTest.kt
@@ -16,8 +16,6 @@
 
 package com.google.samples.apps.nowinandroid.feature.topic
 
-import androidx.lifecycle.SavedStateHandle
-import androidx.navigation.testing.invoke
 import com.google.samples.apps.nowinandroid.core.data.repository.CompositeUserNewsResourceRepository
 import com.google.samples.apps.nowinandroid.core.model.data.FollowableTopic
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
@@ -26,7 +24,6 @@ import com.google.samples.apps.nowinandroid.core.testing.repository.TestNewsRepo
 import com.google.samples.apps.nowinandroid.core.testing.repository.TestTopicsRepository
 import com.google.samples.apps.nowinandroid.core.testing.repository.TestUserDataRepository
 import com.google.samples.apps.nowinandroid.core.testing.util.MainDispatcherRule
-import com.google.samples.apps.nowinandroid.feature.topic.navigation.TopicRoute
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -70,18 +67,16 @@ class TopicViewModelTest {
     @Before
     fun setup() {
         viewModel = TopicViewModel(
-            savedStateHandle = SavedStateHandle(
-                route = TopicRoute(id = testInputTopics[0].topic.id),
-            ),
             userDataRepository = userDataRepository,
             topicsRepository = topicsRepository,
             userNewsResourceRepository = userNewsResourceRepository,
         )
+        viewModel.updateTopic(testInputTopics[0].topic.id)
     }
 
     @Test
     fun topicId_matchesTopicIdFromSavedStateHandle() =
-        assertEquals(testInputTopics[0].topic.id, viewModel.topicId)
+        assertEquals(testInputTopics[0].topic.id, viewModel.topicId.value)
 
     @Test
     fun uiStateTopic_whenSuccess_matchesTopicFromRepository() = runTest {


### PR DESCRIPTION
Removed NavHost for ListDetailPaneScaffold

Creating NavHost object every time user goes to a new interest object is expensive. We may do it with more effective way. Especially when there are only two possible composable choices that can be switched with the only if statement.
