### PR TITLE
fix: typo in README.md for 'analyze'

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Then copy the resulting baseline profile from the emulator to [`app/src/main/bas
 
 ## Compose compiler metrics
 
-Run the following command to get and analyse compose compiler metrics:
+Run the following command to get and analyze compose compiler metrics:
 
 ```bash
 ./gradlew assembleRelease -PenableComposeCompilerMetrics=true -PenableComposeCompilerReports=true


### PR DESCRIPTION
**What I have done and why**

I have fixed a spelling mistake in Readme.md file for the word 'analyse' because we are using American English in our documentation so 'analyse' is for British English and 'analyze' is for American English.
