### PR TITLE
Disable R8 minfication step on PRs

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -111,7 +111,7 @@ jobs:
         run: ./gradlew testDemoDebug :lint:test
 
       - name: Build all build type and flavor permutations
-        run: ./gradlew :app:assemble
+        run: ./gradlew :app:assemble -PminifyWithR8=false
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,8 @@ android {
             applicationIdSuffix = NiaBuildType.DEBUG.applicationIdSuffix
         }
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = providers.gradleProperty("minifyWithR8")
+                .map(String::toBooleanStrict).getOrElse(true)
             applicationIdSuffix = NiaBuildType.RELEASE.applicationIdSuffix
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"),
                           "proguard-rules.pro")


### PR DESCRIPTION
R8 minification is currently wasting a lot of CPU time for no real benefit.

For instance, in [this Gradle Scan](https://scans.gradle.com/s/fd7nnail7weeu/timeline?name=minify), the total amount spent is ~11 minutes (half for the actual wall time since we have 2 workers, but they are on the critical path).

This PR is adding a `minifyWithR8` Gradle property to allow disabling the minification step for PRs builds.

The minification is still enabled by default (e.g. on `Release.yml` and `NightlyBaselineProfiles.yaml`).
