### PR TITLE
docs: note JDK 17 requirement for Gradle builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ in, and be notified when new content is published which matches interests they a
 
 # Development Environment
 
-**Now in Android** uses the Gradle build system and can be imported directly into Android Studio (make sure you are using the latest stable version available [here](https://developer.android.com/studio)). 
+**Now in Android** uses the Gradle build system and can be imported directly into Android Studio (make sure you are using the latest stable version available [here](https://developer.android.com/studio)).
+
+> **Note:** This project requires **JDK 17** for Gradle. In Android Studio, set
+> **Settings → Build, Execution, Deployment → Build Tools → Gradle → Gradle JDK** to **17**
+> (or **Embedded JDK** on recent Studio versions). Using JDK 11 will fail when resolving
+> the baseline profile Gradle plugin and other dependencies that target Java 17.
 
 Change the run configuration to `app`.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ in, and be notified when new content is published which matches interests they a
 
 **Now in Android** uses the Gradle build system and can be imported directly into Android Studio (make sure you are using the latest stable version available [here](https://developer.android.com/studio)).
 
-> **Note:** This project requires **JDK 17** for Gradle. In Android Studio, set
+> [!NOTE]
+> This project requires **JDK 17** for Gradle. In Android Studio, set
 > **Settings → Build, Execution, Deployment → Build Tools → Gradle → Gradle JDK** to **17**
 > (or **Embedded JDK** on recent Studio versions). Using JDK 11 will fail when resolving
 > the baseline profile Gradle plugin and other dependencies that target Java 17.


### PR DESCRIPTION
## Summary
Documents that Gradle must run on **JDK 17** for this project. Using JDK 11 causes resolution failures for the baseline profile Gradle plugin and other Java-17-targeted dependencies.

Closes #1137

## Changes
- Add a callout under **Development Environment** in README with Android Studio Gradle JDK setting instructions

## Test plan
- [x] Documentation-only change