### PR TITLE
Fix android#1982: Improved ConnectivityManagerNetworkMonitor

### DIFF
--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
@@ -22,7 +22,6 @@ import android.net.ConnectivityManager.NetworkCallback
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
-import android.net.NetworkRequest.Builder
 import androidx.core.content.getSystemService
 import androidx.tracing.trace
 import com.google.samples.apps.nowinandroid.core.network.Dispatcher
@@ -33,12 +32,13 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 internal class ConnectivityManagerNetworkMonitor @Inject constructor(
-    @ApplicationContext private val context: Context,
-    @Dispatcher(IO) private val ioDispatcher: CoroutineDispatcher,
+    @param:ApplicationContext private val context: Context,
+    @param:Dispatcher(IO) private val ioDispatcher: CoroutineDispatcher,
 ) : NetworkMonitor {
     override val isOnline: Flow<Boolean> = callbackFlow {
         trace("NetworkMonitor.callbackFlow") {
@@ -69,8 +69,12 @@ internal class ConnectivityManagerNetworkMonitor @Inject constructor(
             }
 
             trace("NetworkMonitor.registerNetworkCallback") {
-                val request = Builder()
+                val request = NetworkRequest.Builder()
                     .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                    .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                    .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+                    .addTransportType(NetworkCapabilities.TRANSPORT_ETHERNET)
                     .build()
                 connectivityManager.registerNetworkCallback(request, callback)
             }
@@ -87,9 +91,31 @@ internal class ConnectivityManagerNetworkMonitor @Inject constructor(
     }
         .flowOn(ioDispatcher)
         .conflate()
+        .distinctUntilChanged()
 
     private fun ConnectivityManager.isCurrentlyConnected(): Boolean {
-        val networkCapabilities = getNetworkCapabilities(activeNetwork) ?: return false
-        return networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        val network = activeNetwork ?: return false
+        val capabilities = getNetworkCapabilities(network) ?: return false
+
+        return hasInternetCapability(capabilities) &&
+            isValidated(capabilities) &&
+            hasSupportedTransport(capabilities)
+    }
+
+    private fun hasInternetCapability(capabilities: NetworkCapabilities): Boolean {
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+
+    private fun isValidated(capabilities: NetworkCapabilities): Boolean {
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
+
+    private fun hasSupportedTransport(capabilities: NetworkCapabilities): Boolean {
+        val supportedTransports = setOf(
+            NetworkCapabilities.TRANSPORT_WIFI,
+            NetworkCapabilities.TRANSPORT_CELLULAR,
+            NetworkCapabilities.TRANSPORT_ETHERNET,
+        )
+        return supportedTransports.any(capabilities::hasTransport)
     }
 }


### PR DESCRIPTION
## What I have done and why

**Fix #1982: Align NetworkRequest and improve transport check readability**

### Changes

1. **Added NET_CAPABILITY_VALIDATED** and transport type checks to `ConnectivityManagerNetworkMonitor`:
   - Ensures the network is actually validated and provides real internet connectivity.
   - Only supports Wi-Fi, Cellular, and Ethernet transports to avoid false positives from other transports like VPN or peer-to-peer networks.

2. **Updated NetworkRequest in registerNetworkCallback**:
   - Constrained to the same transports as `isCurrentlyConnected()` for consistency.
   - Prevents inconsistent flow emissions when network types mismatch.

3. **Refactored transport check logic**:
   - Created a `hasSupportedTransport()` helper.
   - Uses a set and `any()` for cleaner, more maintainable code.

4. **Added `distinctUntilChanged()` to the flow**:
   - Prevents duplicate emissions when connectivity state hasn't actually changed.
   - Reduces unnecessary recompositions or downstream processing.

### Motivation

- Previously, `isCurrentlyConnected()` and `NetworkRequest` used in the callback could disagree on connectivity state.
- This could lead to emitting `true` for networks that are not actually usable for internet access.
- Improving readability and maintainability helps future developers adjust supported transport types easily.

### Additional Context

- See [Android NET_CAPABILITY_VALIDATED documentation](https://developer.android.com/reference/android/net/NetworkCapabilities#NET_CAPABILITY_VALIDATED)
- Inspired by recommendations for reliable connectivity checks on Android 15+ ([Medium Guide](https://medium.com/@doronkakuli/adapting-your-network-connectivity-checks-for-android-15-a-practical-guide-2b1850619294))