### PR TITLE
🏭 Split GHA jobs and extract composite actions

### DIFF
--- a/.github/actions/setup-gradle-managed-devices/action.yaml
+++ b/.github/actions/setup-gradle-managed-devices/action.yaml
@@ -1,0 +1,16 @@
+name: 🐘 Setup Gradle Managed Devices
+description: Gradle Managed Devices setup
+runs:
+  using: composite
+  steps:
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
+
+    - name: Accept licenses
+      run: yes | sdkmanager --licenses || true
+
+    - name: Setup GMD
+      run: ./gradlew :benchmarks:pixel6Api33Setup
+        --info
+        -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true
+        -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect"

--- a/.github/actions/setup-gradle-properties/action.yaml
+++ b/.github/actions/setup-gradle-properties/action.yaml
@@ -1,0 +1,7 @@
+name: 🐘 Setup gradle.properties
+description: Copy .github/ci-gradle.properties into ~/.gradle/gradle.properties
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties

--- a/.github/actions/setup-gradle/action.yaml
+++ b/.github/actions/setup-gradle/action.yaml
@@ -1,0 +1,19 @@
+name: 🐘 Setup Gradle
+description: Gradle setup and wrapper validation
+inputs:
+  cache-encryption-key:
+    description: Gradle Configuration Cache encryption key
+    required: false
+runs:
+  using: composite
+  steps:
+    - uses: gradle/actions/setup-gradle@v4
+      with:
+        add-job-summary-as-pr-comment: on-failure
+        build-scan-publish: true
+        build-scan-terms-of-use-agree: yes
+        build-scan-terms-of-use-url: https://gradle.com/terms-of-service
+        cache-cleanup: on-success
+        cache-encryption-key: ${{ inputs.cache-encryption-key }}
+        gradle-home-cache-strict-match: true
+        validate-wrappers: true

--- a/.github/actions/setup-java/action.yaml
+++ b/.github/actions/setup-java/action.yaml
@@ -1,0 +1,9 @@
+name: ☕️ Setup Java
+description: Java setup
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-java@v5
+      with:
+        distribution: zulu
+        java-version: "21"

--- a/.github/actions/setup-kvm/action.yaml
+++ b/.github/actions/setup-kvm/action.yaml
@@ -1,0 +1,11 @@
+name: ⚙️ Setup KVM group perms
+description: KVM group perms setup
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+        ls /dev/kvm

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: CI
 
 on:
   workflow_dispatch:
@@ -12,37 +12,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test_and_apk:
-    name: "Local tests and APKs"
+  checks:
     runs-on: ubuntu-latest
-
     permissions:
       contents: write
       pull-requests: write
       security-events: write
-
-    timeout-minutes: 60
-
+    timeout-minutes: 20
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: 21
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-gradle
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          build-scan-publish: true
-          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
-          build-scan-terms-of-use-agree: "yes"
+      - uses: ./.github/actions/setup-gradle-properties
 
       - name: Check build-logic
         run: ./gradlew :build-logic:convention:check
@@ -77,6 +60,86 @@ jobs:
           disable_globbing: true
           commit_message: "🤖 Updates baselines for Dependency Guard"
 
+      - name: Check badging
+        run: ./gradlew :app:checkProdReleaseBadging
+
+  assemble:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-gradle
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+      - uses: ./.github/actions/setup-gradle-properties
+
+      - name: Build all build type and flavor permutations
+        run: ./gradlew :app:assemble
+
+      - name: Upload build outputs (APKs)
+        uses: actions/upload-artifact@v4
+        with:
+          name: APKs
+          path: '**/build/outputs/apk/**/*.apk'
+
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-gradle
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+      - uses: ./.github/actions/setup-gradle-properties
+
+      - name: Check lint
+        run: ./gradlew :app:lintProdRelease :app-nia-catalog:lintRelease :lint:lint
+
+      - name: Upload lint reports (HTML)
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-reports
+          path: '**/build/reports/lint-results-*.html'
+
+      - name: Upload lint reports (SARIF) for app module
+        if: ${{ !cancelled() && hashFiles('app/**/*.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: './app/'
+          category: app
+
+      - name: Upload lint reports (SARIF) for app-nia-catalog module
+        if: ${{ !cancelled() && hashFiles('app-nia-catalog/**/*.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: './app-nia-catalog/'
+          category: app-nia-catalog
+
+      - name: Upload lint reports (SARIF) for lint module
+        if: ${{ !cancelled() && hashFiles('lint/**/*.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: './lint/'
+          category: lint
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      security-events: write
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-gradle
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+      - uses: ./.github/actions/setup-gradle-properties
+
       - name: Run all local screenshot tests (Roborazzi)
         id: screenshotsverify
         continue-on-error: true
@@ -110,15 +173,6 @@ jobs:
       - name: Run local tests
         run: ./gradlew testDemoDebug :lint:test
 
-      - name: Build all build type and flavor permutations
-        run: ./gradlew :app:assemble
-
-      - name: Upload build outputs (APKs)
-        uses: actions/upload-artifact@v4
-        with:
-          name: APKs
-          path: '**/build/outputs/apk/**/*.apk'
-
       - name: Upload JVM local results (XML)
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
@@ -133,41 +187,7 @@ jobs:
           name: screenshot-test-results
           path: '**/build/outputs/roborazzi/*_compare.png'
 
-      - name: Check lint
-        run: ./gradlew :app:lintProdRelease :app-nia-catalog:lintRelease :lint:lint
-
-      - name: Upload lint reports (HTML)
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: lint-reports
-          path: '**/build/reports/lint-results-*.html'
-
-      - name: Upload lint reports (SARIF) for app module
-        if: ${{ !cancelled() && hashFiles('app/**/*.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: './app/'
-          category: app
-
-      - name: Upload lint reports (SARIF) for app-nia-catalog module
-        if: ${{ !cancelled() && hashFiles('app-nia-catalog/**/*.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: './app-nia-catalog/'
-          category: app-nia-catalog
-
-      - name: Upload lint reports (SARIF) for lint module
-        if: ${{ !cancelled() && hashFiles('lint/**/*.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: './lint/'
-          category: lint
-
-      - name: Check badging
-        run: ./gradlew :app:checkProdReleaseBadging
-
-  androidTest:
+  instrumented-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 55
     strategy:
@@ -185,33 +205,13 @@ jobs:
           swap-storage: true # rm -f /mnt/swapfile (4GiB)
           docker-images: false # Takes 16s, enable if needed in the future
           large-packages: false # includes google-cloud-sdk and it's slow
-
-      - name: Enable KVM group perms
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-          ls /dev/kvm
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: 21
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-kvm
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-gradle
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          build-scan-publish: true
-          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
-          build-scan-terms-of-use-agree: "yes"
+      - uses: ./.github/actions/setup-gradle-properties
 
       - name: Build projects and run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/NightlyBaselineProfiles.yaml
+++ b/.github/workflows/NightlyBaselineProfiles.yaml
@@ -17,47 +17,14 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Enable KVM group perms
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-          ls /dev/kvm
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: 17
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-kvm
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-gradle
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          build-scan-publish: true
-          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
-          build-scan-terms-of-use-agree: "yes"
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-
-      - name: Accept licenses
-        run: yes | sdkmanager --licenses || true
-
-      - name: Check build-logic
-        run: ./gradlew :build-logic:convention:check
-
-      - name: Setup GMD
-        run: ./gradlew :benchmarks:pixel6Api33Setup
-          --info
-          -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true
-          -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect"
+      - uses: ./.github/actions/setup-gradle-properties
+      - uses: ./.github/actions/setup-gradle-managed-devices
 
       - name: Build all build type and flavor permutations including baseline profiles
         run: ./gradlew :app:assemble

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -13,45 +13,14 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Enable KVM group perms
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-          ls /dev/kvm
-
-      - name: Checkout
-
-        uses: actions/checkout@v4
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: 17
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-kvm
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-gradle
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          build-scan-publish: true
-          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
-          build-scan-terms-of-use-agree: "yes"
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-
-      - name: Accept licenses
-        run: yes | sdkmanager --licenses || true
-
-      - name: Setup GMD
-        run: ./gradlew :benchmarks:pixel6Api33Setup
-          --info
-          -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true
-          -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect"
+      - uses: ./.github/actions/setup-gradle-properties
+      - uses: ./.github/actions/setup-gradle-managed-devices
 
       - name: Build release variant including baseline profile generation
         run: ./gradlew :app:assembleDemoRelease


### PR DESCRIPTION
Main advantages:
- improves GHA readability: less code in the main workflow files
- improves maintainability: composite actions are self contained
- reduces copy/paste mistakes & oversights (e.g. java version was set to 17 and 21)
- slight increase in total build time, but reduces the perceived parallelized time.

Extracted composite actions:
- setup-gradle
- setup-gradle-managed-devices
- setup-gradle-properties
- setup-java
- setup-kvm

Jobs split into more granular groups:
- `checks`: `:build-logic:convention:check`, `spotlessCheck`, `dependencyGuard`, `:app:checkProdReleaseBadging`
- `assemble`: `:app:assemble`
- `lint`: `:app:lintProdRelease`, `:app-nia-catalog:lintRelease`, `:lint:lint`
- `unit-tests`: `verifyRoborazziDemoDebug`, `recordRoborazziDemoDebug`, `testDemoDebug`, `:lint:test`
- `instrumented-tests`: `connectedDemoDebugAndroidTest`, `testDemoDebugUnitTest`, `createDemoDebugCombinedCoverageReport`

---

For the required checked jobs, this [fan-in](https://jakewharton.com/fan-in-to-a-single-required-github-action/) method can be applied to simplify the required checks configuration.