### PR TITLE
Encapsulate shouldDisplayUndoBookmark with private setter

### DIFF
--- a/feature/bookmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModel.kt
+++ b/feature/bookmarks/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/bookmarks/BookmarksViewModel.kt
@@ -42,6 +42,7 @@ class BookmarksViewModel @Inject constructor(
 ) : ViewModel() {
 
     var shouldDisplayUndoBookmark by mutableStateOf(false)
+        private set
     private var lastRemovedBookmarkId: String? = null
 
     val feedUiState: StateFlow<NewsFeedUiState> =


### PR DESCRIPTION
**What I have done and why**

This PR encapsulates the `shouldDisplayUndoBookmark` state in `BookmarksViewModel` by adding a `private set`.

Previously, `shouldDisplayUndoBookmark` was publicly mutable, which allowed external classes or composables to modify its value directly. By making the setter private, only the ViewModel can update this state. This change improves encapsulation and prevents unintended modifications from outside.

Fix #1899 
