### PR TITLE
Handle settings dialog bottom insets

### DIFF
--- a/feature/settings/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/settings/impl/SettingsDialog.kt
+++ b/feature/settings/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/settings/impl/SettingsDialog.kt
@@ -27,10 +27,13 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
@@ -104,8 +107,13 @@ fun SettingsDialog(
      * https://issuetracker.google.com/issues/221643630
      */
     AlertDialog(
-        properties = DialogProperties(usePlatformDefaultWidth = false),
-        modifier = Modifier.widthIn(max = configuration.screenWidthDp.dp - 80.dp),
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false,
+        ),
+        modifier = Modifier
+            .widthIn(max = configuration.screenWidthDp.dp - 80.dp)
+            .windowInsetsPadding(WindowInsets.safeDrawing),
         onDismissRequest = { onDismiss() },
         title = {
             Text(


### PR DESCRIPTION
Fixes #1598

Applies `WindowInsets.safeDrawing` padding to the `AlertDialog` in the settings dialog to prevent it from overlapping with system bars on edge-to-edge layouts.