### PR TITLE
build(build-logic): fix Spotless targets for Kotlin scripts

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Spotless.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/Spotless.kt
@@ -49,9 +49,7 @@ internal fun Project.configureSpotlessForRootProject() {
             endWithNewline()
         }
         format("kts") {
-            target("*.kts")
-            target("build-logic/*.kts")
-            target("build-logic/convention/*.kts")
+            target("*.kts", "build-logic/*.kts", "build-logic/convention/*.kts")
             // Look for the first line that doesn't have a block comment (assumed to be the license)
             licenseHeaderFile(rootDir.resolve("spotless/copyright.kts"), "(^(?![\\/ ]\\*).*$)")
             endWithNewline()


### PR DESCRIPTION
**What I have done and why**

While reviewing the build logic, I noticed that Kotlin script formatting is only applied to the last specified path. The `FormatExtension.target()` method overwrites the internal state on each call rather than appending to it.

Documentation reference:
- Javadoc.io: https://javadoc.io/doc/com.diffplug.spotless/spotless-plugin-gradle/8.3.0/com/diffplug/gradle/spotless/FormatExtension.html#target(java.lang.Object...)
- Source code: https://github.com/diffplug/spotless/blob/gradle/8.3.0/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java#L236-L252

This PR merges the target patterns into a single call:
`target("*.kts", "build-logic/*.kts", "build-logic/convention/*.kts")`

This ensures that the license header and formatting rules are strictly enforced across all script files in the repository.

Note: This change does not introduce any immediate formatting changes to the existing files (they are already compliant), but it ensures they remain so in the future.
