### PR TITLE
Fix #1984 where TestMethodNameDetector does not scan some tests

### DIFF
--- a/lint/src/main/kotlin/com/google/samples/apps/nowinandroid/lint/TestMethodNameDetector.kt
+++ b/lint/src/main/kotlin/com/google/samples/apps/nowinandroid/lint/TestMethodNameDetector.kt
@@ -18,6 +18,7 @@ package com.google.samples.apps.nowinandroid.lint
 
 import com.android.tools.lint.detector.api.AnnotationInfo
 import com.android.tools.lint.detector.api.AnnotationUsageInfo
+import com.android.tools.lint.detector.api.AnnotationUsageType
 import com.android.tools.lint.detector.api.Category.Companion.TESTING
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Implementation
@@ -31,6 +32,7 @@ import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.android.tools.lint.detector.api.TextFormat.RAW
 import com.intellij.psi.PsiMethod
 import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UMethod
 import java.util.EnumSet
 import kotlin.io.path.Path
 
@@ -43,13 +45,18 @@ class TestMethodNameDetector : Detector(), SourceCodeScanner {
 
     override fun applicableAnnotations() = listOf("org.junit.Test")
 
+    // Restrict this detector to `AnnotationUsageType.DEFINITION` following
+    // similar examples in AOSP like `IgnoreWithoutReasonDetector`.
+    override fun isApplicableAnnotationUsage(type: AnnotationUsageType): Boolean =
+        type == AnnotationUsageType.DEFINITION
+
     override fun visitAnnotationUsage(
         context: JavaContext,
         element: UElement,
         annotationInfo: AnnotationInfo,
         usageInfo: AnnotationUsageInfo,
     ) {
-        val method = usageInfo.referenced as? PsiMethod ?: return
+        val method = annotationInfo.annotation.uastParent as? UMethod ?: return
 
         method.detectPrefix(context, usageInfo)
         method.detectFormat(context, usageInfo)

--- a/lint/src/test/kotlin/com/google/samples/apps/nowinandroid/lint/TestMethodNameDetectorTest.kt
+++ b/lint/src/test/kotlin/com/google/samples/apps/nowinandroid/lint/TestMethodNameDetectorTest.kt
@@ -40,6 +40,11 @@ class TestMethodNameDetectorTest {
                         fun test_foo() = Unit
                         @Test
                         fun `test foo`() = Unit
+
+                        @Test
+                        fun test_foo2() {
+                            // Blank body.
+                        }
                     }
                 """,
                 ).indented(),
@@ -53,19 +58,26 @@ class TestMethodNameDetectorTest {
                 src/Test.kt:8: Warning: Test method starts with test [TestMethodPrefix]
                     fun `test foo`() = Unit
                         ~~~~~~~~~~
-                0 errors, 2 warnings
+                src/Test.kt:11: Warning: Test method starts with test [TestMethodPrefix]
+                    fun test_foo2() {
+                        ~~~~~~~~~
+                0 errors, 3 warnings
                 """.trimIndent(),
             )
             .expectFixDiffs(
                 """
                 Autofix for src/Test.kt line 6: Remove prefix:
-                @@ -6 +6
-                -     fun test_foo() = Unit
-                +     fun foo() = Unit
+                @@ -6 +6 @@
+                -    fun test_foo() = Unit
+                +    fun foo() = Unit
                 Autofix for src/Test.kt line 8: Remove prefix:
-                @@ -8 +8
-                -     fun `test foo`() = Unit
-                +     fun `foo`() = Unit
+                @@ -8 +8 @@
+                -    fun `test foo`() = Unit
+                +    fun `foo`() = Unit
+                Autofix for src/Test.kt line 11: Remove prefix:
+                @@ -11 +11 @@
+                -    fun test_foo2() {
+                +    fun foo2() {
                 """.trimIndent(),
             )
     }


### PR DESCRIPTION
**What I have done and why**

Fix #1984 where `TestMethodNameDetector` does not scan some tests.

The reason this is happening is because the annotations in the unit tests are of usage type `AnnotationUsageType.DEFINTION` but the detector does not opt in to scan these.

I have based my solution on [`IgnoreWithoutReasonDetector`](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:lint/libs/lint-checks/src/main/java/com/android/tools/lint/checks/IgnoreWithoutReasonDetector.kt;l=40) which is conceptually similar.