### PR TITLE
Remove @Keep Annotation from Kotlin Serialization Class

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/interests2pane/InterestsListDetailScreen.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/interests2pane/InterestsListDetailScreen.kt
@@ -54,8 +54,6 @@ import java.util.UUID
 
 @Serializable internal object TopicPlaceholderRoute
 
-// TODO: Remove @Keep when https://issuetracker.google.com/353898971 is fixed
-@Keep
 @Serializable internal object DetailPaneNavHostRoute
 
 fun NavGraphBuilder.interestsListDetailScreen() {


### PR DESCRIPTION
The @Keep annotation was previously required to prevent ProGuard or R8 from stripping Kotlin serialization-generated code. However, starting from kotlinx.serialization version 1.8.0, this issue has been resolved [Release 1.8.0](https://github.com/Kotlin/kotlinx.serialization/blob/master/CHANGELOG.md) This PR removes the unnecessary @Keep annotation to clean up the code while ensuring compatibility with the latest version of the serialization library.

Old issue link: https://github.com/android/nowinandroid/issues/1595

Running demoRelease build after the change:

https://github.com/user-attachments/assets/817fa210-3c96-476b-81bb-8fe9d9ebd6f0

