### PR TITLE
fix: render error UI for TopicUiState.Error instead of crashing

### DIFF
--- a/feature/topic/api/src/main/res/values/strings.xml
+++ b/feature/topic/api/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
 -->
 <resources>
     <string name="feature_topic_api_loading">Loading topic</string>
+    <string name="feature_topic_api_error_header">Couldn\'t load topic</string>
 </resources>

--- a/feature/topic/impl/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreenTest.kt
+++ b/feature/topic/impl/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreenTest.kt
@@ -42,11 +42,13 @@ class TopicScreenTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     private lateinit var topicLoading: String
+    private lateinit var topicErrorHeader: String
 
     @Before
     fun setup() {
         composeTestRule.activity.apply {
             topicLoading = getString(R.string.feature_topic_api_loading)
+            topicErrorHeader = getString(R.string.feature_topic_api_error_header)
         }
     }
 
@@ -94,6 +96,26 @@ class TopicScreenTest {
         // Description is shown
         composeTestRule
             .onNodeWithText(testTopic.topic.longDescription)
+            .assertExists()
+    }
+
+    @Test
+    fun errorMessage_whenTopicIsError_isShown() {
+        composeTestRule.setContent {
+            TopicScreen(
+                topicUiState = TopicUiState.Error,
+                newsUiState = NewsUiState.Loading,
+                showBackButton = true,
+                onBackClick = {},
+                onFollowClick = {},
+                onTopicClick = {},
+                onBookmarkChanged = { _, _ -> },
+                onNewsResourceViewed = {},
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(topicErrorHeader)
             .assertExists()
     }
 

--- a/feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt
+++ b/feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt
@@ -129,7 +129,9 @@ internal fun TopicScreen(
                     )
                 }
 
-                TopicUiState.Error -> TODO()
+                TopicUiState.Error -> item {
+                    TopicErrorBody()
+                }
                 is TopicUiState.Success -> {
                     item {
                         TopicToolbar(
@@ -177,7 +179,7 @@ private fun topicItemsSize(
     topicUiState: TopicUiState,
     newsUiState: NewsUiState,
 ) = when (topicUiState) {
-    TopicUiState.Error -> 0 // Nothing
+    TopicUiState.Error -> 1 // Error message
     TopicUiState.Loading -> 1 // Loading bar
     is TopicUiState.Success -> when (newsUiState) {
         NewsUiState.Error -> 0 // Nothing
@@ -201,6 +203,22 @@ private fun LazyListScope.topicBody(
     }
 
     userNewsResourceCards(news, onBookmarkChanged, onNewsResourceViewed, onTopicClick)
+}
+
+@Composable
+private fun TopicErrorBody() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 48.dp),
+    ) {
+        Text(
+            text = stringResource(id = TopicR.string.feature_topic_api_error_header),
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(vertical = 24.dp),
+        )
+    }
 }
 
 @Composable

--- a/feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt
+++ b/feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt
@@ -206,10 +206,10 @@ private fun LazyListScope.topicBody(
 }
 
 @Composable
-private fun TopicErrorBody() {
+private fun TopicErrorBody(modifier: Modifier = Modifier) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 48.dp),
     ) {


### PR DESCRIPTION
## Summary

- Replace `TopicUiState.Error -> TODO()` (`TopicScreen.kt:132`) with a localized error message. `TODO()` throws `NotImplementedError` at runtime, so the topic detail screen currently crashes whenever the upstream topic flow emits an error (`Result.Error` from `asResult`).
- Add `feature_topic_api_error_header` string and a private `TopicErrorBody` composable modeled on `SearchNotReadyBody`.
- Update `topicItemsSize` so the scrollbar item count matches the rendered error item (`0 -> 1`).
- Add `errorMessage_whenTopicIsError_isShown` to `TopicScreenTest`. This test fails on `main` with `NotImplementedError` and passes after the fix.

The other two TODOs in the same file (hardcoded `"Loading news"` at L249 and `Text("Error")` at L253) are in the `NewsUiState` branch and intentionally out of scope to keep this diff small.

Fixes #2108

## Test plan

- [ ] `./gradlew :feature:topic:impl:connectedDemoDebugAndroidTest --tests "*TopicScreenTest*"`
- [ ] `./gradlew :feature:topic:impl:testDemoDebugUnitTest`
- [ ] `./gradlew spotlessApply`
- [ ] `./gradlew :feature:topic:impl:lintDemoDebug :feature:topic:api:lintDemoDebug`
- [ ] Manually verify on a device: force a topic-flow error and confirm the error text appears instead of a crash.