### PR TITLE
Add -repackageclasses to R8 configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,7 +45,8 @@ android {
         release {
             isMinifyEnabled = true
             applicationIdSuffix = NiaBuildType.RELEASE.applicationIdSuffix
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"),
+                          "proguard-rules.pro")
 
             // To publish on the Play store a private signing key is required, but to allow anyone
             // who clones the code to sign and run the release variant, use the debug signing key.

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,2 @@
+# Repackage classes into the default package to reduce the size of descriptors.
+-repackageclasses


### PR DESCRIPTION
This adds -repackageclasses to the R8 configuration so that most classes will have their package name stripped in the release build. This reduces the size of the descriptors in the app and thus the size of the generated dex.