### PR TITLE
  Fix grammar in search empty-state copy ("explorer" -> "explore")

### DIFF
--- a/feature/search/api/src/main/res/values/strings.xml
+++ b/feature/search/api/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="feature_search_api_clear_search_text_content_desc">Clear search text</string>
     <string name="feature_search_api_result_not_found">Sorry, there is no content found for your search \"%1$s\"</string>
     <string name="feature_search_api_not_ready">Sorry, we are still processing the search index. Please come back later</string>
-    <string name="feature_search_api_try_another_search">Try another search or explorer </string>
+    <string name="feature_search_api_try_another_search">Try another search or explore </string>
     <string name="feature_search_api_interests">Interests</string>
     <string name="feature_search_api_to_browse_topics"> to browse topics</string>
     <string name="feature_search_api_topics">Topics</string>


### PR DESCRIPTION

  ## What I've done

  Fixes #2127

  The Search screen's empty-results message contained a grammar error. The
  `feature_search_api_try_another_search` string used "explorer" (a noun) where the
  verb "explore" was intended. The sentence is assembled in `EmptySearchResultBody`
  (`SearchScreen.kt`) as:

  > Try another search or **explorer** Interests to browse topics

  This PR corrects it to:
                                                                                                                                                             
  > Try another search or **explore** Interests to browse topics

  ### Change
  
  A single string-value edit in `feature/search/api/src/main/res/values/strings.xml`:

  ```diff
  - <string name="feature_search_api_try_another_search">Try another search or explorer </string>                                           
  + <string name="feature_search_api_try_another_search">Try another search or explore </string>                                                             

  The string resource name is unchanged, so no Kotlin call sites are affected.

  Testing
                                                                                                                                                             
  - SearchScreenTest builds its expected text from the same string resource, so it
  continues to pass without modification.
  - No committed screenshot golden images cover the search empty-state, so none
  required re-recording.
  - This is a user-facing copy fix only; there is no behavior change.
