### PR TITLE
Use sdkComponents.aapt2 API for executable path

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -44,7 +44,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             }
             extensions.configure<ApplicationAndroidComponentsExtension> {
                 configurePrintApksTask(this)
-                configureBadgingTasks(extensions.getByType<BaseExtension>(), this)
+                configureBadgingTasks(this)
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -16,7 +16,6 @@
 
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
-import com.android.build.gradle.BaseExtension
 import com.google.samples.apps.nowinandroid.configureBadgingTasks
 import com.google.samples.apps.nowinandroid.configureGradleManagedDevices
 import com.google.samples.apps.nowinandroid.configureKotlinAndroid
@@ -25,7 +24,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.getByType
 
 class AndroidApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
@@ -122,14 +122,8 @@ fun Project.configureBadgingTasks(
             tasks.register<GenerateBadgingTask>(generateBadgingTaskName) {
                 apk = variant.artifacts.get(SingleArtifact.APK_FROM_BUNDLE)
                 aapt2Executable.set(
-                    // TODO: Replace with `sdkComponents.aapt2` when it's available in AGP
-                    //       https://issuetracker.google.com/issues/376815836
-                    componentsExtension.sdkComponents.sdkDirectory.map { directory ->
-                        directory.file(
-                            "${SdkConstants.FD_BUILD_TOOLS}/" +
-                                "${baseExtension.buildToolsVersion}/" +
-                                SdkConstants.FN_AAPT2,
-                        )
+                    componentsExtension.sdkComponents.aapt2.flatMap { aapt2 ->
+                        aapt2.executable
                     }
                 )
                 badging = project.layout.buildDirectory.file(

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
@@ -110,7 +110,6 @@ private fun String.capitalized() = replaceFirstChar {
 }
 
 fun Project.configureBadgingTasks(
-    baseExtension: BaseExtension,
     componentsExtension: ApplicationAndroidComponentsExtension,
 ) {
     // Registers a callback to be called, when a new variant is configured

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Badging.kt
@@ -16,10 +16,8 @@
 
 package com.google.samples.apps.nowinandroid
 
-import com.android.SdkConstants
 import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
-import com.android.build.gradle.BaseExtension
 import com.google.common.truth.Truth.assertWithMessage
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -65,8 +65,8 @@ val backendUrl = providers.fileContents(
 
 androidComponents {
     onVariants {
-        it.buildConfigFields.put("BACKEND_URL", backendUrl.map { value ->
-            BuildConfigField(type = "String", value = """"$value"""", comment = null)
+        it.buildConfigFields?.put("BACKEND_URL", backendUrl.map { value ->
+            BuildConfigField(type = "String", value = """"$value"""", comment = "null")
         })
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 accompanist = "0.37.0"
 androidDesugarJdkLibs = "2.1.4"
 # AGP and tools should be updated together
-androidGradlePlugin = "8.9.0"
+androidGradlePlugin = "8.11.1"
 androidTools = "31.9.0"
 androidxActivity = "1.9.3"
 androidxAppCompat = "1.7.0"


### PR DESCRIPTION
**What I have done and why**
Previously, the aapt2 file path was manually constructed by concatenating the SDK directory path with the `buildToolsVersion`.
This was a temporary workaround, marked with a TODO to migrate once an official API became available.
```kotlin
aapt2Executable.set(
    // TODO: Replace with `sdkComponents.aapt2` when it's available in AGP
    //       https://issuetracker.google.com/issues/376815836
    componentsExtension.sdkComponents.sdkDirectory.map { directory ->
        directory.file(
            "${SdkConstants.FD_BUILD_TOOLS}/" +
                "${baseExtension.buildToolsVersion}/" +
                SdkConstants.FN_AAPT2,
        )
    }
)
```
This change replaces the manual path construction with the official Android Gradle Plugin (AGP) API: `componentsExtension.sdkComponents.aapt2`.
```
aapt2Executable.set(
    componentsExtension.sdkComponents.aapt2.flatMap { aapt2 ->
        aapt2.executable
    }
)
```
https://issuetracker.google.com/issues/376815836?pli=1