### PR TITLE
Return immutable `List` instead of `SnapshotStateList` from `toEntries`

### DIFF
--- a/core/navigation/src/main/kotlin/com/google/samples/apps/nowinandroid/core/navigation/NavigationState.kt
+++ b/core/navigation/src/main/kotlin/com/google/samples/apps/nowinandroid/core/navigation/NavigationState.kt
@@ -21,8 +21,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshots.SnapshotStateList
-import androidx.compose.runtime.toMutableStateList
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavEntry
@@ -83,7 +81,7 @@ class NavigationState(
 @Composable
 fun NavigationState.toEntries(
     entryProvider: (NavKey) -> NavEntry<NavKey>,
-): SnapshotStateList<NavEntry<NavKey>> {
+): List<NavEntry<NavKey>> {
     val decoratedEntries = subStacks.mapValues { (_, stack) ->
         val decorators = listOf(
             rememberSaveableStateHolderNavEntryDecorator<NavKey>(),
@@ -98,5 +96,4 @@ fun NavigationState.toEntries(
 
     return topLevelStack
         .flatMap { decoratedEntries[it] ?: emptyList() }
-        .toMutableStateList()
 }


### PR DESCRIPTION
**What I have done and why**

This PR changes `toEntries` to return an immutable `List` instead of `SnapshotStateList`.

Mutating the returned list does not affect `NavigationState`, so exposing a mutable state list may be misleading.

There is no functional behavior change.

Similar change: https://github.com/android/nav3-recipes/pull/234
