### PR TITLE
Use `org.jetbrains.kotlin.jvm` instead of `kotlin-dsl`

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -14,26 +14,29 @@
  * limitations under the License.
  */
 
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
-    `kotlin-dsl`
+    alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.android.lint)
+    alias(libs.plugins.tapmoc)
+    alias(libs.plugins.kotlin.sam.with.receiver)
+    alias(libs.plugins.kotlin.assignment)
+    id("java-gradle-plugin")
+}
+
+samWithReceiver {
+    annotation(HasImplicitReceiver::class.qualifiedName!!)
+}
+assignment {
+    annotation(SupportsKotlinAssignmentOverloading::class.qualifiedName!!)
 }
 
 group = "com.google.samples.apps.nowinandroid.buildlogic"
 
-// Configure the build-logic plugins to target JDK 17
-// This matches the JDK used to build the project, and is not related to what is running on device.
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-}
-
-kotlin {
-    compilerOptions {
-        jvmTarget = JvmTarget.JVM_17
-    }
+tapmoc {
+    /**
+     * Configure Java and Kotlin compatibility according to our Gradle version
+     */
+    gradle(gradle.gradleVersion)
 }
 
 dependencies {
@@ -46,6 +49,7 @@ dependencies {
     compileOnly(libs.ksp.gradlePlugin)
     compileOnly(libs.room.gradlePlugin)
     compileOnly(libs.spotless.gradlePlugin)
+    compileOnly(gradleKotlinDsl())
     implementation(libs.truth)
     lintChecks(libs.androidx.lint.gradle)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ robolectric = "4.16"
 roborazzi = "1.56.0"
 room = "2.8.3"
 spotless = "8.2.1"
+tapmoc = "0.4.0"
 truth = "1.4.4"
 turbine = "1.2.0"
 uiTestJunit4 = "1.9.0-rc01"
@@ -189,12 +190,15 @@ gms = { id = "com.google.gms.google-services", version.ref = "gmsPlugin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlin-sam-with-receiver = { id = "org.jetbrains.kotlin.plugin.sam.with.receiver", version.ref = "kotlin" }
+kotlin-assignment = { id = "org.jetbrains.kotlin.plugin.assignment", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 google-osslicenses = { id = "com.google.android.gms.oss-licenses-plugin", version.ref = "googleOssPlugin" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
 roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }
 room = { id = "androidx.room", version.ref = "room" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+tapmoc = { id = "com.gradleup.tapmoc", version.ref = "tapmoc" }
 
 # Plugins defined by this project
 nowinandroid-android-application = { id = "nowinandroid.android.application" }


### PR DESCRIPTION
Opening this as reference for anyone curious what's going on under the `` `kotlin-dsl` `` hood. 

Feel free to merge or discard this PR. 

For more context, you can also read [this blog post](https://mbonnin.net/2025-07-10_the_case_against_kotlin_dsl/).

The immediate benefits in this repo aren't huge. The main one is to be able to use [newer tooling without having to wait](https://blog.alllex.me/posts/2023-11-03-liberal-library-tooling/) for Gradle to integrate newer versions of Kotlin. As of today, this effectively allows to use KGP `2.3` in `build-logic` instead of KGP `2.2`. 

Also, since [precompiled scripts plugins are not used anymore](https://github.com/android/nowinandroid/pull/38), this removes that code from build logic and makes it a tiny bit slimmer (I didn't notice any real performance improvement).

If there is interest, I can also make a follow up PR to make build-logic even slimmer and removes `sam-with-receiver`, `assignment` and `gradleKotlinDsl()`. That will also make the Kotlin code in `build-logic` closer to everyday Kotlin.