### PR TITLE
Exclude the ime window inset at the snack bar.

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -168,10 +168,9 @@ internal fun NiaApp(
                         )
                     },
                     label = { Text(stringResource(destination.iconTextId)) },
-                    modifier =
-                        Modifier
-                            .testTag("NiaNavItem")
-                            .then(if (hasUnread) Modifier.notificationDot() else Modifier),
+                    modifier = Modifier
+                        .testTag("NiaNavItem")
+                        .then(if (hasUnread) Modifier.notificationDot() else Modifier),
                 )
             }
         },


### PR DESCRIPTION
**What I have done and why**

Fix #1864

I exclude the ime window insets from the snack bar window insets, because I think it is fine to covered in software keyboard same as the bottom navigation bar.


https://github.com/user-attachments/assets/e92413ee-7ff2-41e0-910a-606bf35e665d

