### PR TITLE
 Fix incorrect back navigation to ForYou instead of Topic screen (#1866)

### DIFF
--- a/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
+++ b/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
@@ -46,7 +46,6 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import javax.inject.Inject
@@ -255,9 +254,6 @@ class NavigationTest {
         }
     }
 
-    // TODO decide if backStack should preserve previous stacks when navigating back to home tab (ForYou)
-    // https://github.com/android/nowinandroid/issues/1937
-    @Ignore
     @Test
     fun navigationBar_multipleBackStackInterests() {
         composeTestRule.apply {
@@ -279,6 +275,32 @@ class NavigationTest {
             onNodeWithText(interests).performClick()
 
             // Verify the topic is still shown
+            onNodeWithTag("topic:${topic.id}").assertExists()
+        }
+    }
+
+    @Test
+    fun navigationBar_backFromTabPreservesSubStack() {
+        composeTestRule.apply {
+            onNodeWithText(interests).performClick()
+
+            // Select a topic
+            val topic = runBlocking {
+                topicsRepository.getTopics().first().sortedBy(Topic::name).last()
+            }
+            onNodeWithTag(LIST_PANE_TEST_TAG).performScrollToNode(hasText(topic.name))
+            onNodeWithText(topic.name).performClick()
+
+            // Verify the topic is shown
+            onNodeWithTag("topic:${topic.id}").assertIsDisplayed()
+
+            // Switch to another tab
+            onNodeWithText(saved).performClick()
+
+            // Press back to return to previous tab
+            Espresso.pressBack()
+
+            // Verify the topic detail is still shown (sub-stack preserved)
             onNodeWithTag("topic:${topic.id}").assertExists()
         }
     }

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
@@ -16,6 +16,7 @@
 
 package com.google.samples.apps.nowinandroid.ui
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
@@ -264,8 +265,16 @@ internal fun NiaApp(
                         searchEntry(navigator)
                     }
 
+                    val navigationState = appState.navigationState
+                    BackHandler(
+                        enabled = navigationState.currentKey == navigationState.currentTopLevelKey &&
+                            navigationState.currentTopLevelKey != navigationState.startKey,
+                    ) {
+                        navigator.goBack()
+                    }
+
                     NavDisplay(
-                        entries = appState.navigationState.toEntries(entryProvider),
+                        entries = navigationState.toEntries(entryProvider),
                         sceneStrategy = listDetailStrategy,
                         onBack = { navigator.goBack() },
                     )

--- a/core/navigation/src/main/kotlin/com/google/samples/apps/nowinandroid/core/navigation/NavigationState.kt
+++ b/core/navigation/src/main/kotlin/com/google/samples/apps/nowinandroid/core/navigation/NavigationState.kt
@@ -96,7 +96,5 @@ fun NavigationState.toEntries(
         )
     }
 
-    return topLevelStack
-        .flatMap { decoratedEntries[it] ?: emptyList() }
-        .toMutableStateList()
+    return (decoratedEntries[currentTopLevelKey] ?: emptyList()).toMutableStateList()
 }

--- a/core/navigation/src/test/kotlin/com/google/samples/apps/nowinandroid/core/navigation/NavigatorTest.kt
+++ b/core/navigation/src/test/kotlin/com/google/samples/apps/nowinandroid/core/navigation/NavigatorTest.kt
@@ -248,6 +248,32 @@ class NavigatorTest {
     }
 
     @Test
+    fun testSubStackPreservedAfterTabSwitchAndBack() {
+        // Navigate to sub-page in first tab (ForYou → Topic)
+        navigator.navigate(TestKeyFirst)
+
+        assertThat(navigationState.currentKey).isEqualTo(TestKeyFirst)
+        assertThat(navigationState.currentTopLevelKey).isEqualTo(TestFirstTopLevelKey)
+
+        // Switch to second tab (e.g. Bookmarks)
+        navigator.navigate(TestSecondTopLevelKey)
+
+        assertThat(navigationState.currentKey).isEqualTo(TestSecondTopLevelKey)
+        assertThat(navigationState.currentTopLevelKey).isEqualTo(TestSecondTopLevelKey)
+
+        // Press back from second tab
+        navigator.goBack()
+
+        // Should return to first tab with sub-stack preserved
+        assertThat(navigationState.currentTopLevelKey).isEqualTo(TestFirstTopLevelKey)
+        assertThat(navigationState.currentKey).isEqualTo(TestKeyFirst)
+        assertThat(navigationState.currentSubStack).containsExactly(
+            TestFirstTopLevelKey,
+            TestKeyFirst,
+        ).inOrder()
+    }
+
+    @Test
     fun throwOnEmptyBackStack() {
         assertFailsWith<IllegalStateException> {
             navigator.goBack()


### PR DESCRIPTION

  - Fix cross-tab back navigation losing sub-stack state — pressing back after switching tabs now correctly returns to the previously viewed sub-page (e.g. Topic detail)
  instead of the tab root (ForYou)
  - Change toEntries() to only pass the current tab's entries to NavDisplay, preventing ListDetailSceneStrategy from mis-rendering after cross-tab transitions
  - Add BackHandler for tab-level back navigation since NavDisplay now only sees within-tab entries

  Root Cause

  toEntries() in NavigationState.kt flattened all tab sub-stacks into a single entries list. When pressing back from another tab, entries transitioned from [ForYouEntry,
  TopicEntry, BookmarksEntry] to [ForYouEntry, TopicEntry], but ListDetailSceneStrategy failed to re-render the detail pane correctly because ForYouEntry lacks pane
  metadata while TopicEntry has detailPane() metadata.

  Test plan

  - Unit test added: testSubStackPreservedAfterTabSwitchAndBack in NavigatorTest.kt
  - Un-ignored navigationBar_multipleBackStackInterests instrumented test
  - Added navigationBar_backFromTabPreservesSubStack instrumented test with system back button
  - Manual verification: ForYou → tap topic → switch to Bookmarks → press back → Topic screen should be visible

  Fixes #1866
