### PR TITLE
Fix: Cards are sometimes rendered with an empty title (#1901)

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,84 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <JavaCodeStyleSettings>
-      <option name="ANNOTATION_PARAMETER_WRAP" value="1" />
-      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="5" />
-      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="3" />
-      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
-        <value>
-          <package name="java.awt" withSubpackages="false" static="false" />
-          <package name="javax.swing" withSubpackages="false" static="false" />
-        </value>
-      </option>
-      <option name="IMPORT_LAYOUT_TABLE">
-        <value>
-          <package name="" withSubpackages="true" static="false" />
-          <emptyLine />
-          <package name="javax" withSubpackages="true" static="false" />
-          <package name="java" withSubpackages="true" static="false" />
-          <emptyLine />
-          <package name="" withSubpackages="true" static="true" />
-        </value>
-      </option>
-      <option name="JD_P_AT_EMPTY_LINES" value="false" />
-      <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
-      <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
-      <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
-      <option name="JD_KEEP_EMPTY_RETURN" value="false" />
-      <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
-    </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="99" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="99" />
-      <option name="IMPORT_NESTED_CLASSES" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
-    <Properties>
-      <option name="KEEP_BLANK_LINES" value="true" />
-    </Properties>
-    <XML>
-      <option name="XML_ATTRIBUTE_WRAP" value="2" />
-    </XML>
-    <ADDITIONAL_INDENT_OPTIONS fileType="java">
-      <option name="TAB_SIZE" value="8" />
-    </ADDITIONAL_INDENT_OPTIONS>
-    <ADDITIONAL_INDENT_OPTIONS fileType="js">
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-    </ADDITIONAL_INDENT_OPTIONS>
-    <codeStyleSettings language="JAVA">
-      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-      <option name="ALIGN_MULTILINE_FOR" value="false" />
-      <option name="CALL_PARAMETERS_WRAP" value="1" />
-      <option name="PREFER_PARAMETERS_WRAP" value="true" />
-      <option name="METHOD_PARAMETERS_WRAP" value="1" />
-      <option name="RESOURCE_LIST_WRAP" value="1" />
-      <option name="EXTENDS_LIST_WRAP" value="1" />
-      <option name="THROWS_LIST_WRAP" value="1" />
-      <option name="EXTENDS_KEYWORD_WRAP" value="1" />
-      <option name="THROWS_KEYWORD_WRAP" value="1" />
-      <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-      <option name="BINARY_OPERATION_WRAP" value="1" />
-      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-      <option name="TERNARY_OPERATION_WRAP" value="1" />
-      <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-      <option name="FOR_STATEMENT_WRAP" value="1" />
-      <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-      <option name="ASSIGNMENT_WRAP" value="1" />
-      <option name="IF_BRACE_FORCE" value="3" />
-      <option name="DOWHILE_BRACE_FORCE" value="3" />
-      <option name="WHILE_BRACE_FORCE" value="3" />
-      <option name="FOR_BRACE_FORCE" value="3" />
-      <option name="WRAP_LONG_LINES" value="true" />
-      <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
-      <option name="VARIABLE_ANNOTATION_WRAP" value="1" />
-      <option name="ENUM_CONSTANTS_WRAP" value="1" />
-    </codeStyleSettings>
-    <codeStyleSettings language="JSON">
-      <indentOptions>
-        <option name="CONTINUATION_INDENT_SIZE" value="4" />
-        <option name="TAB_SIZE" value="2" />
-      </indentOptions>
-    </codeStyleSettings>
     <codeStyleSettings language="XML">
       <option name="FORCE_REARRANGE_MODE" value="1" />
       <indentOptions>
@@ -157,80 +81,12 @@
             <rule>
               <match>
                 <AND>
-                  <NAME>.*:layout_width</NAME>
+                  <NAME>.*</NAME>
                   <XML_ATTRIBUTE />
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_height</NAME>
-                  <XML_ATTRIBUTE />
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_.*</NAME>
-                  <XML_ATTRIBUTE />
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
               <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:width</NAME>
-                  <XML_ATTRIBUTE />
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:height</NAME>
-                  <XML_ATTRIBUTE />
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:viewportWidth</NAME>
-                  <XML_ATTRIBUTE />
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:viewportHeight</NAME>
-                  <XML_ATTRIBUTE />
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
             </rule>
           </section>
           <section>
@@ -242,43 +98,7 @@
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_.*</NAME>
-                  <XML_ATTRIBUTE />
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res-auto</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*</NAME>
-                  <XML_ATTRIBUTE />
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res-auto</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_.*</NAME>
-                  <XML_ATTRIBUTE />
-                  <XML_NAMESPACE>.*</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
             </rule>
           </section>
           <section>
@@ -298,17 +118,6 @@
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
-      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
-      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
-      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-      <option name="FIELD_ANNOTATION_WRAP" value="1" />
-      <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
-      <option name="VARIABLE_ANNOTATION_WRAP" value="1" />
-      <option name="ENUM_CONSTANTS_WRAP" value="5" />
-      <indentOptions>
-        <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      </indentOptions>
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.draganddrop.dragAndDropSource
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -53,6 +54,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draganddrop.DragAndDropTransferData
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
@@ -110,6 +112,17 @@ fun NewsResourceCardExpanded(
         0
     }
 
+    var isDragging by remember { mutableStateOf(false) }
+    val draggingModifier = Modifier.dragAndDropSource { _ ->
+        DragAndDropTransferData(
+            ClipData.newPlainText(
+                sharingLabel,
+                sharingContent,
+            ),
+            flags = dragAndDropFlags,
+        )
+    }
+
     Card(
         onClick = onClick,
         shape = RoundedCornerShape(16.dp),
@@ -138,15 +151,10 @@ fun NewsResourceCardExpanded(
                             userNewsResource.title,
                             modifier = Modifier
                                 .fillMaxWidth((.8f))
-                                .dragAndDropSource { _ ->
-                                    DragAndDropTransferData(
-                                        ClipData.newPlainText(
-                                            sharingLabel,
-                                            sharingContent,
-                                        ),
-                                        flags = dragAndDropFlags,
-                                    )
-                                },
+                                .pointerInput(Unit) {
+                                    detectTapGestures(onLongPress = { _ -> isDragging = true })
+                                }
+                                .then(if (isDragging) draggingModifier else Modifier),
                         )
                         Spacer(modifier = Modifier.weight(1f))
                         BookmarkButton(isBookmarked, onToggleBookmark)


### PR DESCRIPTION
**What I have done and why**

The issue occurred because the drag-and-drop Modifier containing the DragAndDropTransferData and title information was being initialized inline within the Card content. As a result, under certain recomposition conditions, the title was not consistently passed or rendered, leading to blank titles.

Changes made:

- Created isDragging variable to avoid making the text draggable by default(which was causing bug)
- Applied the shared dragAndDropModifier only when isDragging is true, preventing accidental reuse or premature initialization.

This makes the card title stable during drag gestures and ensures it’s always properly rendered.
