### PR TITLE
docs: fix grammar in SyncInitializer comment

### DIFF
--- a/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/initializers/SyncInitializer.kt
+++ b/sync/work/src/main/kotlin/com/google/samples/apps/nowinandroid/sync/initializers/SyncInitializer.kt
@@ -22,7 +22,7 @@ import androidx.work.WorkManager
 import com.google.samples.apps.nowinandroid.sync.workers.SyncWorker
 
 object Sync {
-    // This method is initializes sync, the process that keeps the app's data current.
+    // This method initializes sync, the process that keeps the app's data current.
     // It is called from the app module's Application.onCreate() and should be only done once.
     fun initialize(context: Context) {
         WorkManager.getInstance(context).apply {


### PR DESCRIPTION
## Summary
Fixes a small grammar error in the `Sync.initialize` comment.

Closes #2121

**Before:** `This method is initializes sync...`  
**After:** `This method initializes sync...`

Comment-only change; no behavior change.

## Test plan
- [x] Comment-only documentation cleanup