### PR TITLE
Handle TopicUiState.Error without crashing TopicScreen

### DIFF
--- a/feature/topic/api/src/main/res/values/strings.xml
+++ b/feature/topic/api/src/main/res/values/strings.xml
@@ -16,4 +16,6 @@
 -->
 <resources>
     <string name="feature_topic_api_loading">Loading topic</string>
+    <string name="feature_topic_api_error">Unable to load topic</string>
+    <string name="feature_topic_api_news_error">Unable to load news</string>
 </resources>

--- a/feature/topic/impl/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreenTest.kt
+++ b/feature/topic/impl/src/androidTest/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreenTest.kt
@@ -42,11 +42,13 @@ class TopicScreenTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     private lateinit var topicLoading: String
+    private lateinit var topicError: String
 
     @Before
     fun setup() {
         composeTestRule.activity.apply {
             topicLoading = getString(R.string.feature_topic_api_loading)
+            topicError = getString(R.string.feature_topic_api_error)
         }
     }
 
@@ -67,6 +69,26 @@ class TopicScreenTest {
 
         composeTestRule
             .onNodeWithContentDescription(topicLoading)
+            .assertExists()
+    }
+
+    @Test
+    fun topicError_whenTopicIsError_isShown() {
+        composeTestRule.setContent {
+            TopicScreen(
+                topicUiState = TopicUiState.Error,
+                newsUiState = NewsUiState.Loading,
+                showBackButton = true,
+                onBackClick = {},
+                onFollowClick = {},
+                onTopicClick = {},
+                onBookmarkChanged = { _, _ -> },
+                onNewsResourceViewed = {},
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(topicError)
             .assertExists()
     }
 

--- a/feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt
+++ b/feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt
@@ -190,9 +190,9 @@ private fun topicItemsSize(
     TopicUiState.Error -> 2 // Toolbar and error message
     TopicUiState.Loading -> 1 // Loading bar
     is TopicUiState.Success -> when (newsUiState) {
-        NewsUiState.Error -> 0 // Nothing
-        NewsUiState.Loading -> 1 // Loading bar
-        is NewsUiState.Success -> 2 + newsUiState.news.size // Toolbar, header
+        NewsUiState.Error -> 3 // Toolbar, header, and error message
+        NewsUiState.Loading -> 3 // Toolbar, header, and loading indicator
+        is NewsUiState.Success -> 2 + newsUiState.news.size // Toolbar, header, and news items
     }
 }
 

--- a/feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt
+++ b/feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt
@@ -129,7 +129,17 @@ internal fun TopicScreen(
                     )
                 }
 
-                TopicUiState.Error -> TODO()
+                TopicUiState.Error -> {
+                    item {
+                        TopicErrorToolbar(
+                            showBackButton = showBackButton,
+                            onBackClick = onBackClick,
+                        )
+                    }
+                    item {
+                        TopicErrorState()
+                    }
+                }
                 is TopicUiState.Success -> {
                     item {
                         TopicToolbar(
@@ -177,7 +187,7 @@ private fun topicItemsSize(
     topicUiState: TopicUiState,
     newsUiState: NewsUiState,
 ) = when (topicUiState) {
-    TopicUiState.Error -> 0 // Nothing
+    TopicUiState.Error -> 2 // Toolbar and error message
     TopicUiState.Loading -> 1 // Loading bar
     is TopicUiState.Success -> when (newsUiState) {
         NewsUiState.Error -> 0 // Nothing
@@ -250,7 +260,11 @@ private fun LazyListScope.userNewsResourceCards(
         }
 
         else -> item {
-            Text("Error") // TODO
+            Text(
+                text = stringResource(id = TopicR.string.feature_topic_api_news_error),
+                modifier = Modifier.padding(24.dp),
+                style = MaterialTheme.typography.bodyLarge,
+            )
         }
     }
 }
@@ -269,6 +283,44 @@ private fun TopicBodyPreview() {
                 onNewsResourceViewed = {},
                 onTopicClick = {},
             )
+        }
+    }
+}
+
+@Composable
+private fun TopicErrorState(modifier: Modifier = Modifier) {
+    Text(
+        text = stringResource(id = TopicR.string.feature_topic_api_error),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(24.dp)
+            .testTag("topic:error"),
+        style = MaterialTheme.typography.bodyLarge,
+    )
+}
+
+@Composable
+private fun TopicErrorToolbar(
+    showBackButton: Boolean,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        horizontalArrangement = Arrangement.Start,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(bottom = 32.dp),
+    ) {
+        if (showBackButton) {
+            IconButton(onClick = onBackClick) {
+                Icon(
+                    imageVector = NiaIcons.ArrowBack,
+                    contentDescription = stringResource(
+                        id = UiR.string.core_ui_back,
+                    ),
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace `TODO()` in `TopicScreen` with error UI when topic loading fails
- Show a user-visible message for news loading errors instead of a hardcoded placeholder
- Add a compose test covering `TopicUiState.Error`
- Fix scrollbar item count to include toolbar and header for news loading/error states

Fixes #2108

## Test plan
- [x] `./gradlew assembleDemoDebug` passes
- [x] `./gradlew :feature:topic:impl:compileDemoDebugAndroidTestKotlin` passes
- [ ] Run `TopicScreenTest.topicError_whenTopicIsError_isShown` on device/emulator