### PR TITLE
Refine Spotless configuration to avoid wildcards

### DIFF
--- a/gradle/init.gradle.kts
+++ b/gradle/init.gradle.kts
@@ -33,8 +33,8 @@ rootProject {
         apply<com.diffplug.gradle.spotless.SpotlessPlugin>()
         extensions.configure<com.diffplug.gradle.spotless.SpotlessExtension> {
             kotlin {
-                target("**/*.kt")
-                targetExclude("**/build/**/*.kt")
+                target("src/**/*.kt")
+                targetExclude("**/build/**")
                 ktlint(ktlintVersion).editorConfigOverride(
                     mapOf(
                         "android" to "true",
@@ -44,13 +44,13 @@ rootProject {
             }
             format("kts") {
                 target("**/*.kts")
-                targetExclude("**/build/**/*.kts")
+                targetExclude("**/build/**")
                 // Look for the first line that doesn't have a block comment (assumed to be the license)
                 licenseHeaderFile(rootProject.file("spotless/copyright.kts"), "(^(?![\\/ ]\\*).*$)")
             }
             format("xml") {
                 target("**/*.xml")
-                targetExclude("**/build/**/*.xml")
+                targetExclude("**/build/**")
                 // Look for the first XML tag that isn't a comment (<!--) or the xml declaration (<?xml)
                 licenseHeaderFile(rootProject.file("spotless/copyright.xml"), "(<[^!?])")
             }


### PR DESCRIPTION
Fix #1832 
This PR refines the Spotless configuration to avoid using heavily discouraged wildcards. The changes:
- Target only the `src` directories for Kotlin and XML files.
- Exclude the `build` directory explicitly.
- Improve performance and avoid unintended formatting.

