### PR TITLE
Move to a custom setup for BuildConfig.BACKEND_URL

### DIFF
--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
+import com.android.build.api.variant.BuildConfigField
+import java.io.StringReader
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.nowinandroid.android.library)
     alias(libs.plugins.nowinandroid.android.library.jacoco)
     alias(libs.plugins.nowinandroid.hilt)
     id("kotlinx-serialization")
-    id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
 }
 
 android {
@@ -32,10 +35,6 @@ android {
             isIncludeAndroidResources = true
         }
     }
-}
-
-secrets {
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 dependencies {
@@ -51,4 +50,22 @@ dependencies {
     implementation(libs.retrofit.kotlin.serialization)
 
     testImplementation(libs.kotlinx.coroutines.test)
+}
+
+val backendUrl = providers.fileContents(
+    isolated.rootProject.projectDirectory.file("local.properties")
+).asText.map { text ->
+    val properties = Properties()
+    properties.load(StringReader(text))
+    if (properties.containsKey("BACKEND_URL"))
+        (properties["BACKEND_URL"] as String)
+    else "http://example.com"
+}.orElse("http://example.com")
+
+androidComponents {
+    onVariants {
+        it.buildConfigFields.put("BACKEND_URL", backendUrl.map { value ->
+            BuildConfigField(type = "String", value = """"$value"""", comment = null)
+        })
+    }
 }

--- a/secrets.defaults.properties
+++ b/secrets.defaults.properties
@@ -1,4 +1,0 @@
-## This file provides default values to modules using the secrets-gradle-plugin. It is necessary
-# because the secrets properties file is not under source control so CI builds will fail without
-# default values.
-BACKEND_URL="http://example.com"


### PR DESCRIPTION
secrets gradle plugin is not Gradle project isolation compatible and is using deprecated AGP variant API. This change removes the usage by using a custom provider to set this value.

Inspiration https://github.com/android/gradle-recipes/blob/agp-8.10/addCustomBuildConfigFields/build-logic/plugins/src/main/kotlin/CustomPlugin.kt

https://github.com/android/nowinandroid/issues/1842

Test: ./gradlew core:network:assemble -> BuildConfig.java has correct
      value
