### PR TITLE
Add network validate check and defaultNetwork callback

### DIFF
--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
@@ -120,8 +120,7 @@ internal class ConnectivityManagerNetworkMonitor @Inject constructor(
      * Check [NetworkCapabilities.NET_CAPABILITY_INTERNET]
      * and [NetworkCapabilities.NET_CAPABILITY_VALIDATED]
      */
-    private fun NetworkCapabilities.isNetworkConnected(): Boolean = with(this) {
+    private fun NetworkCapabilities.isNetworkConnected(): Boolean =
         hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
             hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
-    }
 }

--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
@@ -23,6 +23,7 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.net.NetworkRequest.Builder
+import android.os.Build
 import androidx.core.content.getSystemService
 import androidx.tracing.trace
 import com.google.samples.apps.nowinandroid.core.common.network.Dispatcher
@@ -58,21 +59,43 @@ internal class ConnectivityManagerNetworkMonitor @Inject constructor(
                 private val networks = mutableSetOf<Network>()
 
                 override fun onAvailable(network: Network) {
-                    networks += network
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+                        networks += network
+                    }
                     channel.trySend(true)
                 }
 
                 override fun onLost(network: Network) {
-                    networks -= network
-                    channel.trySend(networks.isNotEmpty())
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                        channel.trySend(false)
+                    } else {
+                        networks -= network
+                        channel.trySend(networks.isEmpty())
+                    }
+                }
+
+                override fun onCapabilitiesChanged(
+                    network: Network,
+                    networkCapabilities: NetworkCapabilities,
+                ) {
+                    super.onCapabilitiesChanged(network, networkCapabilities)
+
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                        val isNetworkConnected = networkCapabilities.isNetworkConnected()
+                        channel.trySend(isNetworkConnected)
+                    }
                 }
             }
 
             trace("NetworkMonitor.registerNetworkCallback") {
-                val request = Builder()
-                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                    .build()
-                connectivityManager.registerNetworkCallback(request, callback)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    connectivityManager.registerDefaultNetworkCallback(callback)
+                } else {
+                    val request = Builder()
+                        .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                        .build()
+                    connectivityManager.registerNetworkCallback(request, callback)
+                }
             }
 
             /**
@@ -90,6 +113,15 @@ internal class ConnectivityManagerNetworkMonitor @Inject constructor(
 
     private fun ConnectivityManager.isCurrentlyConnected(): Boolean {
         val networkCapabilities = getNetworkCapabilities(activeNetwork) ?: return false
-        return networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        return networkCapabilities.isNetworkConnected()
+    }
+
+    /**
+     * Check [NetworkCapabilities.NET_CAPABILITY_INTERNET]
+     * and [NetworkCapabilities.NET_CAPABILITY_VALIDATED]
+     */
+    private fun NetworkCapabilities.isNetworkConnected(): Boolean = with(this) {
+        hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
     }
 }

--- a/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
+++ b/core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt
@@ -70,7 +70,7 @@ internal class ConnectivityManagerNetworkMonitor @Inject constructor(
                         channel.trySend(false)
                     } else {
                         networks -= network
-                        channel.trySend(networks.isEmpty())
+                        channel.trySend(networks.isNotEmpty())
                     }
                 }
 


### PR DESCRIPTION
**What I have done and why**

according these documentations
- https://developer.android.com/develop/connectivity/network-ops/reading-network-state#introducing-net-capabilities
- https://developer.android.com/reference/android/net/NetworkCapabilities#NET_CAPABILITY_VALIDATED

We need to check validate capability to ensure that network connect with internet.
And we don't need all of available network, we just check default network so that I add defaultNetworkCallback.


![network image](https://github.com/user-attachments/assets/330d5ecb-a417-4dcc-b79c-bdddf91b0c8b)
