### PR TITLE
Fix dispatcher qualifier target

### DIFF
--- a/core/common/src/main/kotlin/com/google/samples/apps/nowinandroid/core/common/network/NiaDispatchers.kt
+++ b/core/common/src/main/kotlin/com/google/samples/apps/nowinandroid/core/common/network/NiaDispatchers.kt
@@ -18,8 +18,11 @@ package com.google.samples.apps.nowinandroid.core.common.network
 
 import javax.inject.Qualifier
 import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
 
 @Qualifier
+@Target(FUNCTION, VALUE_PARAMETER)
 @Retention(RUNTIME)
 annotation class Dispatcher(val niaDispatcher: NiaDispatchers)
 


### PR DESCRIPTION
**What I have done and why**

This PR adds explicit Kotlin annotation targets to the `@Dispatcher` qualifier.

`@Dispatcher` is used on injected value parameters and on Hilt provider functions, so the target list includes both `VALUE_PARAMETER` and `FUNCTION`. This keeps the qualifier usage explicit while preserving the existing provider declarations.

Fixes #2001

**Testing**

- `./gradlew :core:common:test`
- `./gradlew :app:compileDemoDebugKotlin`
- `./gradlew :build-logic:convention:check`
- `./gradlew spotlessCheck`
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ./gradlew testDemoDebug :lint:test`
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ./gradlew dependencyGuard`
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ./gradlew verifyRoborazziDemoDebug`
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ./gradlew :app:assemble -PminifyWithR8=false`
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ./gradlew :app:lintProdRelease :app-nia-catalog:lintRelease :lint:lint`
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ./gradlew :app:checkProdReleaseBadging`