### PR TITLE
Disable Gradle configuration cache on unsupported DependencyGuard task

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Check Dependency Guard
         id: dependencyguard_verify
         continue-on-error: true
-        run: ./gradlew dependencyGuard
+        run: ./gradlew dependencyGuard --no-configuration-cache
 
       - name: Prevent updating Dependency Guard baselines if this is a fork
         id: checkfork_dependencyguard


### PR DESCRIPTION
Fix Gradle Configuration Cache issue with Dependency Guard:

https://github.com/android/nowinandroid/actions/runs/13933394498/job/38995815537

```
Configuration cache state could not be cached: field `__monitoredConfigurationsMap__` of task `:app:dependencyGuard` of type `com.dropbox.gradle.plugins.dependencyguard.internal.list.DependencyGuardListTask`: error writing value of type 'org.gradle.api.internal.provider.DefaultMapProperty'
```