### PR TITLE
[Bug Fix]: Fixed text color updates on cards after light<>dark mode c…

### DIFF
--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
@@ -46,6 +46,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -53,6 +54,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draganddrop.DragAndDropTransferData
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
@@ -88,6 +90,31 @@ import java.util.Locale
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun NewsResourceCardExpanded(
+    userNewsResource: UserNewsResource,
+    isBookmarked: Boolean,
+    hasBeenViewed: Boolean,
+    onToggleBookmark: () -> Unit,
+    onClick: () -> Unit,
+    onTopicClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val onSurfaceColor = MaterialTheme.colorScheme.onSurface.toArgb()
+
+    key(onSurfaceColor) {
+        NewsResourceCardExpandedContent(
+            userNewsResource = userNewsResource,
+            isBookmarked = isBookmarked,
+            hasBeenViewed = hasBeenViewed,
+            onToggleBookmark = onToggleBookmark,
+            onClick = onClick,
+            onTopicClick = onTopicClick,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun NewsResourceCardExpandedContent(
     userNewsResource: UserNewsResource,
     isBookmarked: Boolean,
     hasBeenViewed: Boolean,


### PR DESCRIPTION
**What I have done and why**

*Problem*
When switching between light and dark themes in the Settings dialog, text colors on news cards (in "For You" and "Saved" tabs) were not updating immediately. Users had to scroll away and back for the colors to refresh.

*Solution*
Added a key() wrapper around the NewsResourceCardExpanded content that observes the theme's onSurface color

References:
https://github.com/android/nowinandroid/issues/1892

Before:

https://github.com/user-attachments/assets/ea5179e8-7129-4e23-9df4-f6d96852ca46

After:

https://github.com/user-attachments/assets/53e15214-6e04-4687-b87f-f4e4cd2eb5c2




