### PR TITLE
Replace `Enum.values()` with `Enum.entries`

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaFlavor.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/NiaFlavor.kt
@@ -24,12 +24,12 @@ fun configureFlavors(
     flavorConfigurationBlock: ProductFlavor.(flavor: NiaFlavor) -> Unit = {},
 ) {
     commonExtension.apply {
-        FlavorDimension.values().forEach { flavorDimension ->
+        FlavorDimension.entries.forEach { flavorDimension ->
             flavorDimensions += flavorDimension.name
         }
 
         productFlavors {
-            NiaFlavor.values().forEach { niaFlavor ->
+            NiaFlavor.entries.forEach { niaFlavor ->
                 register(niaFlavor.name) {
                     dimension = niaFlavor.dimension.name
                     flavorConfigurationBlock(this, niaFlavor)


### PR DESCRIPTION
> 'Enum.values()' is recommended to be replaced by 'Enum.entries' since 1.9

... started in #1120