### PR TITLE
Update architecture docs for user news resource flow

### DIFF
--- a/docs/ArchitectureLearningJourney.md
+++ b/docs/ArchitectureLearningJourney.md
@@ -72,9 +72,9 @@ Here's what's happening in each step. The easiest way to find the associated cod
   <tr>
    <td>2
    </td>
-   <td>The <code>ForYouViewModel</code> calls <code>GetUserNewsResourcesUseCase</code> to obtain a stream of news resources with their bookmarked/saved state. No items will be emitted into this stream until both the user and news repositories emit an item. While waiting, the feed state is set to <code>Loading</code>.
+   <td>The <code>ForYouViewModel</code> calls <code>UserNewsResourceRepository.observeAllForFollowedTopics</code> to obtain a stream of news resources with their bookmarked/saved state. The repository implementation combines news resources from <code>NewsRepository</code> with user data from <code>UserDataRepository</code>. While waiting, the feed state is set to <code>Loading</code>.
    </td>
-   <td>Search for usages of <code>NewsFeedUiState.Loading</code>
+   <td><code>ForYouViewModel.feedState</code>
    </td>
   </tr>
   <tr>
@@ -144,9 +144,9 @@ Here's what's happening in each step. The easiest way to find the associated cod
   <tr>
    <td>11
    </td>
-   <td><code>GetUserNewsResourcesUseCase</code> combines the list of news resources with the user data to emit a list of <code>UserNewsResource</code>s.  
+   <td><code>CompositeUserNewsResourceRepository</code> combines the list of news resources with the user data to emit a list of <code>UserNewsResource</code>s.
    </td>
-   <td><code>GetUserNewsResourcesUseCase.invoke</code>
+   <td><code>CompositeUserNewsResourceRepository.observeAll</code>
    </td>
   </tr>
   <tr>
@@ -256,7 +256,7 @@ The [domain layer](https://developer.android.com/topic/architecture/domain-layer
 
 These use cases are used to simplify and remove duplicate logic from ViewModels. They typically combine and transform data from repositories. 
 
-For example, `GetUserNewsResourcesUseCase` combines a stream (implemented using `Flow`) of `NewsResource`s from a `NewsRepository` with a stream of `UserData` objects from a `UserDataRepository` to create a stream of `UserNewsResource`s. This stream is used by various ViewModels to display news resources on screen with their bookmarked state.  
+For example, `GetFollowableTopicsUseCase` combines a stream (implemented using `Flow`) of `List<Topic>` from a `TopicsRepository` with a stream of `UserData` objects from a `UserDataRepository` to create a stream of `List<FollowableTopic>`. This stream is used by various ViewModels to display topics on screen with their followed state.
 
 Notably, the domain layer in Now in Android _does not_ (for now) contain any use cases for event handling. Events are handled by the UI layer calling methods on repositories directly.
 


### PR DESCRIPTION
**What I have done and why**

Updated `docs/ArchitectureLearningJourney.md` so the For You feed flow matches the current implementation.

The document referenced `GetUserNewsResourcesUseCase`, but the current code uses `UserNewsResourceRepository.observeAllForFollowedTopics` from `ForYouViewModel.feedState`, backed by `CompositeUserNewsResourceRepository`.

This change also updates the domain-layer example to use the existing `GetFollowableTopicsUseCase`, which combines topics with user data to produce followable topics.

Fixes #2119

Test: `git diff --check`