### PR TITLE
Replace org.junit.Assert.assertEquals with kotlin.test.assertEquals for consistency

### DIFF
--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/UserNewsResourceTest.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/UserNewsResourceTest.kt
@@ -24,9 +24,9 @@ import com.google.samples.apps.nowinandroid.core.model.data.Topic
 import com.google.samples.apps.nowinandroid.core.model.data.UserData
 import com.google.samples.apps.nowinandroid.core.model.data.UserNewsResource
 import kotlinx.datetime.Clock
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class UserNewsResourceTest {
 


### PR DESCRIPTION
**What I have done and why**

In PR #420, the project transitioned from JUnit assertions to `kotlin.test.assertEquals`.  
However, I found one class where `org.junit.Assert.assertEquals` was still being used.  
This PR updates it to maintain consistency across tests.  
All tests pass after the change.
