### PR TITLE
Move TopicScreen strings to resources

### DIFF
--- a/feature/topic/api/src/main/res/values/strings.xml
+++ b/feature/topic/api/src/main/res/values/strings.xml
@@ -16,4 +16,8 @@
 -->
 <resources>
     <string name="feature_topic_api_loading">Loading topic</string>
+    <string name="feature_topic_api_loading_news">Loading news</string>
+    <string name="feature_topic_api_news_error">Error</string>
+    <string name="feature_topic_api_following">Following</string>
+    <string name="feature_topic_api_not_following">Not following</string>
 </resources>

--- a/feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt
+++ b/feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt
@@ -68,6 +68,7 @@ import com.google.samples.apps.nowinandroid.core.ui.TrackScreenViewEvent
 import com.google.samples.apps.nowinandroid.core.ui.TrackScrollJank
 import com.google.samples.apps.nowinandroid.core.ui.UserNewsResourcePreviewParameterProvider
 import com.google.samples.apps.nowinandroid.core.ui.userNewsResourceCardItems
+import java.util.Locale
 import com.google.samples.apps.nowinandroid.core.ui.R as UiR
 import com.google.samples.apps.nowinandroid.feature.topic.api.R as TopicR
 
@@ -246,11 +247,11 @@ private fun LazyListScope.userNewsResourceCards(
         }
 
         is NewsUiState.Loading -> item {
-            NiaLoadingWheel(contentDesc = "Loading news") // TODO
+            NiaLoadingWheel(contentDesc = stringResource(TopicR.string.feature_topic_api_loading_news))
         }
 
         else -> item {
-            Text("Error") // TODO
+            Text(stringResource(TopicR.string.feature_topic_api_news_error))
         }
     }
 }
@@ -308,9 +309,9 @@ private fun TopicToolbar(
             modifier = Modifier.padding(end = 24.dp),
         ) {
             if (selected) {
-                Text("FOLLOWING")
+                Text(stringResource(TopicR.string.feature_topic_api_following).uppercase(Locale.getDefault()))
             } else {
-                Text("NOT FOLLOWING")
+                Text(stringResource(TopicR.string.feature_topic_api_not_following).uppercase(Locale.getDefault()))
             }
         }
     }


### PR DESCRIPTION
## Summary

- Move the remaining hardcoded user-facing strings in `TopicScreen` into topic string resources.
- Keep the visible English text unchanged while making the strings consistent with the rest of the app and ready for localization.

Fixes #2115

## Test plan

- [x] `./gradlew spotlessCheck`
- [x] `./gradlew :feature:topic:impl:testDemoDebugUnitTest`
- [x] `./gradlew :feature:topic:impl:lintDemoDebug :feature:topic:api:lintDemoDebug`
- [x] `./gradlew :feature:topic:impl:connectedDemoDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.google.samples.apps.nowinandroid.feature.topic.impl.TopicScreenTest`