### PR TITLE
CI: Integrate workflow_triggers for nowinandroid from cartland's fork

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
   pull_request:
-    branches: [ main ]
 
 concurrency:
   group: build-${{ github.ref }}

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -1,10 +1,12 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
   pull_request:
+    branches: [ main ]
 
 concurrency:
   group: build-${{ github.ref }}

--- a/.github/workflows/NightlyBaselineProfiles.yaml
+++ b/.github/workflows/NightlyBaselineProfiles.yaml
@@ -1,6 +1,9 @@
 name: NightlyBaselineProfiles
 
 on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
   schedule:
     - cron:  '42 4 * * *'
 

--- a/.github/workflows/NightlyBaselineProfiles.yaml
+++ b/.github/workflows/NightlyBaselineProfiles.yaml
@@ -2,8 +2,6 @@ name: NightlyBaselineProfiles
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
   schedule:
     - cron:  '42 4 * * *'
 

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,6 +1,7 @@
 name: GitHub Release with APKs
 
 on:
+  workflow_dispatch:
   push:
     tags:
     - 'v*'
@@ -75,4 +76,4 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: app/build/outputs/apk/demo/release/app-demo-release.apk
           asset_name: app-demo-release.apk
-          asset_content_type: application/vnd.android.package-archive          
+          asset_content_type: application/vnd.android.package-archive


### PR DESCRIPTION
This PR modifies GitHub Actions triggers in workflow files within .github/workflows/.

This is part of a batch of pull requests across repositories owned by the `android` organization on GitHub.
We are checking to make sure GitHub Actions are correctly using the following 3 triggers: workflow_dispatch, push, pull_request. This change modifies at least one of the following triggers:

1) `workflow_dispatch`: This trigger allows the workflow to be manually run in the GitHub UI. Most workflows should contain this trigger.
2) `push`: Most build and test scripts should run after a change is merged. This should at least run on the default branch, like `main`, but it could be configured to run on more branches.
3) `pull_request`: Most build and test scripts should run on pull requests, at least to the `main` branch.

Project Owner: Please review the changes carefully to ensure they are correct and appropriate for this project before approving and merging.

If you do not think this change is appropriate (e.g., a workflow should NOT run on one of these triggers), please leave a comment explaining why.
If you think the goal is appropriate but notice a mistake in the implementation, please leave a comment detailing the mistake.

