### PR TITLE
Sync dark theme preference to UiModeManager for splash screen

### DIFF
--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/MainActivity.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/MainActivity.kt
@@ -135,13 +135,13 @@ class MainActivity : ComponentActivity() {
         // Sync the user's dark theme preference to the system-level UiModeManager so the
         // splash screen uses the correct theme on the next cold start.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val uiModeManager = getSystemService(UiModeManager::class.java)
             lifecycleScope.launch {
                 lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                     viewModel.uiState
                         .mapNotNull { (it as? Success)?.userData?.darkThemeConfig }
                         .distinctUntilChanged()
                         .collect { darkThemeConfig ->
-                            val uiModeManager = getSystemService(UiModeManager::class.java)
                             uiModeManager.setApplicationNightMode(
                                 when (darkThemeConfig) {
                                     DarkThemeConfig.FOLLOW_SYSTEM -> UiModeManager.MODE_NIGHT_AUTO


### PR DESCRIPTION
## Summary

- Syncs the user's `DarkThemeConfig` preference to `UiModeManager.setApplicationNightMode()` so the splash screen uses the correct theme on the next cold start
- Without this fix, selecting "Dark" in the app settings still shows a light splash screen on relaunch, causing a visual flash
- Guarded behind `Build.VERSION_CODES.S` (API 31+) since `setApplicationNightMode` was introduced there

## Details

On cold start, the Android splash screen theme is determined by the system-level `UiModeManager` night mode, not by the in-app Compose theme. The app already correctly applies the user's dark theme preference to edge-to-edge styling and `NiaTheme`, but never communicated this preference back to the system.

This adds a lifecycle-aware `Flow` collector in `MainActivity.onCreate()` that:
1. Observes `MainActivityUiState` for the user's `DarkThemeConfig`
2. Maps it to the corresponding `UiModeManager` night mode constant
3. Calls `setApplicationNightMode()` to keep the system in sync

Uses `distinctUntilChanged()` to avoid redundant system calls and `mapNotNull` to skip the `Loading` state.

## Test plan

- [x] Build succeeds (`./gradlew :app:installDemoDebug`)
- [x] App launches without crashes on API 36 emulator
- [x] No logcat errors related to `UiModeManager`
- [ ] Manual: Set theme to Dark → force stop → cold launch → splash screen should be dark
- [ ] Manual: Set theme to Light → force stop → cold launch → splash screen should be light
- [ ] Manual: Set theme to Follow System → verify splash follows system setting
- [ ] Verify no behavior change on API < 31 (code is guarded)