### PR TITLE
Fix baseline profile generation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,8 +53,6 @@ android {
             // who clones the code to sign and run the release variant, use the debug signing key.
             // TODO: Abstract the signing configuration to a separate file to avoid hardcoding this.
             signingConfig = signingConfigs.named("debug").get()
-            // Ensure Baseline Profile is fresh for release builds.
-            baselineProfile.automaticGenerationDuringBuild = true
         }
     }
 
@@ -145,6 +143,11 @@ baselineProfile {
 
     // Make use of Dex Layout Optimizations via Startup Profiles
     dexLayoutOptimization = true
+
+    // Ensure Baseline Profile is fresh for release builds.
+    variants.create("release") {
+        automaticGenerationDuringBuild = true
+    }
 }
 
 dependencyGuard {


### PR DESCRIPTION
Before this change baseline profiles where not being generated at all because
android { buildTypes { release {
            baselineProfile.automaticGenerationDuringBuild = true
}}}

is overwritten by
baselineProfile {
    // Don't build on every iteration of a full assemble.
    // Instead enable generation directly for the release build variant.
    automaticGenerationDuringBuild = false
}

Instead, correctly set it for the release variant