### PR TITLE
Replace apk to aab.

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test_and_apk:
-    name: "Local tests and APKs"
+  test_and_aab:
+    name: "Local tests and AABs"
     runs-on: ubuntu-latest
 
     permissions:
@@ -134,13 +134,13 @@ jobs:
         run: ./gradlew testDemoDebug :lint:test
 
       - name: Build all build type and flavor permutations
-        run: ./gradlew :app:assemble -PminifyWithR8=false
+        run: ./gradlew :app:bundle -PminifyWithR8=false
 
-      - name: Upload build outputs (APKs)
+      - name: Upload build outputs (AABs)
         uses: actions/upload-artifact@v4
         with:
-          name: APKs
-          path: '**/build/outputs/apk/**/*.apk'
+          name: AABs
+          path: '**/build/outputs/bundle/**/*.aab'
 
       - name: Upload JVM local results (XML)
         if: ${{ !cancelled() }}

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -54,7 +54,7 @@ jobs:
           -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect"
 
       - name: Build release variant including baseline profile generation
-        run: ./gradlew :app:assembleDemoRelease
+        run: ./gradlew :app:bundleDemoRelease
              -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile
              -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect"
              -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true
@@ -77,6 +77,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: app/build/outputs/apk/demo/release/app-demo-release.apk
-          asset_name: app-demo-release.apk
+          asset_path: app/build/outputs/bundle/demoRelease/app-demo-release.aab
+          asset_name: app-demo-release.aab
           asset_content_type: application/vnd.android.package-archive


### PR DESCRIPTION
**What I have done and why**

Nowadays Google play console requires an AAB, not APK.
It seems that doesn't make sense to build test on APK at CI.

https://developer.android.com/studio/publish
<img width="897" height="188" alt="image" src="https://github.com/user-attachments/assets/4312e8f0-4b8f-478e-ba01-65dc7f5933e2" />
