### PR TITLE
Make isolated projects mode pass without issues

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -21,12 +21,16 @@ import com.google.samples.apps.nowinandroid.configureGradleManagedDevices
 import com.google.samples.apps.nowinandroid.configureKotlinAndroid
 import com.google.samples.apps.nowinandroid.configurePrintApksTask
 import com.google.samples.apps.nowinandroid.configureSpotlessForAndroid
+import com.google.samples.apps.nowinandroid.isIsolatedProjectsEnabled
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.configuration.BuildFeatures
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
+import javax.inject.Inject
 
-class AndroidApplicationConventionPlugin : Plugin<Project> {
+abstract class AndroidApplicationConventionPlugin : Plugin<Project> {
+    @get:Inject abstract val buildFeatures: BuildFeatures
     override fun apply(target: Project) {
         with(target) {
             apply(plugin = "com.android.application")
@@ -43,7 +47,9 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 configurePrintApksTask(this)
                 configureBadgingTasks(this)
             }
-            configureSpotlessForAndroid()
+            if (!buildFeatures.isIsolatedProjectsEnabled()) {
+                configureSpotlessForAndroid()
+            }
         }
     }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -22,14 +22,18 @@ import com.google.samples.apps.nowinandroid.configureKotlinAndroid
 import com.google.samples.apps.nowinandroid.configurePrintApksTask
 import com.google.samples.apps.nowinandroid.configureSpotlessForAndroid
 import com.google.samples.apps.nowinandroid.disableUnnecessaryAndroidTests
+import com.google.samples.apps.nowinandroid.isIsolatedProjectsEnabled
 import com.google.samples.apps.nowinandroid.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.configuration.BuildFeatures
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
+import javax.inject.Inject
 
-class AndroidLibraryConventionPlugin : Plugin<Project> {
+abstract class AndroidLibraryConventionPlugin : Plugin<Project> {
+    @get:Inject abstract val buildFeatures: BuildFeatures
     override fun apply(target: Project) {
         with(target) {
             apply(plugin = "com.android.library")
@@ -53,7 +57,9 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 configurePrintApksTask(this)
                 disableUnnecessaryAndroidTests(target)
             }
-            configureSpotlessForAndroid()
+            if (!buildFeatures.isIsolatedProjectsEnabled()) {
+                configureSpotlessForAndroid()
+            }
             dependencies {
                 "androidTestImplementation"(libs.findLibrary("kotlin.test").get())
                 "testImplementation"(libs.findLibrary("kotlin.test").get())

--- a/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
@@ -16,20 +16,26 @@
 
 import com.google.samples.apps.nowinandroid.configureKotlinJvm
 import com.google.samples.apps.nowinandroid.configureSpotlessForJvm
+import com.google.samples.apps.nowinandroid.isIsolatedProjectsEnabled
 import com.google.samples.apps.nowinandroid.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.configuration.BuildFeatures
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.dependencies
+import javax.inject.Inject
 
-class JvmLibraryConventionPlugin : Plugin<Project> {
+abstract class JvmLibraryConventionPlugin : Plugin<Project> {
+    @get:Inject abstract val buildFeatures: BuildFeatures
     override fun apply(target: Project) {
         with(target) {
             apply(plugin = "org.jetbrains.kotlin.jvm")
             apply(plugin = "nowinandroid.android.lint")
 
             configureKotlinJvm()
-            configureSpotlessForJvm()
+            if (!buildFeatures.isIsolatedProjectsEnabled()) {
+                configureSpotlessForJvm()
+            }
             dependencies {
                 "testImplementation"(libs.findLibrary("kotlin.test").get())
             }

--- a/build-logic/convention/src/main/kotlin/RootPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/RootPlugin.kt
@@ -16,13 +16,20 @@
 
 import com.google.samples.apps.nowinandroid.configureGraphTasks
 import com.google.samples.apps.nowinandroid.configureSpotlessForRootProject
+import com.google.samples.apps.nowinandroid.isIsolatedProjectsEnabled
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.configuration.BuildFeatures
+import javax.inject.Inject
 
-class RootPlugin : Plugin<Project> {
+abstract class RootPlugin : Plugin<Project> {
+    @get:Inject abstract val buildFeatures: BuildFeatures
+
     override fun apply(target: Project) {
         require(target.path == ":")
-        target.subprojects { configureGraphTasks() }
-        target.configureSpotlessForRootProject()
+        if (!buildFeatures.isIsolatedProjectsEnabled()) {
+            target.subprojects { configureGraphTasks() }
+            target.configureSpotlessForRootProject()
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/ProjectIsolation.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/ProjectIsolation.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.nowinandroid
+
+import org.gradle.api.configuration.BuildFeatures
+
+fun BuildFeatures.isIsolatedProjectsEnabled(): Boolean {
+    return isolatedProjects.active.orElse(false).get()
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -63,3 +63,5 @@ roborazzi.test.verify=true
 # Prevent uninstall app after instrumented tests
 # https://issuetracker.google.com/issues/295039976
 android.injected.androidTest.leaveApksInstalledAfterRun=true
+
+ksp.project.isolation.enabled=true


### PR DESCRIPTION
- Enable KSP isolated projects support https://github.com/google/ksp/issues/1752
- Disable spotless in isolated projects mode https://github.com/diffplug/spotless/issues/1979
- Disable graph tasks in isolated projects mode

https://github.com/android/nowinandroid/issues/1842

Test: ./gradlew build -Dorg.gradle.unsafe.isolated-projects=true --dry-run
