### PR TITLE
Remove death penalty from strict mode violations

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaApplication.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaApplication.kt
@@ -66,7 +66,7 @@ class NiaApplication : Application(), ImageLoaderFactory {
     private fun setStrictModePolicy() {
         if (isDebuggable()) {
             StrictMode.setThreadPolicy(
-                Builder().detectAll().penaltyLog().penaltyDeath().build(),
+                Builder().detectAll().penaltyLog().build(),
             )
         }
     }


### PR DESCRIPTION
The app was still crashing in non-debug after strict mode was enabled. Less restrictive, now only logging violations