### PR TITLE
Remove manual Protobuf source sets #2050

### DIFF
--- a/core/datastore-proto/build.gradle.kts
+++ b/core/datastore-proto/build.gradle.kts
@@ -42,14 +42,6 @@ protobuf {
     }
 }
 
-androidComponents.beforeVariants {
-    android.sourceSets.register(it.name) {
-        val buildDir = layout.buildDirectory.get().asFile
-        java.srcDir(buildDir.resolve("generated/source/proto/${it.name}/java"))
-        kotlin.srcDir(buildDir.resolve("generated/source/proto/${it.name}/kotlin"))
-    }
-}
-
 dependencies {
     api(libs.protobuf.kotlin.lite)
 }


### PR DESCRIPTION
Fixes #2050 
Removed manual source set registration for Protobuf. 


This is the description of the solution:

The `protobuf-gradle-plugin` (version 0.9.5) automatically handles adding generated sources to the appropriate Android source sets. Using `android.sourceSets.register(it.name)` could have been causing the Kotlin compiler to see the same generated files twice.

[Protobuf release update](https://github.com/google/protobuf-gradle-plugin/releases/tag/v0.9.5)
**Change default output folder to Gradle best practices (generated/sources/proto; plural, not singular)**
