### PR TITLE
Fix issue with `github/codeql-action/upload-sarif@v3`

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -140,11 +140,26 @@ jobs:
           name: lint-reports
           path: '**/build/reports/lint-results-*.html'
 
-      - name: Upload lint reports (SARIF)
-        if: ${{ !cancelled() && hashFiles('**/*.sarif') != '' }}
+      - name: Upload lint reports (SARIF) for app module
+        if: ${{ !cancelled() && hashFiles('app/**/*.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: './'
+          sarif_file: './app/'
+          category: app
+
+      - name: Upload lint reports (SARIF) for app-nia-catalog module
+        if: ${{ !cancelled() && hashFiles('app-nia-catalog/**/*.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: './app-nia-catalog/'
+          category: app-nia-catalog
+
+      - name: Upload lint reports (SARIF) for lint module
+        if: ${{ !cancelled() && hashFiles('lint/**/*.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: './lint/'
+          category: lint
 
       - name: Check badging
         run: ./gradlew :app:checkProdReleaseBadging


### PR DESCRIPTION
where multiple runs of the same tool (e.g. through mutliple files) is now considered an error: https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/

Since the main app module is already using `checkDependencies`

https://github.com/android/nowinandroid/blob/ddf16478801dec4b9374cf5e00f0dabd63838911/build-logic/convention/src/main/kotlin/AndroidLintConventionPlugin.kt#L44-L49

and based on this usage

https://github.com/android/nowinandroid/blob/ddf16478801dec4b9374cf5e00f0dabd63838911/.github/workflows/Build.yaml#L134
 
we only have to report these 3 files from 3 distinct modules:
- `./app/build/reports/lint-results-prodRelease.sarif`
- `./app-nia-catalog/build/reports/lint-results-release.sarif`
- `./lint/build/reports/lint-results.sarif`

Closes #1915