### PR TITLE
Refactor: Replace list initialization with emptyList() for clarity

### DIFF
--- a/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNewsResourceDao.kt
+++ b/core/data/src/test/kotlin/com/google/samples/apps/nowinandroid/core/data/testdoubles/TestNewsResourceDao.kt
@@ -36,7 +36,7 @@ class TestNewsResourceDao : NewsResourceDao {
 
     private val entitiesStateFlow = MutableStateFlow(emptyList<NewsResourceEntity>())
 
-    internal var topicCrossReferences: List<NewsResourceTopicCrossRef> = listOf()
+    internal var topicCrossReferences: List<NewsResourceTopicCrossRef> = emptyList()
 
     override fun getNewsResources(
         useFilterTopicIds: Boolean,

--- a/core/database/src/main/kotlin/com/google/samples/apps/nowinandroid/core/database/model/NewsResourceEntity.kt
+++ b/core/database/src/main/kotlin/com/google/samples/apps/nowinandroid/core/database/model/NewsResourceEntity.kt
@@ -49,5 +49,5 @@ fun NewsResourceEntity.asExternalModel() = NewsResource(
     headerImageUrl = headerImageUrl,
     publishDate = publishDate,
     type = type,
-    topics = listOf(),
+    topics = emptyList(),
 )

--- a/core/network/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/model/NetworkNewsResource.kt
+++ b/core/network/src/main/kotlin/com/google/samples/apps/nowinandroid/core/network/model/NetworkNewsResource.kt
@@ -16,6 +16,7 @@
 
 package com.google.samples.apps.nowinandroid.core.network.model
 
+import android.annotation.SuppressLint
 import com.google.samples.apps.nowinandroid.core.model.data.NewsResource
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
@@ -23,6 +24,7 @@ import kotlinx.serialization.Serializable
 /**
  * Network representation of [NewsResource] when fetched from /newsresources
  */
+@SuppressLint("UnsafeOptInUsageError")
 @Serializable
 data class NetworkNewsResource(
     val id: String,
@@ -32,5 +34,5 @@ data class NetworkNewsResource(
     val headerImageUrl: String,
     val publishDate: Instant,
     val type: String,
-    val topics: List<String> = listOf(),
+    val topics: List<String> = emptyList(),
 )


### PR DESCRIPTION
**What I have done and why**

Refactor: Replace list initialization with emptyList() for clarity

