### PR TITLE
Update README graphs with correct datastore-proto plugin

### DIFF
--- a/feature/interests/impl/README.md
+++ b/feature/interests/impl/README.md
@@ -30,7 +30,7 @@ graph TB
     :core:data[data]:::android-library
     :core:database[database]:::android-library
     :core:datastore[datastore]:::android-library
-    :core:datastore-proto[datastore-proto]:::android-library
+    :core:datastore-proto[datastore-proto]:::jvm-library
     :core:designsystem[designsystem]:::android-library
     :core:domain[domain]:::android-library
     :core:model[model]:::jvm-library

--- a/feature/topic/impl/README.md
+++ b/feature/topic/impl/README.md
@@ -26,7 +26,7 @@ graph TB
     :core:data[data]:::android-library
     :core:database[database]:::android-library
     :core:datastore[datastore]:::android-library
-    :core:datastore-proto[datastore-proto]:::android-library
+    :core:datastore-proto[datastore-proto]:::jvm-library
     :core:designsystem[designsystem]:::android-library
     :core:model[model]:::jvm-library
     :core:navigation[navigation]:::android-library


### PR DESCRIPTION
**What I have done and why**

Ran `./gradlew graphUpdate` so that [Check Graphs](https://github.com/android/nowinandroid/actions/runs/24601257469/job/71940220590) can pass. The datastore-proto module uses jvm-library but is referenced as an android-library in two of the READMEs.
