### PR TITLE
fix: source Interests top-level nav label from feature/interests module

### DIFF
--- a/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
+++ b/app/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/ui/NavigationTest.kt
@@ -52,7 +52,7 @@ import org.junit.Test
 import javax.inject.Inject
 import com.google.samples.apps.nowinandroid.feature.bookmarks.api.R as BookmarksR
 import com.google.samples.apps.nowinandroid.feature.foryou.api.R as FeatureForyouR
-import com.google.samples.apps.nowinandroid.feature.search.api.R as FeatureSearchR
+import com.google.samples.apps.nowinandroid.feature.interests.api.R as FeatureInterestsR
 import com.google.samples.apps.nowinandroid.feature.settings.impl.R as SettingsR
 
 /**
@@ -88,7 +88,7 @@ class NavigationTest {
     // The strings used for matching in these tests
     private val navigateUp by composeTestRule.stringResource(FeatureForyouR.string.feature_foryou_api_navigate_up)
     private val forYou by composeTestRule.stringResource(FeatureForyouR.string.feature_foryou_api_title)
-    private val interests by composeTestRule.stringResource(FeatureSearchR.string.feature_search_api_interests)
+    private val interests by composeTestRule.stringResource(FeatureInterestsR.string.feature_interests_api_title)
     private val sampleTopic = "Headlines"
     private val appName by composeTestRule.stringResource(R.string.app_name)
     private val saved by composeTestRule.stringResource(BookmarksR.string.feature_bookmarks_api_title)

--- a/app/src/main/kotlin/com/google/samples/apps/nowinandroid/navigation/TopLevelNavItem.kt
+++ b/app/src/main/kotlin/com/google/samples/apps/nowinandroid/navigation/TopLevelNavItem.kt
@@ -25,7 +25,7 @@ import com.google.samples.apps.nowinandroid.feature.foryou.api.navigation.ForYou
 import com.google.samples.apps.nowinandroid.feature.interests.api.navigation.InterestsNavKey
 import com.google.samples.apps.nowinandroid.feature.bookmarks.api.R as bookmarksR
 import com.google.samples.apps.nowinandroid.feature.foryou.api.R as forYouR
-import com.google.samples.apps.nowinandroid.feature.search.api.R as searchR
+import com.google.samples.apps.nowinandroid.feature.interests.api.R as interestsR
 
 /**
  * Type for the top level navigation items in the application. Contains UI information about the
@@ -62,8 +62,8 @@ val BOOKMARKS = TopLevelNavItem(
 val INTERESTS = TopLevelNavItem(
     selectedIcon = NiaIcons.Grid3x3,
     unselectedIcon = NiaIcons.Grid3x3,
-    iconTextId = searchR.string.feature_search_api_interests,
-    titleTextId = searchR.string.feature_search_api_interests,
+    iconTextId = interestsR.string.feature_interests_api_title,
+    titleTextId = interestsR.string.feature_interests_api_title,
 )
 
 val TOP_LEVEL_NAV_ITEMS = mapOf(


### PR DESCRIPTION
## Summary

- Switch `INTERESTS` in `app/.../navigation/TopLevelNavItem.kt` from `searchR.string.feature_search_api_interests` to `interestsR.string.feature_interests_api_title`. The previously-orphaned `feature_interests_api_title` resource (added on 2025-11-19 in `068d8cc` during the api/impl module split, never wired up) is now the source of truth for the Interests bottom-nav label.
- Restores the per-module-ownership pattern used by the sibling `FOR_YOU` / `BOOKMARKS` entries.
- Eliminates the silent cross-feature coupling: changing the in-search "Interests" link copy at [SearchScreen.kt:248](https://github.com/android/nowinandroid/blob/main/feature/search/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/search/impl/SearchScreen.kt#L248) no longer also rewrites the bottom-nav tab.
- Updates `NavigationTest.kt` to read the interests label from the interests module's resource, matching the production change.

User-visible behavior is unchanged — both strings have the value `"Interests"`, so existing tests, screenshots, and snapshots stay green. The `feature_search_api_interests` resource in the search module is untouched and still used by `SearchScreen.kt:248` and `SearchScreenTest.kt:83`.

Fixes #2112

## Test plan

- [ ] `./gradlew spotlessApply`
- [ ] `./gradlew :app:assembleDemoDebug`
- [ ] `./gradlew :app:lintDemoDebug`
- [ ] `./gradlew :app:connectedDemoDebugAndroidTest --tests "*NavigationTest*"` (needs emulator/device)
- [ ] Manually verify the Interests bottom-nav tab still reads "Interests" on a launched debug build.
