### PR TITLE
Bump number of core on CI emulator

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -241,6 +241,8 @@ jobs:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
           disable-animations: true
+          # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+          # Number of core of default public repository github action runner is 4 in all.
           cores: 4
           disk-size: 6000M
           heap-size: 600M


### PR DESCRIPTION
**What I have done and why**

This PR follows up #1816.

The standard public repository runner has 4 cores, so that I use that all cores as running emulator on github action.

Number of core documentation.
https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories


<img width="774" height="593" alt="image" src="https://github.com/user-attachments/assets/83e6f5ea-05ef-43d6-a562-dc93a1c56696" />
