### PR TITLE
Disable Gradle parallel execution

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,8 @@ kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSP
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-org.gradle.parallel=true
+# Currently this is disabled as it causes problems in some setups, e.g. https://github.com/microsoft/vscode-gradle/issues/1712
+org.gradle.parallel=false
 
 # Not encouraged by Gradle and can produce weird results. Wait for isolated projects instead.
 org.gradle.configureondemand=false


### PR DESCRIPTION
Since the move to Gradle 9 this seems to cause breakage in some setups, e.g. microsoft/vscode-gradle#1712.
