### PR TITLE
[Bug Fix]: Fixed text color updates on cards after light<>dark mode c…

### DIFF
--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsResourceCard.kt
@@ -46,6 +46,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -53,6 +54,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draganddrop.DragAndDropTransferData
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
@@ -88,6 +90,31 @@ import java.util.Locale
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun NewsResourceCardExpanded(
+    userNewsResource: UserNewsResource,
+    isBookmarked: Boolean,
+    hasBeenViewed: Boolean,
+    onToggleBookmark: () -> Unit,
+    onClick: () -> Unit,
+    onTopicClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val onSurfaceColor = MaterialTheme.colorScheme.onSurface.toArgb()
+
+    key(onSurfaceColor) {
+        NewsResourceCardExpandedContent(
+            userNewsResource = userNewsResource,
+            isBookmarked = isBookmarked,
+            hasBeenViewed = hasBeenViewed,
+            onToggleBookmark = onToggleBookmark,
+            onClick = onClick,
+            onTopicClick = onTopicClick,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun NewsResourceCardContent(
     userNewsResource: UserNewsResource,
     isBookmarked: Boolean,
     hasBeenViewed: Boolean,


### PR DESCRIPTION
**What I have done and why**

*Problem*
When switching between light and dark themes in the Settings dialog, text colors on news cards (in "For You" and "Saved" tabs) were not updating immediately. Users had to scroll away and back for the colors to refresh.

*Solution*
Added a key() wrapper around the NewsResourceCardExpanded content that observes the theme's onSurface color

*References*
https://github.com/android/nowinandroid/issues/1892

Before:

https://github.com/user-attachments/assets/6a32b9aa-e5ec-4499-9d90-6fb929a60684

After:

https://github.com/user-attachments/assets/fbd152d3-4681-453a-9f7f-eadb477d11bc

