### PR TITLE
Remove ComposableModifierFactory suppress lint

### DIFF
--- a/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
+++ b/core/designsystem/src/main/kotlin/com/google/samples/apps/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
@@ -164,9 +164,6 @@ private fun ScrollableState.DecorativeScrollbarThumb(
     )
 }
 
-// TODO: This lint is removed in 1.6 as the recommendation has changed
-// remove when project is upgraded
-@SuppressLint("ComposableModifierFactory")
 @Composable
 private fun Modifier.scrollThumb(
     scrollableState: ScrollableState,


### PR DESCRIPTION
**What I have done and why**

I removed the `ComposableModifierFactory` lint suppression because it no longer reports an error.

This lint warning was removed after the official recommendation for custom modifiers changed.

Reference : [Custom modifier documentation](https://developer.android.com/develop/ui/compose/custom-modifiers)