### PR TITLE
 Update SettingsViewModel.kt

### DIFF
--- a/feature/settings/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/settings/SettingsViewModel.kt
@@ -78,7 +78,6 @@ class SettingsViewModel @Inject constructor(
                 DARK -> AppCompatDelegate.MODE_NIGHT_YES
             }
             AppCompatDelegate.setDefaultNightMode(splashMode)
-            
             if (Build.VERSION.SDK_INT >= VERSION_CODES.S) {
                 val uiModeMode = when (darkThemeConfig) {
                     FOLLOW_SYSTEM -> UiModeManager.MODE_NIGHT_AUTO


### PR DESCRIPTION
What I have done and why

- Used setApplicationNightMode via UiModeManager for API 31+ (Android 12+).
- Used AppCompatDelegate.setDefaultNightMode for below API 31.
- Ensures consistent dark theme behaviour across all Android versions.