### PR TITLE
feat: updates `@DevicePreviews` to use the Devices object constants

### DIFF
--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/DevicePreviews.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/DevicePreviews.kt
@@ -16,14 +16,15 @@
 
 package com.google.samples.apps.nowinandroid.core.ui
 
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 
 /**
  * Multipreview annotation that represents various device sizes. Add this annotation to a composable
  * to render various devices.
  */
-@Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
-@Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
-@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
-@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
+@Preview(name = "phone", device = Devices.PHONE, showBackground = true)
+@Preview(name = "foldable", device = Devices.FOLDABLE, showBackground = true)
+@Preview(name = "tablet", device = Devices.TABLET, showBackground = true)
+@Preview(name = "desktop", device = Devices.DESKTOP, showBackground = true)
 annotation class DevicePreviews

--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/DevicePreviews.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/DevicePreviews.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
  * to render various devices.
  */
 @Preview(name = "phone", device = Devices.PHONE, showBackground = true)
+@Preview(name = "phone_in_landscape", widthDp = 891, heightDp = 411, showBackground = true)
 @Preview(name = "foldable", device = Devices.FOLDABLE, showBackground = true)
 @Preview(name = "tablet", device = Devices.TABLET, showBackground = true)
 @Preview(name = "desktop", device = Devices.DESKTOP, showBackground = true)


### PR DESCRIPTION
**What I have done and why**

- The `@DevicePreviews` annotation didn't show different form factors; they were always portrait. I changed the annotation so that it uses the constants from the [`Devices`](https://developer.android.com/reference/kotlin/androidx/compose/ui/tooling/preview/Devices#device()) object.

This is the existing behavior for previews (from InterestsScreen): 

<img width="470" height="497" alt="image" src="https://github.com/user-attachments/assets/06a5186d-b912-4561-8a24-48fd7e3e8293" />

