### PR TITLE
Make scrollbar thumb size configurable

### DIFF
--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
@@ -66,6 +66,11 @@ import kotlinx.coroutines.delay
 private const val SCROLLBAR_INACTIVE_TO_DORMANT_TIME_IN_MS = 2_000L
 
 /**
+ * The size of the scrollbar thumb
+ */
+private const val THUMB_SIZE = 12
+
+/**
  * A [Scrollbar] that allows for fast scrolling of content by dragging its thumb.
  * Its thumb disappears when the scrolling container is dormant.
  * @param modifier a [Modifier] for the [Scrollbar]
@@ -136,8 +141,8 @@ private fun ScrollableState.DraggableScrollbarThumb(
         modifier = Modifier
             .run {
                 when (orientation) {
-                    Vertical -> width(12.dp).fillMaxHeight()
-                    Horizontal -> height(12.dp).fillMaxWidth()
+                    Vertical -> width(THUMB_SIZE.dp).fillMaxHeight()
+                    Horizontal -> height(THUMB_SIZE.dp).fillMaxWidth()
                 }
             }
             .scrollThumb(this, interactionSource),


### PR DESCRIPTION
This change introduces a constant `THUMB_SIZE` to control the size of the scrollbar thumb, making it easier to adjust its appearance.

**What I have done and why:**

I just added a `const` variable to set the size of the scrollbar thumb, as I see it convenient to be able adapt it.
